### PR TITLE
libc and xboxkrnl fixes

### DIFF
--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -315,7 +315,7 @@ extern int errno;
  * LWIP_DNS==1: Turn on DNS module. UDP must be available for DNS
  * transport.
  */
-#define LWIP_DNS                        0
+#define LWIP_DNS                        1
 
 /*
    ---------------------------------

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -1332,20 +1332,20 @@ typedef struct _IRP
 
 struct _DEVICE_OBJECT;
 
-typedef VOID (*PDRIVER_STARTIO) (
+typedef NTAPI VOID (*PDRIVER_STARTIO) (
     IN struct _DEVICE_OBJECT *DeviceObject,
-    IN PIRP *Irp
+    IN struct _IRP *Irp
 );
 
-typedef VOID (*PDRIVER_DELETEDEVICE) (
+typedef NTAPI VOID (*PDRIVER_DELETEDEVICE) (
     IN struct _DEVICE_OBJECT *DeviceObject
 );
 
-typedef NTSTATUS (*PDRIVER_DISMOUNTVOLUME) (
+typedef NTAPI NTSTATUS (*PDRIVER_DISMOUNTVOLUME) (
     IN struct _DEVICE_OBJECT *DeviceObject
 );
 
-typedef NTSTATUS (*PDRIVER_DISPATCH) (
+typedef NTAPI NTSTATUS (*PDRIVER_DISPATCH) (
     IN struct _DEVICE_OBJECT *DeviceObject,
     IN struct _IRP *Irp
 );

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -4348,7 +4348,8 @@ XBAPI VOID FASTCALL KfLowerIrql
 
 XBAPI VOID FASTCALL IofCompleteRequest
 (
-    IN PDEVICE_OBJECT DeviceObject
+    IN PIRP Irp,
+    IN CCHAR PriorityBoost
 );
 
 XBAPI NTSTATUS FASTCALL IofCallDriver

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -34,7 +34,7 @@ extern "C"
 #define CONST const
 
 typedef unsigned int SIZE_T, *PSIZE_T;
-typedef int BOOLEAN, *PBOOLEAN, BOOL;
+typedef unsigned char BOOLEAN, *PBOOLEAN, BOOL;
 typedef void VOID, *PVOID, *LPVOID;
 typedef unsigned char UCHAR, *PUCHAR;
 typedef unsigned short USHORT, *PUSHORT, CSHORT;

--- a/lib/xboxrt/stdbool.h
+++ b/lib/xboxrt/stdbool.h
@@ -1,6 +1,7 @@
 #ifndef XBOXRT_STDBOOL
 #define XBOXRT_STDBOOL
 
+typedef _Bool bool;
 #define true 1
 #define false 0
 

--- a/lib/xboxrt/stdlib.c
+++ b/lib/xboxrt/stdlib.c
@@ -153,7 +153,7 @@ static void* VirtualAlloc(void *lpAddress, unsigned int dwSize, unsigned int flA
 
 static int VirtualFree(void *lpAddress, unsigned int dwSize, unsigned int dwFreeType)
 {
-    return NtFreeVirtualMemory(lpAddress, &dwSize, dwFreeType);
+    return NtFreeVirtualMemory(&lpAddress, &dwSize, dwFreeType);
 }
 
 void * malloc(size_t size) {
@@ -161,7 +161,7 @@ void * malloc(size_t size) {
 }
 
 void free(void *ptr) {
-    VirtualFree(ptr, 0, 0);
+    VirtualFree(ptr, 0, MEM_RELEASE);
 }
 
 void *calloc(size_t count, size_t size)

--- a/lib/xboxrt/stdlib.c
+++ b/lib/xboxrt/stdlib.c
@@ -262,3 +262,7 @@ long strtol(const char *nptr, char **endptr, register int base)
 		*endptr = (char *) (any ? s - 1 : nptr);
 	return (acc);
 }
+
+int atoi(const char *nptr) {
+	return (int) strtol (nptr, (char **) NULL, 10);
+}

--- a/lib/xboxrt/stdlib.c
+++ b/lib/xboxrt/stdlib.c
@@ -175,7 +175,19 @@ void *realloc(void *ptr, size_t size)
 {
     void *new = malloc(size);
     if (ptr != NULL) {
-        memcpy(new, ptr, size);
+
+        // Retrieve the old size
+        MEMORY_BASIC_INFORMATION information;
+        NtQueryVirtualMemory(ptr, &information);
+
+        // Calculate how many bytes can be copied from old to new buffer
+        size_t old_size = information.RegionSize;
+        if (old_size > size) {
+          old_size = size;
+        }
+
+        // Copy data and remove old allocation
+        memcpy(new, ptr, old_size);
         free(ptr);
     }
     return new;

--- a/lib/xboxrt/stdlib.h
+++ b/lib/xboxrt/stdlib.h
@@ -16,4 +16,6 @@ void *realloc(void *ptr, size_t size);
 
 long strtol(const char *nptr, char **endptr, register int base);
 
+int atoi(const char *nptr);
+
 #endif

--- a/lib/xboxrt/string.c
+++ b/lib/xboxrt/string.c
@@ -1,4 +1,5 @@
 #include "string.h"
+#include "stdlib.h"
 #include "ctype.h"
 
 int memcmp(const void *p1, const void *p2, int num) {
@@ -47,18 +48,16 @@ void *memset(void *ptr, int val, int num) {
 
 
 size_t strlen(const char *s1) {
-    size_t i = 0;
-    do i++; while (s1[i] != '\0');
-    return i;
+  size_t i = 0;
+  while (s1[i] != '\0') { i++; }
+  return i;
 }
 
-#if 0
-void *strdup(const char *s1) {
-    void *out = malloc(strlen(s1));
+char *strdup(const char *s1) {
+    char *out = malloc(strlen(s1) + 1);
     strcpy(out, s1);
     return out;
 }
-#endif
 
 int strcmp(const char *s1, const char *s2) {
     return strncmp(s1, s2, SIZE_MAX);

--- a/lib/xboxrt/string.c
+++ b/lib/xboxrt/string.c
@@ -2,17 +2,16 @@
 #include "stdlib.h"
 #include "ctype.h"
 
-int memcmp(const void *p1, const void *p2, int num) {
-    unsigned char *c1 = (unsigned char *)p1;
-    unsigned char *c2 = (unsigned char *)p2;
-    for (int i = 0; i < num; i++) {
-        if (c1[i] < c2[i]) {
-            return -1;
-        } else if (c1[i] > c2[i]) {
-            return 1;
-        }
-    }
+#include <xboxkrnl/xboxkrnl.h>
+
+int memcmp(const void *p1, const void *p2, size_t num) {
+  SIZE_T first_difference = RtlCompareMemory(p1, p2, num);
+  if (first_difference == num) {
     return 0;
+  }
+  unsigned char *c1 = (unsigned char *)p1;
+  unsigned char *c2 = (unsigned char *)p2;
+  return (int)c1[first_difference] - (int)c2[first_difference];
 }
 
 void *memchr(const void *ptr, int c, int n) {
@@ -25,25 +24,20 @@ void *memchr(const void *ptr, int c, int n) {
     return 0;
 }
 
-void *memcpy(void *dst, const void *src, int num) {
-    char *cdst = dst;
-    const char *csrc = src;
-    for (int i = 0; i < num; i++) {
-        *cdst++ = *csrc++;
-    }
-    return dst;
+void *memmove(void *dst, const void *src, size_t num) {
+  RtlMoveMemory(dst, src, num);
+  return dst;
 }
 
-void *memmove(void *dst, const void *src, int num) {
-    return memcpy(dst, src, num);
+void *memcpy(void *dst, const void *src, size_t num) {
+  //FIXME: This could be done faster using RtlCopyMemory.
+  //       However, the kernel doesn't expose that and I'm lazy.
+  return memmove(dst, src, num);
 }
 
-void *memset(void *ptr, int val, int num) {
-    unsigned char *cptr = ptr;
-    for (int i = 0; i < num; i++) {
-        *cptr++ = val;
-    }
-    return ptr;
+void *memset(void *ptr, int val, size_t num) {
+  RtlFillMemory(ptr, num, val);
+  return ptr;
 }
 
 

--- a/lib/xboxrt/string.h
+++ b/lib/xboxrt/string.h
@@ -12,7 +12,7 @@ void *memset(void *ptr, int val, int num);
 
 char *strcat(char *s1, const char *s2);
 char *strcpy(char *dst, const char *src);
-// void *strdup(const char *s1);
+char *strdup(const char *s1);
 char *strncat(char *s1, const char *s2, size_t n);
 char *strncpy(char *dst, const char *src, size_t n);
 char *strupr(char *s1);

--- a/lib/xboxrt/string.h
+++ b/lib/xboxrt/string.h
@@ -4,11 +4,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
-int memcmp(const void *p1, const void *p2, int num);
+int memcmp(const void *p1, const void *p2, size_t num);
 void *memchr(const void *ptr, int c, int n);
-void *memcpy(void *dst, const void *src, int num);
-void *memmove(void *dst, const void *src, int num);
-void *memset(void *ptr, int val, int num);
+void *memcpy(void *dst, const void *src, size_t num);
+void *memmove(void *dst, const void *src, size_t num);
+void *memset(void *ptr, int val, size_t num);
 
 char *strcat(char *s1, const char *s2);
 char *strcpy(char *dst, const char *src);


### PR DESCRIPTION
Changes necessary for xbe-loader, nxdk-rdt and other projects:

* This *should* fix our `free()` function which should make all nxdk programs more stable. Our existing `free` does not actually free memory. Could affect #35.
* It also fixes `strlen()` which broke many things for me. It used to return 1 for `strlen("")`. I've fixed and re-enabled `strdup` as a result.
* I also decided to enable LWIP DNS support, which required `atoi`.
* I also added a `bool` type to our stdbool.
* The mem* functions are now handled using the kernel Rtl functions. This should improve performance.
* I've addressed all sort of bugs in the xboxkrnl which prevented people from writing new drivers (this includes changing calling conventions and making `BOOL` a smaller type - most of our xboxkrnl structs were the wrong size).

See commit titles for more infos.

Ideally, someone should test this - I assume most of it works, but I'm not sure either:
I added whatever I needed to make errors disappear. So I just assumed my code was working (even if it might only be a workaround, eventually leading to other errors).