### PR TITLE
libc additions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ TOOLS        = cxbe vp20compiler fp20compiler extract-xiso
 NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -ffreestanding -nostdlib -fno-builtin -fno-exceptions \
                -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt \
+               -isystem $(NXDK_DIR)/lib/xlibc/include \
                -Wno-ignored-attributes -DNXDK
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -21,6 +21,8 @@ USB_SRCS := \
 
 SRCS += \
 	$(wildcard $(NXDK_DIR)/lib/xboxrt/*.c) \
+	$(shell find $(NXDK_DIR)/lib/xlibc/src/ -name "*.c") \
+	$(shell find $(NXDK_DIR)/lib/xlibc/src/ -name "*.s") \
 	$(wildcard $(NXDK_DIR)/lib/xlibc-rt/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/xlibc-rt/*.s) \
 	$(wildcard $(NXDK_DIR)/lib/hal/*.c) \

--- a/lib/hal/fileio.c
+++ b/lib/hal/fileio.c
@@ -4,7 +4,7 @@
 #include <hal/fileio.h>
 #include <xboxkrnl/xboxkrnl.h>
 #include <xboxrt/debug.h>
-#include <xboxrt/stdbool.h>
+#include <stdbool.h>
 
 // #define DEBUG
 

--- a/lib/xboxrt/stdbool.h
+++ b/lib/xboxrt/stdbool.h
@@ -1,8 +1,0 @@
-#ifndef XBOXRT_STDBOOL
-#define XBOXRT_STDBOOL
-
-typedef _Bool bool;
-#define true 1
-#define false 0
-
-#endif

--- a/lib/xlibc/include/_restrict.h
+++ b/lib/xlibc/include/_restrict.h
@@ -1,0 +1,10 @@
+#ifndef _XLIBC__RESTRICT_H
+#define _XLIBC__RESTRICT_H
+
+#ifdef __cplusplus
+    #define XLIBC_RESTRICT __restrict
+#else
+    #define XLIBC_RESTRICT restrict
+#endif
+
+#endif /* end of include guard: _XLIBC__RESTRICT_H */

--- a/lib/xlibc/include/assert.h
+++ b/lib/xlibc/include/assert.h
@@ -1,0 +1,41 @@
+#ifndef _XLIBC_ASSERT_H
+#define _XLIBC_ASSERT_H
+
+/* based on _PDCLIB_symbol2value from PDCLIB */
+#ifndef _XLIBC_symbol2value
+#define _XLIBC_symbol2value(x) #x
+#endif
+
+/* based on _PDCLIB_symbol2string from PDCLIB */
+#ifndef _XLIBC_symbol2string
+#define _XLIBC_symbol2string(x) _XLIBC_symbol2value(x)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#undef assert
+#ifdef NDEBUG
+    #define assert(ignore) ((void)0)
+#else
+    void _xlibc_assert(char const * const expression, char const * const file_name, char const * const function_name, unsigned long line);
+
+    #define assert(expression) \
+        do { \
+            if(!(expression)) { \
+                _xlibc_assert(_XLIBC_symbol2string(expression), \
+                              __FILE__, \
+                              __func__, \
+                              __LINE__); \
+            } \
+        } while(0)
+#endif
+
+#define static_assert _Static_assert
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* end of include guard: _XLIBC_ASSERT_H */

--- a/lib/xlibc/include/setjmp.h
+++ b/lib/xlibc/include/setjmp.h
@@ -1,0 +1,26 @@
+#ifndef _XLIBC_SETJMP_H
+#define _XLIBC_SETJMP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+Buffer layout:
+     0: unsigned long ebp
+     4: unsigned long ebx
+     8: unsigned long edi
+    12: unsigned long esi
+    16: unsigned long esp
+    20: unsigned long eip
+*/
+typedef unsigned long jmp_buf[6];
+
+int setjmp (jmp_buf env);
+_Noreturn void longjmp (jmp_buf env, int val);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* end of include guard: _XLIBC_SETJMP_H */

--- a/lib/xlibc/include/stdarg.h
+++ b/lib/xlibc/include/stdarg.h
@@ -1,0 +1,19 @@
+#ifndef _XLIBC_STDARG_H
+#define _XLIBC_STDARG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef __builtin_va_list va_list;
+
+#define va_start(v,l) __builtin_va_start((v), (l))
+#define va_end __builtin_va_end
+#define va_arg __builtin_va_arg
+#define va_copy(d,s) __builtin_va_copy((d),(s))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* end of include guard: _XLIBC_STDARG_H */

--- a/lib/xlibc/include/stdbool.h
+++ b/lib/xlibc/include/stdbool.h
@@ -1,0 +1,9 @@
+#ifndef _XLIBC_STDBOOL_H
+#define _XLIBC_STDBOOL_H
+
+#define bool _Bool
+#define true 1
+#define false 0
+#define __bool_true_false_are_defined 1
+
+#endif /* end of include guard: _XLIBC_STDBOOL_H */

--- a/lib/xlibc/include/stdnoreturn.h
+++ b/lib/xlibc/include/stdnoreturn.h
@@ -1,0 +1,6 @@
+#ifndef _XLIBC_STDNORETURN_H
+#define _XLIBC_STDNORETURN_H
+
+#define noreturn _Noreturn
+
+#endif /* end of include guard: _XLIBC_STDNORETURN_H */

--- a/lib/xlibc/src/assert/_xlibc_assert.c
+++ b/lib/xlibc/src/assert/_xlibc_assert.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <debug.h>
+#include <stdlib.h>
+#include "xboxkrnl/xboxkrnl.h"
+
+void _xlibc_assert(char const * const expression, char const * const file_name, char const * const function_name, unsigned long line)
+{
+    #ifdef DEBUG_CONSOLE
+        char buffer[512];
+        snprintf(buffer, 512, "In function '%s': ", function_name);
+        RtlAssert((PVOID)expression, (PVOID)file_name, line, buffer);
+    #else
+        debugPrint("\nAssertion failed: '%s' in function '%s', file '%s', line %u\n", expression, function_name, file_name, line);
+        __asm__ ("cli\n"
+                 ".l:\n"
+                 "hlt\n"
+                 "jmp .l\n");
+    #endif
+}

--- a/lib/xlibc/src/setjmp/longjmp.s
+++ b/lib/xlibc/src/setjmp/longjmp.s
@@ -1,0 +1,24 @@
+.text
+
+/*
+Buffer layout:
+     0: unsigned long ebp
+     4: unsigned long ebx
+     8: unsigned long edi
+    12: unsigned long esi
+    16: unsigned long esp
+    20: unsigned long eip
+*/
+
+.globl _longjmp
+_longjmp:
+    movl 4(%esp), %ecx
+    movl 8(%esp), %eax
+
+    movl (%ecx), %ebp
+    movl 4(%ecx), %ebx
+    movl 8(%ecx), %edi
+    movl 12(%ecx), %esi
+    movl 16(%ecx), %esp
+    movl 20(%ecx), %edx
+    jmp *%edx

--- a/lib/xlibc/src/setjmp/setjmp.s
+++ b/lib/xlibc/src/setjmp/setjmp.s
@@ -1,0 +1,27 @@
+.text
+
+/*
+Buffer layout:
+     0: unsigned long ebp
+     4: unsigned long ebx
+     8: unsigned long edi
+    12: unsigned long esi
+    16: unsigned long esp
+    20: unsigned long eip
+*/
+
+.globl _setjmp
+_setjmp:
+    movl 4(%esp), %eax
+
+    movl %ebp, (%eax)
+    movl %ebx, 4(%eax)
+    movl %edi, 8(%eax)
+    movl %esi, 12(%eax)
+    leal 4(%esp), %ecx
+    movl %ecx, 16(%eax)
+    movl (%esp), %ecx
+    movl %ecx, 20(%eax)
+
+    xorl %eax, %eax
+    ret


### PR DESCRIPTION
These are the first bits and pieces of my libc work. Additions mostly, without much replacing going on yet.

a6e0ec8cf355af94c8a1d6d9056dbca12a05ca26 adds the prerequisites for the later additions (include dir and source paths).
f3c9cbab073df536e18de2df525fd98db32524ca adds _restrict.h, which is meant as a libc-internal header to allow using the "restrict"-specifier while staying C++ compatible.
d89f109400cd4fe07d9290e8a6de6ac82d22b051 adds assert(). The standard actually says to call abort() (which would exit the program) which doesn't make much sense here, so the Xbox is halted instead. When compiled for a debug console (this isn't integrated with the makefile yet), RtlAssert is used instead of printing to the screen, and the Xbox is not halted in order to support tools like xbWatson, which allows the user to resume execution. Both codepaths were tested.
0efd6b70a73becf198561ca6e6bb5c99cdd9c8c6 adds stdbool.h, replacing the pre-existing incomplete one.
2640201c3f6bf0a6ca07e0bbf424834a5e03e4da adds stdnoreturn.h, not the most useful header, but the standard demands it.
95a84ddf6f6e2bc3826c376240d0ae7b998dbfae adds setjmp.h and implements setjmp and longjmp.
652cf683de0dff62f0ab5502b52319d0802e0f3b adds stdarg.h which provides va_start, va_end, va_arg and va_copy (we've actually been using the host's stdarg.h till now).

@JayFoxRox I tested setjmp/longjmp with your [code sample](https://github.com/JayFoxRox/nxdk/blob/8da92893d1cc94f43828bce9b6b9114b67bd6dd1/samples/setjmp/main.c) and it seemed to work fine, but you might want to double-check.

I previously wasn't sure if setjmp/longjmp should also touch FPU registers because the standard only says "it does not include the state of the floating-point status flags[...]", but looking at other libc's it seems normal to not store FPU registers on x86.

My assert-macro contains a loop that might seem pointless, but it's there to prevent users from accidentally doing things like `assert(0==1)
 else {
     print("This is broken\n");
 }`