### PR TITLE
build: Change linux lld call name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
-LD           = lld-link
+LD           = lld -flavor link
 CC           = clang
 CXX          = clang++
 CGC          = $(NXDK_DIR)/tools/cg/linux/cgc


### PR DESCRIPTION
Closes #56.

As suggested by @thrimbor, changing `ld = lld-link` into `ld = lld -flavor link` makes the call work out of the box in Ubuntu.