### PR TITLE
Move nxdk-sdl submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 	url = git://git.savannah.nongnu.org/lwip.git
 [submodule "lib/sdl/SDL2"]
 	path = lib/sdl/SDL2
-	url = https://github.com/mborgerson/nxdk-sdl.git
+	url = https://github.com/XboxDev/nxdk-sdl.git
 	branch = nxdk


### PR DESCRIPTION
Closes #47.

nxdk-SDL has moved. Let the repository consider that.