### PR TITLE
Fix SDL sample building

### DIFF
--- a/samples/sdl/main.c
+++ b/samples/sdl/main.c
@@ -18,20 +18,6 @@
 #include "string.h"
 #include <SDL.h>
 
-int _fltused = 1;
-
-void _aullrem(void) {
-    debugPrint("%s unimplemented!\n", __func__);
-    XSleep(5000);
-    XReboot();
-}
-
-void _aulldiv(void) {
-    debugPrint("%s unimplemented!\n", __func__);
-    XSleep(5000);
-    XReboot();
-}
-
 int _exit(int x)
 {
     debugPrint("_exit called\n");


### PR DESCRIPTION
The SDL sample contained stubs for _fltused, _aullrem and _aulldiv. While e30f9ffe9c6e3e9f4a8102f412dc9662cdcdb207 added a proper implementation, I forgot to remove the stubs, which broke linking for the SDL sample due to duplicated symbols. This PR fixes that by removing the stubs.

I also made sure the SDL sample really works by running it on my Xbox.