### PR TITLE
CI: Add Appveyor support

### DIFF
--- a/.ci_build_samples.sh
+++ b/.ci_build_samples.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+cd samples
+
+for dir in */
+do
+    cd "$dir"
+    make
+    cd ..
+done
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,14 @@
+image: ubuntu1804
+
+install:
+    - sh: git submodule update --init --recursive
+    - sh: sudo apt-get update >/dev/null
+    - sh: sudo apt-get install -y build-essential flex bison clang lld >/dev/null
+
+build_script:
+    - sh: ./.ci_build_samples.sh
+
+artifacts:
+    - path: samples
+      name: nxdk-samples
+      type: zip


### PR DESCRIPTION
This adds basic CI support, building the nxdk-samples on Ubuntu 18.04. I've used Appveyor for this because the travis Ubuntu image is very old and complicates lld installation.
This also adds a small CI helper script to work around a known problem with Appveyor where calling `exit` in code contained in appveyor.yml would hang the build.
The artifacts-part currently packages the whole samples-directory and could surely be improved to not include unnecessary files (like code and .obj-files), but I've decided to keep it simple for now.
I tested the Appveyor support with my own copy of the repo to make sure it actually works.

Of course, Appveyor also has to be enabled for the repository by someone with the necessary access rights (like @mborgerson did for xqemu).

Addresses #36.