### PR TITLE
Small fix for longjmp return value

### DIFF
--- a/lib/xlibc/src/setjmp/longjmp.s
+++ b/lib/xlibc/src/setjmp/longjmp.s
@@ -21,4 +21,7 @@ _longjmp:
     movl 12(%ecx), %esi
     movl 16(%ecx), %esp
     movl 20(%ecx), %edx
-    jmp *%edx
+    testl %eax, %eax
+    jnz .r
+    incl %eax
+.r: jmp *%edx


### PR DESCRIPTION
This fixes a small oversight I noticed this morning: longjmp isn't allowed to make setjmp return zero, instead it should return one if the val-parameter was zero.