### PR TITLE
Add libc runtime functions

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -21,6 +21,8 @@ USB_SRCS := \
 
 SRCS += \
 	$(wildcard $(NXDK_DIR)/lib/xboxrt/*.c) \
+	$(wildcard $(NXDK_DIR)/lib/xlibc-rt/*.c) \
+	$(wildcard $(NXDK_DIR)/lib/xlibc-rt/*.s) \
 	$(wildcard $(NXDK_DIR)/lib/hal/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/pbkit/*.c) \
 	$(USB_SRCS)

--- a/lib/xlibc-rt/CREDITS.TXT
+++ b/lib/xlibc-rt/CREDITS.TXT
@@ -1,0 +1,36 @@
+This file is a partial list of people who have contributed to the LLVM/CompilerRT
+project.  If you have contributed a patch or made some other contribution to
+LLVM/CompilerRT, please submit a patch to this file to add yourself, and it will be
+done!
+
+The list is sorted by surname and formatted to allow easy grepping and
+beautification by scripts.  The fields are: name (N), email (E), web-address
+(W), PGP key ID and fingerprint (P), description (D), and snail-mail address
+(S).
+
+N: Craig van Vliet
+E: cvanvliet@auroraux.org
+W: http://www.auroraux.org
+D: Code style and Readability fixes.
+
+N: Edward O'Callaghan
+E: eocallaghan@auroraux.org
+W: http://www.auroraux.org
+D: CMake'ify Compiler-RT build system
+D: Maintain Solaris & AuroraUX ports of Compiler-RT
+
+N: Howard Hinnant
+E: hhinnant@apple.com
+D: Architect and primary author of compiler-rt
+
+N: Guan-Hong Liu
+E: koviankevin@hotmail.com
+D: IEEE Quad-precision functions
+
+N: Joerg Sonnenberger
+E: joerg@NetBSD.org
+D: Maintains NetBSD port.
+
+N: Matt Thomas
+E: matt@NetBSD.org
+D: ARM improvements.

--- a/lib/xlibc-rt/LICENSE.txt
+++ b/lib/xlibc-rt/LICENSE.txt
@@ -1,0 +1,91 @@
+==============================================================================
+compiler_rt License
+==============================================================================
+
+The compiler_rt library is dual licensed under both the University of Illinois
+"BSD-Like" license and the MIT license.  As a user of this code you may choose
+to use it under either license.  As a contributor, you agree to allow your code
+to be used under both.
+
+Full text of the relevant licenses is included below.
+
+==============================================================================
+
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2009-2015 by the contributors listed in CREDITS.TXT
+
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+
+==============================================================================
+
+Copyright (c) 2009-2015 by the contributors listed in CREDITS.TXT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+==============================================================================
+Copyrights and Licenses for Third Party Software Distributed with LLVM:
+==============================================================================
+The LLVM software contains code written by third parties.  Such software will
+have its own individual LICENSE.TXT file in the directory in which it appears.
+This file will describe the copyrights, license, and restrictions which apply
+to that code.
+
+The disclaimer of warranty in the University of Illinois Open Source License
+applies to all code in the LLVM Distribution, and nothing in any of the
+other licenses gives permission to use the names of the LLVM Team or the
+University of Illinois to endorse or promote products derived from this
+Software.
+

--- a/lib/xlibc-rt/_alldiv.s
+++ b/lib/xlibc-rt/_alldiv.s
@@ -1,0 +1,158 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+// di_int __divdi3(di_int a, di_int b);
+
+// result = a / b.
+// both inputs and the output are 64-bit signed integers.
+// This will do whatever the underlying hardware is set to do on division by zero.
+// No other exceptions are generated, as the divide cannot overflow.
+//
+// This is targeted at 32-bit x86 *only*, as this can be done directly in hardware
+// on x86_64.  The performance goal is ~40 cycles per divide, which is faster than
+// currently possible via simulation of integer divides on the x87 unit.
+//
+// Stephen Canon, December 2008
+
+// Modified for stdcall calling convention for use in nxdk
+
+.text
+.balign 4
+.globl __alldiv
+__alldiv:
+
+/* This is currently implemented by wrapping the unsigned divide up in an absolute
+   value, then restoring the correct sign at the end of the computation.  This could
+   certainly be improved upon. */
+
+	pushl		%esi
+	movl	 20(%esp),			%edx	// high word of b
+	movl	 16(%esp),			%eax	// low word of b
+	movl		%edx,			%ecx
+	sarl		$31,			%ecx	// (b < 0) ? -1 : 0
+	xorl		%ecx,			%eax
+	xorl		%ecx,			%edx	// EDX:EAX = (b < 0) ? not(b) : b
+	subl		%ecx,			%eax
+	sbbl		%ecx,			%edx	// EDX:EAX = abs(b)
+	movl		%edx,		 20(%esp)
+	movl		%eax,		 16(%esp)	// store abs(b) back to stack
+	movl		%ecx,			%esi	// set aside sign of b
+
+	movl	 12(%esp),			%edx	// high word of b
+	movl	  8(%esp),			%eax	// low word of b
+	movl		%edx,			%ecx
+	sarl		$31,			%ecx	// (a < 0) ? -1 : 0
+	xorl		%ecx,			%eax
+	xorl		%ecx,			%edx	// EDX:EAX = (a < 0) ? not(a) : a
+	subl		%ecx,			%eax
+	sbbl		%ecx,			%edx	// EDX:EAX = abs(a)
+	movl		%edx,		 12(%esp)
+	movl		%eax,		  8(%esp)	// store abs(a) back to stack
+	xorl		%ecx,			%esi	// sign of result = (sign of a) ^ (sign of b)
+
+	pushl		%ebx
+	movl	 24(%esp),			%ebx	// Find the index i of the leading bit in b.
+	bsrl		%ebx,			%ecx	// If the high word of b is zero, jump to
+	jz			9f						// the code to handle that special case [9].
+
+	/* High word of b is known to be non-zero on this branch */
+
+	movl	 20(%esp),			%eax	// Construct bhi, containing bits [1+i:32+i] of b
+
+	shrl		%cl,			%eax	// Practically, this means that bhi is given by:
+	shrl		%eax					//
+	notl		%ecx					//		bhi = (high word of b) << (31 - i) |
+	shll		%cl,			%ebx	//			  (low word of b) >> (1 + i)
+	orl			%eax,			%ebx	//
+	movl	 16(%esp),			%edx	// Load the high and low words of a, and jump
+	movl	 12(%esp),			%eax	// to [1] if the high word is larger than bhi
+	cmpl		%ebx,			%edx	// to avoid overflowing the upcoming divide.
+	jae			1f
+
+	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+
+	divl		%ebx					// eax <-- qs, edx <-- r such that ahi:alo = bs*qs + r
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	shrl		%cl,			%eax	// q = qs >> (1 + i)
+	movl		%eax,			%edi
+	mull	 24(%esp)					// q*blo
+	movl	 16(%esp),			%ebx
+	movl	 20(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 28(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	sbbl		$0,				%edi	// decrement q if remainder is negative
+	xorl		%edx,			%edx
+	movl		%edi,			%eax
+
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%edi					// Restore callee-save registers
+	popl		%ebx
+	popl		%esi
+	ret         $0x10					// Return
+
+
+1:	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+
+	subl		%ebx,			%edx	// subtract bhi from ahi so that divide will not
+	divl		%ebx					// overflow, and find q and r such that
+										//
+										//		ahi:alo = (1:q)*bhi + r
+										//
+										// Note that q is a number in (31-i).(1+i)
+										// fix point.
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	orl			$0x80000000,	%eax
+	shrl		%cl,			%eax	// q = (1:qs) >> (1 + i)
+	movl		%eax,			%edi
+	mull	 24(%esp)					// q*blo
+	movl	 16(%esp),			%ebx
+	movl	 20(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 28(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	sbbl		$0,				%edi	// decrement q if remainder is negative
+	xorl		%edx,			%edx
+	movl		%edi,			%eax
+
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%edi					// Restore callee-save registers
+	popl		%ebx
+	popl		%esi
+	ret         $0x10					// Return
+
+
+9:	/* High word of b is zero on this branch */
+
+	movl	 16(%esp),			%eax	// Find qhi and rhi such that
+	movl	 20(%esp),			%ecx	//
+	xorl		%edx,			%edx	//		ahi = qhi*b + rhi	with	0 ≤ rhi < b
+	divl		%ecx					//
+	movl		%eax,			%ebx	//
+	movl	 12(%esp),			%eax	// Find qlo such that
+	divl		%ecx					//
+	movl		%ebx,			%edx	//		rhi:alo = qlo*b + rlo  with 0 ≤ rlo < b
+
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%ebx					// Restore callee-save registers
+	popl		%esi
+	ret         $0x10					// Return

--- a/lib/xlibc-rt/_allmul.s
+++ b/lib/xlibc-rt/_allmul.s
@@ -1,0 +1,26 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+// di_int __muldi3(di_int a, di_int b);
+
+// Modified for stdcall calling convention for use in nxdk
+
+.text
+.balign 4
+.globl __allmul
+__allmul:
+	pushl	%ebx
+	movl  16(%esp),		%eax	// b.lo
+	movl  12(%esp),		%ecx	// a.hi
+	imull	%eax,		%ecx	// b.lo * a.hi
+
+	movl   8(%esp),		%edx	// a.lo
+	movl  20(%esp),		%ebx	// b.hi
+	imull	%edx,		%ebx	// a.lo * b.hi
+
+	mull	%edx				// EDX:EAX = a.lo * b.lo
+	addl	%ecx,		%ebx	// EBX = (a.lo*b.hi + a.hi*b.lo)
+	addl	%ebx,		%edx
+
+	popl	%ebx
+	ret     $0x10

--- a/lib/xlibc-rt/_allrem.s
+++ b/lib/xlibc-rt/_allrem.s
@@ -1,0 +1,162 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+// di_int __moddi3(di_int a, di_int b);
+
+// result = remainder of a / b.
+// both inputs and the output are 64-bit signed integers.
+// This will do whatever the underlying hardware is set to do on division by zero.
+// No other exceptions are generated, as the divide cannot overflow.
+//
+// This is targeted at 32-bit x86 *only*, as this can be done directly in hardware
+// on x86_64.  The performance goal is ~40 cycles per divide, which is faster than
+// currently possible via simulation of integer divides on the x87 unit.
+//
+
+// Stephen Canon, December 2008
+
+// Modified for stdcall calling convention for use in nxdk
+
+.text
+.balign 4
+.globl __allrem
+__allrem:
+
+/* This is currently implemented by wrapping the unsigned modulus up in an absolute
+   value.  This could certainly be improved upon. */
+
+	pushl		%esi
+	movl	 20(%esp),			%edx	// high word of b
+	movl	 16(%esp),			%eax	// low word of b
+	movl		%edx,			%ecx
+	sarl		$31,			%ecx	// (b < 0) ? -1 : 0
+	xorl		%ecx,			%eax
+	xorl		%ecx,			%edx	// EDX:EAX = (b < 0) ? not(b) : b
+	subl		%ecx,			%eax
+	sbbl		%ecx,			%edx	// EDX:EAX = abs(b)
+	movl		%edx,		 20(%esp)
+	movl		%eax,		 16(%esp)	// store abs(b) back to stack
+
+	movl	 12(%esp),			%edx	// high word of b
+	movl	  8(%esp),			%eax	// low word of b
+	movl		%edx,			%ecx
+	sarl		$31,			%ecx	// (a < 0) ? -1 : 0
+	xorl		%ecx,			%eax
+	xorl		%ecx,			%edx	// EDX:EAX = (a < 0) ? not(a) : a
+	subl		%ecx,			%eax
+	sbbl		%ecx,			%edx	// EDX:EAX = abs(a)
+	movl		%edx,		 12(%esp)
+	movl		%eax,		  8(%esp)	// store abs(a) back to stack
+	movl		%ecx,			%esi	// set aside sign of a
+
+	pushl		%ebx
+	movl	 24(%esp),			%ebx	// Find the index i of the leading bit in b.
+	bsrl		%ebx,			%ecx	// If the high word of b is zero, jump to
+	jz			9f						// the code to handle that special case [9].
+
+	/* High word of b is known to be non-zero on this branch */
+
+	movl	 20(%esp),			%eax	// Construct bhi, containing bits [1+i:32+i] of b
+
+	shrl		%cl,			%eax	// Practically, this means that bhi is given by:
+	shrl		%eax					//
+	notl		%ecx					//		bhi = (high word of b) << (31 - i) |
+	shll		%cl,			%ebx	//			  (low word of b) >> (1 + i)
+	orl			%eax,			%ebx	//
+	movl	 16(%esp),			%edx	// Load the high and low words of a, and jump
+	movl	 12(%esp),			%eax	// to [2] if the high word is larger than bhi
+	cmpl		%ebx,			%edx	// to avoid overflowing the upcoming divide.
+	jae			2f
+
+	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+
+	divl		%ebx					// eax <-- qs, edx <-- r such that ahi:alo = bs*qs + r
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	shrl		%cl,			%eax	// q = qs >> (1 + i)
+	movl		%eax,			%edi
+	mull	 24(%esp)					// q*blo
+	movl	 16(%esp),			%ebx
+	movl	 20(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 28(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+
+	jnc			1f						// if positive, this is the result.
+	addl	 24(%esp),			%ebx	// otherwise
+	adcl	 28(%esp),			%ecx	// ECX:EBX = a - (q-1)*b = result
+1:	movl		%ebx,			%eax
+	movl		%ecx,			%edx
+
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%edi					// Restore callee-save registers
+	popl		%ebx
+	popl		%esi
+	ret         $0x10		        	// Return
+
+2:	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+
+	subl		%ebx,			%edx	// subtract bhi from ahi so that divide will not
+	divl		%ebx					// overflow, and find q and r such that
+										//
+										//		ahi:alo = (1:q)*bhi + r
+										//
+										// Note that q is a number in (31-i).(1+i)
+										// fix point.
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	orl			$0x80000000,	%eax
+	shrl		%cl,			%eax	// q = (1:qs) >> (1 + i)
+	movl		%eax,			%edi
+	mull	 24(%esp)					// q*blo
+	movl	 16(%esp),			%ebx
+	movl	 20(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 28(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+
+	jnc			3f						// if positive, this is the result.
+	addl	 24(%esp),			%ebx	// otherwise
+	adcl	 28(%esp),			%ecx	// ECX:EBX = a - (q-1)*b = result
+3:	movl		%ebx,			%eax
+	movl		%ecx,			%edx
+
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%edi					// Restore callee-save registers
+	popl		%ebx
+	popl		%esi
+	ret         $0x10					// Return
+
+9:	/* High word of b is zero on this branch */
+
+	movl	 16(%esp),			%eax	// Find qhi and rhi such that
+	movl	 20(%esp),			%ecx	//
+	xorl		%edx,			%edx	//		ahi = qhi*b + rhi	with	0 ≤ rhi < b
+	divl		%ecx					//
+	movl		%eax,			%ebx	//
+	movl	 12(%esp),			%eax	// Find rlo such that
+	divl		%ecx					//
+	movl		%edx,			%eax	//		rhi:alo = qlo*b + rlo  with 0 ≤ rlo < b
+	popl		%ebx					//
+	xorl		%edx,			%edx	// and return 0:rlo
+
+	addl		%esi,			%eax	// Restore correct sign to result
+	adcl		%esi,			%edx
+	xorl		%esi,			%eax
+	xorl		%esi,			%edx
+	popl		%esi
+	ret         $0x10					// Return

--- a/lib/xlibc-rt/_allshl.s
+++ b/lib/xlibc-rt/_allshl.s
@@ -1,0 +1,10 @@
+.globl __allshl
+__allshl:
+    shldl %cl, %eax, %edx
+    sall %cl, %eax
+    testb $32, %cl
+    je .l
+    movl %eax, %edx
+    xorl %eax, %eax
+.l:
+    ret

--- a/lib/xlibc-rt/_allshr.s
+++ b/lib/xlibc-rt/_allshr.s
@@ -1,0 +1,10 @@
+.globl __allshr
+__allshr:
+    shrdl %cl, %edx, %eax
+    sarl %cl, %edx
+    testb $32, %cl
+    je .l
+    movl %edx, %eax
+    sarl $31, %edx
+.l:
+    ret

--- a/lib/xlibc-rt/_aulldiv.s
+++ b/lib/xlibc-rt/_aulldiv.s
@@ -1,0 +1,111 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+// du_int __udivdi3(du_int a, du_int b);
+
+// result = a / b.
+// both inputs and the output are 64-bit unsigned integers.
+// This will do whatever the underlying hardware is set to do on division by zero.
+// No other exceptions are generated, as the divide cannot overflow.
+//
+// This is targeted at 32-bit x86 *only*, as this can be done directly in hardware
+// on x86_64.  The performance goal is ~40 cycles per divide, which is faster than
+// currently possible via simulation of integer divides on the x87 unit.
+//
+// Stephen Canon, December 2008
+
+// Modified for stdcall calling convention for use in nxdk
+
+.text
+.balign 4
+.globl __aulldiv
+__aulldiv:
+
+	pushl		%ebx
+	movl	 20(%esp),			%ebx	// Find the index i of the leading bit in b.
+	bsrl		%ebx,			%ecx	// If the high word of b is zero, jump to
+	jz			9f						// the code to handle that special case [9].
+
+	/* High word of b is known to be non-zero on this branch */
+
+	movl	 16(%esp),			%eax	// Construct bhi, containing bits [1+i:32+i] of b
+
+	shrl		%cl,			%eax	// Practically, this means that bhi is given by:
+	shrl		%eax					//
+	notl		%ecx					//		bhi = (high word of b) << (31 - i) |
+	shll		%cl,			%ebx	//			  (low word of b) >> (1 + i)
+	orl			%eax,			%ebx	//
+	movl	 12(%esp),			%edx	// Load the high and low words of a, and jump
+	movl	  8(%esp),			%eax	// to [1] if the high word is larger than bhi
+	cmpl		%ebx,			%edx	// to avoid overflowing the upcoming divide.
+	jae			1f
+
+	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+
+	divl		%ebx					// eax <-- qs, edx <-- r such that ahi:alo = bs*qs + r
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	shrl		%cl,			%eax	// q = qs >> (1 + i)
+	movl		%eax,			%edi
+	mull	 20(%esp)					// q*blo
+	movl	 12(%esp),			%ebx
+	movl	 16(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 24(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	sbbl		$0,				%edi	// decrement q if remainder is negative
+	xorl		%edx,			%edx
+	movl		%edi,			%eax
+	popl		%edi
+	popl		%ebx
+	ret         $0x10
+
+
+1:	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+
+	subl		%ebx,			%edx	// subtract bhi from ahi so that divide will not
+	divl		%ebx					// overflow, and find q and r such that
+										//
+										//		ahi:alo = (1:q)*bhi + r
+										//
+										// Note that q is a number in (31-i).(1+i)
+										// fix point.
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	orl			$0x80000000,	%eax
+	shrl		%cl,			%eax	// q = (1:qs) >> (1 + i)
+	movl		%eax,			%edi
+	mull	 20(%esp)					// q*blo
+	movl	 12(%esp),			%ebx
+	movl	 16(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 24(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+	sbbl		$0,				%edi	// decrement q if remainder is negative
+	xorl		%edx,			%edx
+	movl		%edi,			%eax
+	popl		%edi
+	popl		%ebx
+	ret         $0x10
+
+
+9:	/* High word of b is zero on this branch */
+
+	movl	 12(%esp),			%eax	// Find qhi and rhi such that
+	movl	 16(%esp),			%ecx	//
+	xorl		%edx,			%edx	//		ahi = qhi*b + rhi	with	0 ≤ rhi < b
+	divl		%ecx					//
+	movl		%eax,			%ebx	//
+	movl	  8(%esp),			%eax	// Find qlo such that
+	divl		%ecx					//
+	movl		%ebx,			%edx	//		rhi:alo = qlo*b + rlo  with 0 ≤ rlo < b
+	popl		%ebx					//
+	ret         $0x10					// and return qhi:qlo

--- a/lib/xlibc-rt/_aullrem.s
+++ b/lib/xlibc-rt/_aullrem.s
@@ -1,0 +1,122 @@
+// This file is dual licensed under the MIT and the University of Illinois Open
+// Source Licenses. See LICENSE.TXT for details.
+
+// du_int __umoddi3(du_int a, du_int b);
+
+// result = remainder of a / b.
+// both inputs and the output are 64-bit unsigned integers.
+// This will do whatever the underlying hardware is set to do on division by zero.
+// No other exceptions are generated, as the divide cannot overflow.
+//
+// This is targeted at 32-bit x86 *only*, as this can be done directly in hardware
+// on x86_64.  The performance goal is ~40 cycles per divide, which is faster than
+// currently possible via simulation of integer divides on the x87 unit.
+//
+
+// Stephen Canon, December 2008
+
+// Modified for stdcall calling convention for use in nxdk
+
+.text
+.balign 4
+.globl __aullrem
+__aullrem:
+
+	pushl		%ebx
+	movl	 20(%esp),			%ebx	// Find the index i of the leading bit in b.
+	bsrl		%ebx,			%ecx	// If the high word of b is zero, jump to
+	jz			9f						// the code to handle that special case [9].
+
+	/* High word of b is known to be non-zero on this branch */
+
+	movl	 16(%esp),			%eax	// Construct bhi, containing bits [1+i:32+i] of b
+
+	shrl		%cl,			%eax	// Practically, this means that bhi is given by:
+	shrl		%eax					//
+	notl		%ecx					//		bhi = (high word of b) << (31 - i) |
+	shll		%cl,			%ebx	//			  (low word of b) >> (1 + i)
+	orl			%eax,			%ebx	//
+	movl	 12(%esp),			%edx	// Load the high and low words of a, and jump
+	movl	  8(%esp),			%eax	// to [2] if the high word is larger than bhi
+	cmpl		%ebx,			%edx	// to avoid overflowing the upcoming divide.
+	jae			2f
+
+	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+
+	divl		%ebx					// eax <-- qs, edx <-- r such that ahi:alo = bs*qs + r
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	shrl		%cl,			%eax	// q = qs >> (1 + i)
+	movl		%eax,			%edi
+	mull	 20(%esp)					// q*blo
+	movl	 12(%esp),			%ebx
+	movl	 16(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 24(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+
+	jnc			1f						// if positive, this is the result.
+	addl	 20(%esp),			%ebx	// otherwise
+	adcl	 24(%esp),			%ecx	// ECX:EBX = a - (q-1)*b = result
+1:	movl		%ebx,			%eax
+	movl		%ecx,			%edx
+
+	popl		%edi
+	popl		%ebx
+	ret         $0x10
+
+
+2:	/* High word of a is greater than or equal to (b >> (1 + i)) on this branch */
+
+	subl		%ebx,			%edx	// subtract bhi from ahi so that divide will not
+	divl		%ebx					// overflow, and find q and r such that
+										//
+										//		ahi:alo = (1:q)*bhi + r
+										//
+										// Note that q is a number in (31-i).(1+i)
+										// fix point.
+
+	pushl		%edi
+	notl		%ecx
+	shrl		%eax
+	orl			$0x80000000,	%eax
+	shrl		%cl,			%eax	// q = (1:qs) >> (1 + i)
+	movl		%eax,			%edi
+	mull	 20(%esp)					// q*blo
+	movl	 12(%esp),			%ebx
+	movl	 16(%esp),			%ecx	// ECX:EBX = a
+	subl		%eax,			%ebx
+	sbbl		%edx,			%ecx	// ECX:EBX = a - q*blo
+	movl	 24(%esp),			%eax
+	imull		%edi,			%eax	// q*bhi
+	subl		%eax,			%ecx	// ECX:EBX = a - q*b
+
+	jnc			3f						// if positive, this is the result.
+	addl	 20(%esp),			%ebx	// otherwise
+	adcl	 24(%esp),			%ecx	// ECX:EBX = a - (q-1)*b = result
+3:	movl		%ebx,			%eax
+	movl		%ecx,			%edx
+
+	popl		%edi
+	popl		%ebx
+	ret         $0x10
+
+
+
+9:	/* High word of b is zero on this branch */
+
+	movl	 12(%esp),			%eax	// Find qhi and rhi such that
+	movl	 16(%esp),			%ecx	//
+	xorl		%edx,			%edx	//		ahi = qhi*b + rhi	with	0 ≤ rhi < b
+	divl		%ecx					//
+	movl		%eax,			%ebx	//
+	movl	  8(%esp),			%eax	// Find rlo such that
+	divl		%ecx					//
+	movl		%edx,			%eax	//		rhi:alo = qlo*b + rlo  with 0 ≤ rlo < b
+	popl		%ebx					//
+	xorl		%edx,			%edx	// and return 0:rlo
+	ret         $0x10			        //

--- a/lib/xlibc-rt/_aullshl.s
+++ b/lib/xlibc-rt/_aullshl.s
@@ -1,0 +1,10 @@
+.globl __aullshl
+__aullshl:
+    shldl %cl, %eax, %edx
+    sall %cl, %eax
+    testb $32, %cl
+    je .l
+    movl %eax, %edx
+    xorl %eax, %eax
+.l:
+    ret

--- a/lib/xlibc-rt/_aullshr.s
+++ b/lib/xlibc-rt/_aullshr.s
@@ -1,0 +1,10 @@
+.globl __aullshr
+__aullshr:
+    shrdl %cl, %edx, %eax
+    shrl %cl, %edx
+    testb $32, %cl
+    je .l
+    movl %edx, %eax
+    xorl %edx, %edx
+.l:
+    ret

--- a/lib/xlibc-rt/_fltused.c
+++ b/lib/xlibc-rt/_fltused.c
@@ -1,0 +1,1 @@
+int _fltused = 1;

--- a/lib/xlibc-rt/check_stack.c
+++ b/lib/xlibc-rt/check_stack.c
@@ -1,0 +1,23 @@
+#include <debug.h>
+#include "xboxkrnl/xboxkrnl.h"
+
+#ifdef DEBUG_CONSOLE
+    #define _print DbgPrint
+#else
+    #define _print debugPrint
+#endif
+
+void _cdecl _xlibc_check_stack (DWORD requested_size, DWORD stack_ptr)
+{
+    PKTHREAD current_thread = KeGetCurrentThread();
+
+    if (requested_size >= stack_ptr || stack_ptr - requested_size < (DWORD)current_thread->StackLimit)
+    {
+        _print("\nStack overflow caught!\n"
+               "stack pointer: 0x%x\n"
+               "request size:  0x%x\n"
+               "stack limit:   0x%x)\n\n",
+               stack_ptr, requested_size, (DWORD)current_thread->StackLimit);
+        // TODO: halt execution
+    }
+}

--- a/lib/xlibc-rt/chkstk.s
+++ b/lib/xlibc-rt/chkstk.s
@@ -1,0 +1,37 @@
+/*
+    This file is licensed under the CC0 1.0.
+    For details, see: https://creativecommons.org/publicdomain/zero/1.0/
+*/
+
+.text
+
+/*
+    __chkstk does not comply to any standardized calling convention.
+    When called, eax contains the size of the request, and esp is modified
+    accordingly before returning.
+    Calling __chkstk has the same effect as "subl %eax, %esp".
+*/
+.globl __chkstk
+__chkstk:
+    pushl %ecx
+    leal 8(%esp), %ecx  // Load original stack address into ecx
+    pushl %ecx          // Save caller-saved registers before calling a C-function
+    pushl %eax
+    pushl %edx
+
+    pushl %ecx
+    pushl %eax
+    call __xlibc_check_stack
+    addl $8, %esp
+
+    popl %edx
+    popl %eax
+    popl %ecx
+    subl %eax, %ecx     // ecx is the new stack pointer
+    leal 4(%esp), %eax  // eax is a pointer to the return address variable
+    movl %ecx, %esp     // load the new stack address
+    movl -4(%eax), %ecx // restore ecx
+    pushl (%eax)        // put return address back on the stack
+    subl %esp, %eax     // restore eax
+
+    ret


### PR DESCRIPTION
This adds functions required at runtime by compiler generated function calls. Most of the 64-bit math code was taken from LLVM's compiler_rt library (required license files are included) and modified to fit the required calling convention.

I originally intended to use LLVM's __chkstk implementation too, but their implementation expects the OS to grow the stack when the guard page is hit during probing. However, on the Xbox, it seems that stacks are statically allocated, and while there is a guard page, it is only used to catch stack overflows - dynamic growth is not supported. So I wrote my own __chkstk implementation, which uses a C helper function to check whether the requested amount fits into the current thread's stack and prints an error if it doesn't.

I quickly tested it by running a sample program which creates a large array on the stack, and it seemed to work correctly.

Should fix #32.