### PR TITLE
Provide a very basic LED sample

### DIFF
--- a/samples/led/Makefile
+++ b/samples/led/Makefile
@@ -1,0 +1,4 @@
+XBE_TITLE=led
+SRCS = $(wildcard $(CURDIR)/*.c)
+NXDK_DIR = $(CURDIR)/../..
+include $(NXDK_DIR)/Makefile

--- a/samples/led/main.c
+++ b/samples/led/main.c
@@ -1,0 +1,22 @@
+#include <hal/xbox.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+#define SMC_REG_LEDMODE             0x07
+#define SMC_REG_LEDSEQ              0x08
+
+void main(void)
+{
+    // Set LED to be user controlled
+    HalWriteSMBusValue(0x20, SMC_REG_LEDMODE, FALSE, 0x01);
+
+    // LED pattern is:
+    //   Red:   0xC = 1100 (ON,  ON,  OFF, OFF;   ON,  ON,  OFF, OFF;   ...)
+    //   Green: 0x0 = 0000 (OFF, OFF, OFF, OFF;   OFF, OFF, OFF, OFF;   ...)
+    // This means the red LED will blink slowly and the green LED is off
+    HalWriteSMBusValue(0x20, SMC_REG_LEDSEQ, FALSE, 0xC0);
+
+    // If we quit, the LED might get reset, so we loop forever
+    while(1) {
+        XSleep(1000);
+    }
+}


### PR DESCRIPTION
I've tried to construct the most basic example possible.
Having the LED code also helps for `printf`-style debugging.

However, this is primarily meant for those people who had crashes with other samples in nxdk.
Therefore, this sample does not require any video mode initialization and we can tell people to just remove 1 line from startup.c to test it without any AV code.

I'm aware that the code is somewhat cryptic and I hope we'll have a higher level API to control the LED in the future. For now, this will have to do.