### PR TITLE
[Don't merge] Add improved printf-style functions

### DIFF
--- a/lib/xboxrt/stdlib.c
+++ b/lib/xboxrt/stdlib.c
@@ -3,148 +3,6 @@
 #include "ctype.h"
 #include <xboxkrnl/xboxkrnl.h>
 
-static const char digits[] = "0123456789abcdef";
-
-static unsigned int find_divisor(unsigned long val, unsigned int base)
-{
-  unsigned int n;
-
-  for (n = 1; val >= base; n *= base, val /= base);
-
-  return n;
-}
-
-static unsigned int write_uint(char *dst,
-                               unsigned int len,
-                               unsigned long val,
-                               unsigned int base)
-{
-  unsigned int div;
-  unsigned int n;
-
-  if (base < 2)
-    base = 2;
-  else if (base > sizeof(digits) - 1)
-    base = sizeof(digits) - 1;
-
-  div = find_divisor(val, base); // div < base unless val <= 1
-  n = 0;
-
-  while (n < len && div != 0) {
-    dst[n++] = digits[val / div];
-    val %= div;
-    div /= base;
-  }
-
-  return n;
-}
-
-static unsigned int write_int(char *dst,
-                              unsigned int len,
-                              long val,
-                              unsigned int base)
-{
-  if (len == 0)
-    return 0;
-
-  if (val < 0) {
-    *dst = '-';
-    return 1 + write_uint(dst + 1, len - 1, -val, base);
-  }
-
-  return write_uint(dst, len, val, base);
-}
-
-static unsigned int write_string(char *dst, unsigned int len, const char *src)
-{
-  unsigned int n;
-  char c;
-
-  if (src == NULL)
-    src = "(null)";
-
-  for (n = 0; n < len; n++) {
-    c = src[n];
-
-    if (c == '\0')
-      break;
-
-    dst[n] = c;
-  }
-
-  return n;
-}
-
-int vsnprintf(char *buf, unsigned int len, const char *fmt, va_list ap)
-{
-  unsigned int i;
-  unsigned int n;
-  char c;
-
-  if (len == 0)
-    return 0;
-
-  for (i = n = 0; n < len; i++) {
-    c = fmt[i];
-
-    if (c == '\0')
-      break;
-
-    if (c != '%') {
-      buf[n++] = c;
-      continue;
-    }
-
-    c = fmt[++i];
-
-    if (c == 's')
-      n += write_string(buf + n, len - n, va_arg(ap, const char *));
-    else if (c == 'd')
-      n += write_int(buf + n, len - n, va_arg(ap, long), 10);
-    else if (c == 'o')
-      n += write_uint(buf + n, len - n, va_arg(ap, unsigned long), 8);
-    else if (c == 'u')
-      n += write_uint(buf + n, len - n, va_arg(ap, unsigned long), 10);
-    else if (c == 'p' || c == 'x')
-      n += write_uint(buf + n, len - n, va_arg(ap, unsigned long), 16);
-    else if (c == 'c')
-      buf[n++] = va_arg(ap, int);
-    else if (c == '%')
-      buf[n++] = '%';
-    else
-      buf[n++] = c;
-  }
-
-  if (n >= len)
-    n = len - 1;
-
-  buf[n] = '\0';
-
-  return n;
-}
-
-int vsprintf(char *buf, const char *fmt, va_list args)
-{
-    return vsnprintf(buf, SIZE_MAX, fmt, args);
-}
-
-int snprintf(char * str, unsigned int len, const char * fmt, ...) {
-    va_list argList;
-    va_start(argList, fmt);
-    int r = vsnprintf(str, len, fmt, argList);
-    va_end(argList);
-    return r;
-}
-
-int sprintf(char * str, const char * fmt, ...) {
-    va_list argList;
-    va_start(argList, fmt);
-    int r = vsprintf(str, fmt, argList);
-    va_end(argList);
-    return r;
-}
-
-
 static void* VirtualAlloc(void *lpAddress, unsigned int dwSize, unsigned int flAllocationType, unsigned int flProtect)
 {
     NtAllocateVirtualMemory(&lpAddress, 0, &dwSize, flAllocationType, flProtect);
@@ -277,4 +135,9 @@ long strtol(const char *nptr, char **endptr, register int base)
 
 int atoi(const char *nptr) {
 	return (int) strtol (nptr, (char **) NULL, 10);
+}
+
+int abs (int j)
+{
+    return (j < 0) ? -j : j;
 }

--- a/lib/xboxrt/stdlib.h
+++ b/lib/xboxrt/stdlib.h
@@ -17,5 +17,6 @@ void *realloc(void *ptr, size_t size);
 long strtol(const char *nptr, char **endptr, register int base);
 
 int atoi(const char *nptr);
+int abs (int j);
 
 #endif

--- a/lib/xboxrt/string.c
+++ b/lib/xboxrt/string.c
@@ -47,6 +47,16 @@ size_t strlen(const char *s1) {
   return i;
 }
 
+size_t strnlen( const char * s, size_t maxlen )
+{
+    for( size_t len = 0; len != maxlen; len++ )
+    {
+        if(s[len] == '\0')
+            return len;
+    }
+    return maxlen;
+}
+
 char *strdup(const char *s1) {
     char *out = malloc(strlen(s1) + 1);
     strcpy(out, s1);

--- a/lib/xboxrt/string.h
+++ b/lib/xboxrt/string.h
@@ -17,6 +17,7 @@ char *strncat(char *s1, const char *s2, size_t n);
 char *strncpy(char *dst, const char *src, size_t n);
 char *strupr(char *s1);
 size_t strlen(const char *s1);
+size_t strnlen(const char *s, size_t maxlen);
 int strcmp(const char *s1, const char *s2);
 int strncmp(const char *s1, const char *s2, size_t n);
 int stricmp(const char *s1, const char *s2);

--- a/lib/xlibc/include/_print.h
+++ b/lib/xlibc/include/_print.h
@@ -1,0 +1,24 @@
+#include <stdarg.h>
+#include <stdio.h>
+
+static const char _XLIBC_digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+static const char _XLIBC_Xdigits[] = "0123456789ABCDEF";
+
+/* Status structure required by _XLIBC_print(). */
+struct _XLIBC_status_t
+{
+    int              base;   /* base to which the value shall be converted   */
+    long             flags;  /* flags and length modifiers                   */
+    unsigned         n;      /* print: maximum characters to be written      */
+                             /* scan:  number matched conversion specifiers  */
+    unsigned         i;      /* number of characters read/written            */
+    unsigned         current;/* chars read/written in the CURRENT conversion */
+    char *           s;      /* *sprintf(): target buffer                    */
+                             /* *sscanf():  source string                    */
+    unsigned         width;  /* specified field width                        */
+    int              prec;   /* specified field precision                    */
+    FILE           * stream; /* *fprintf() / *fscanf() stream                */
+    va_list          arg;    /* argument stack                               */
+};
+
+const char * _XLIBC_print (const char * spec, struct _XLIBC_status_t * status);

--- a/lib/xlibc/include/stdio.h
+++ b/lib/xlibc/include/stdio.h
@@ -1,0 +1,96 @@
+#ifndef _XLIBC_STDIO_H
+#define _XLIBC_STDIO_H
+
+#include <stdarg.h>
+#include <_restrict.h>
+#include <_unimplemented.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _XLIBC_SIZE_T_DEFINED
+#define _XLIBC_SIZE_T_DEFINED _XLIBC_SIZE_T_DEFINED
+typedef unsigned int size_t;
+#endif
+
+#ifndef _XLIBC_NULL_DEFINED
+#define _XLIBC_NULL_DEFINED _XLIBC_NULL_DEFINED
+#define NULL ((void *)0)
+#endif
+
+#define BUFSIZ 256
+
+#define _IOFBF 0
+#define _IOLBF 1
+#define _IONBF 2
+
+#define SEEK_SET 1
+#define SEEK_CUR 2
+#define SEEK_END 3
+
+#define EOF -1
+
+typedef struct {
+    // FIXME
+} FILE;
+
+typedef struct _xlibc_fpos
+{
+    // FIXME
+} fpos_t;
+
+int remove (const char *filename) __unimplemented;
+int rename (const char *old, const char *new) __unimplemented;
+
+FILE *tmpfile (void) __unimplemented;
+char *tmpnam(char *s) __unimplemented;
+
+int fclose (FILE *stream) __unimplemented;
+int fflush (FILE *stream) __unimplemented;
+FILE *fopen (const char * XLIBC_RESTRICT filename, const char * XLIBC_RESTRICT mode) __unimplemented;
+FILE *freopen (const char * XLIBC_RESTRICT filename, const char * XLIBC_RESTRICT mode, FILE * XLIBC_RESTRICT stream) __unimplemented;
+void setbuf (FILE * XLIBC_RESTRICT stream, char * XLIBC_RESTRICT buf) __unimplemented;
+int setvbuf (FILE * XLIBC_RESTRICT stream, char * XLIBC_RESTRICT buf, int mode, size_t size) __unimplemented;
+int fprintf (FILE * XLIBC_RESTRICT stream, const char * XLIBC_RESTRICT format, ...) __unimplemented;
+int fscanf (FILE * XLIBC_RESTRICT stream, const char * XLIBC_RESTRICT format, ...) __unimplemented;
+
+int printf (const char * XLIBC_RESTRICT format, ...) __unimplemented;
+int scanf (const char * XLIBC_RESTRICT format, ...) __unimplemented;
+int snprintf (char * XLIBC_RESTRICT s, size_t n, const char * XLIBC_RESTRICT format, ...);
+int sprintf (char * XLIBC_RESTRICT s, const char * XLIBC_RESTRICT format, ...);
+int sscanf (const char * XLIBC_RESTRICT s, const char * XLIBC_RESTRICT format, ...) __unimplemented;
+int vfprintf (FILE * XLIBC_RESTRICT stream, const char * XLIBC_RESTRICT format, va_list arg) __unimplemented;
+int vfscanf (FILE * XLIBC_RESTRICT stream, const char * XLIBC_RESTRICT format, va_list arg) __unimplemented;
+int vprintf (const char * XLIBC_RESTRICT format, va_list arg) __unimplemented;
+int vscanf (const char * XLIBC_RESTRICT format, va_list arg) __unimplemented;
+int vsnprintf (char * XLIBC_RESTRICT s, size_t n, const char * XLIBC_RESTRICT format, va_list arg);
+int vsprintf (char * XLIBC_RESTRICT s, const char * XLIBC_RESTRICT format, va_list arg);
+int vsscanf (const char * XLIBC_RESTRICT s, const char * XLIBC_RESTRICT format, va_list arg) __unimplemented;
+int fgetc (FILE *stream) __unimplemented;
+char *fgets (char * XLIBC_RESTRICT s, int n, FILE * XLIBC_RESTRICT stream) __unimplemented;
+int fputc (int c, FILE *stream) __unimplemented;
+int fputs (const char * XLIBC_RESTRICT s, FILE * XLIBC_RESTRICT stream) __unimplemented;
+int getc (FILE *stream) __unimplemented;
+int getchar (void) __unimplemented;
+int putc (int c, FILE *stream) __unimplemented;
+int putchar (int c) __unimplemented;
+int ungetc (int c, FILE *stream) __unimplemented;
+
+size_t fread (void * XLIBC_RESTRICT ptr, size_t size, size_t nmemb, FILE * XLIBC_RESTRICT stream) __unimplemented;
+size_t fwrite (const void * XLIBC_RESTRICT ptr, size_t size, size_t nmemb, FILE * XLIBC_RESTRICT stream) __unimplemented;
+int fgetpos (FILE * XLIBC_RESTRICT stream, fpos_t * XLIBC_RESTRICT pos) __unimplemented;
+int fseek (FILE *stream, long int offset, int whence) __unimplemented;
+int fsetpos(FILE *stream, const fpos_t *pos) __unimplemented;
+long int ftell (FILE *stream) __unimplemented;
+void rewind (FILE *stream) __unimplemented;
+void clearerr (FILE *stream) __unimplemented;
+int feof (FILE *stream) __unimplemented;
+int ferror (FILE *stream) __unimplemented;
+void perror (const char *s) __unimplemented;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* end of include guard: _XLIBC_STDIO_H */

--- a/lib/xlibc/src/stdio/_xlibc_print.c
+++ b/lib/xlibc/src/stdio/_xlibc_print.c
@@ -1,0 +1,521 @@
+/* _XLIBC_print( const char *, struct _XLIBC_status_t * )
+
+   This code is based on PDCLib
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <limits.h>
+
+#include "_print.h"
+
+/* Using an integer's bits as flags for both the conversion flags and length
+   modifiers.
+*/
+#define E_minus    (1<<0)
+#define E_plus     (1<<1)
+#define E_alt      (1<<2)
+#define E_space    (1<<3)
+#define E_zero     (1<<4)
+#define E_done     (1<<5)
+
+#define E_char     (1<<6)
+#define E_short    (1<<7)
+#define E_long     (1<<8)
+#define E_llong    (1<<9)
+#define E_intmax   (1<<10)
+#define E_size     (1<<11)
+#define E_ptrdiff  (1<<12)
+#define E_intptr   (1<<13)
+
+#define E_ldouble  (1<<14)
+
+#define E_lower    (1<<15)
+#define E_unsigned (1<<16)
+
+#define E_TYPES (E_char | E_short | E_long | E_llong | E_intmax \
+                | E_size | E_ptrdiff | E_intptr)
+
+/* This macro delivers a given character to either a memory buffer or a stream,
+   depending on the contents of 'status' (struct _XLIBC_status_t).
+   x - the character to be delivered
+   i - pointer to number of characters already delivered in this call
+   n - pointer to maximum number of characters to be delivered in this call
+   s - the buffer into which the character shall be delivered
+*/
+#define PUT( x ) \
+do { \
+    int character = x; \
+    if ( status->i < status->n ) { \
+        status->s[status->i] = character; \
+    } \
+    ++(status->i); \
+} while ( 0 )
+
+/* Maximum number of output characters =
+ *   number of bits in (u)intmax_t / number of bits per character in smallest
+ *   base. Smallest base is octal, 3 bits/char.
+ *
+ * Additionally require 2 extra characters for prefixes
+ */
+static const size_t maxIntLen = sizeof(intmax_t) * CHAR_BIT / 3 + 1;
+
+static void int2base( uintmax_t value, struct _XLIBC_status_t * status )
+{
+    char sign = 0;
+    if ( ! ( status->flags & E_unsigned ) )
+    {
+        intmax_t signval = (intmax_t) value;
+        bool negative = signval < 0;
+        value = signval < 0 ? -signval : signval;
+
+        if ( negative )
+        {
+            sign = '-';
+        }
+        else if ( status->flags & E_plus )
+        {
+            sign = '+';
+        }
+        else if (status->flags & E_space )
+        {
+            sign = ' ';
+        }
+    }
+
+    // The user could theoretically ask for a silly buffer length here.
+    // Perhaps after a certain size we should malloc? Or do we refuse to protect
+    // them from their own stupidity?
+    size_t bufLen = (status->width > maxIntLen ? status->width : maxIntLen) + 2;
+    char outbuf[bufLen];
+    char * outend = outbuf + bufLen;
+    int written = 0;
+
+    // Build up our output string - backwards
+    {
+        const char * digits = (status->flags & E_lower) ?
+                                _XLIBC_digits : _XLIBC_Xdigits;
+        uintmax_t remaining = value;
+        if(status->prec != 0 || remaining != 0) do {
+            uintmax_t digit = remaining % status->base;
+            remaining /= status->base;
+
+            outend[-++written] = digits[digit];
+        } while(remaining != 0);
+    }
+
+    // Pad field out to the precision specification
+    while( (long) written < status->prec ) outend[-++written] = '0';
+
+    // If a field width specified, and zero padding was requested, then pad to
+    // the field width
+    unsigned padding = 0;
+    if ( ( ! ( status->flags & E_minus ) ) && ( status->flags & E_zero ) )
+    {
+        while( written < (int) status->width )
+        {
+            outend[-++written] = '0';
+            padding++;
+        }
+    }
+
+    // Prefixes
+    if ( sign != 0 )
+    {
+        if ( padding == 0 ) written++;
+        outend[-written] = sign;
+    }
+    else if ( status->flags & E_alt )
+    {
+        switch ( status->base )
+        {
+            case 8:
+                if ( outend[-written] != '0' ) outend[-++written] = '0';
+                break;
+            case 16:
+                // No prefix if zero
+                if ( value == 0 ) break;
+
+                written += padding < 2 ? 2 - padding : 0;
+                outend[-written    ] = '0';
+                outend[-written + 1] = (status->flags & E_lower) ? 'x' : 'X';
+                break;
+            default:
+                break;
+        }
+    }
+
+    // Space padding to field width
+    if ( ! ( status->flags & ( E_minus | E_zero ) ) )
+    {
+        while( written < (int) status->width ) outend[-++written] = ' ';
+    }
+
+    // Write output
+    status->current = written;
+    while ( written )
+        PUT( outend[-written--] );
+}
+
+static void printstr( const char * str, struct _XLIBC_status_t * status )
+{
+    if ( status->width == 0 || status->flags & E_minus )
+    {
+        // Simple case or left justification
+        while ( str[status->current] &&
+            ( status->prec < 0 || (long)status->current < status->prec ) )
+        {
+            PUT( str[status->current++] );
+        }
+
+        while( status->current < status->width )
+        {
+            PUT( ' ' );
+            status->current++;
+        }
+    } else {
+        // Right justification
+        size_t len = status->prec >= 0 ? strnlen( str, status->prec )
+                                       :  strlen( str );
+        int padding = status->width - len;
+        while((long)status->current < padding)
+        {
+            PUT( ' ' );
+            status->current++;
+        }
+
+        for( size_t i = 0; i != len; i++ )
+        {
+            PUT( str[i] );
+            status->current++;
+        }
+    }
+}
+
+static void printchar( char chr, struct _XLIBC_status_t * status )
+{
+    if( ! ( status->flags & E_minus ) )
+    {
+        // Right justification
+        for( ; status->current + 1 < status->width; status->current++)
+        {
+            PUT( ' ' );
+        }
+        PUT( chr );
+        status->current++;
+    } else {
+        // Left justification
+        PUT( chr );
+        status->current++;
+
+        for( ; status->current < status->width; status->current++)
+        {
+            PUT( ' ' );
+        }
+    }
+}
+
+const char * _XLIBC_print( const char * spec, struct _XLIBC_status_t * status )
+{
+    const char * orig_spec = spec;
+    if ( *(++spec) == '%' )
+    {
+        /* %% -> print single '%' */
+        PUT( *spec );
+        return ++spec;
+    }
+    /* Initializing status structure */
+    status->flags = 0;
+    status->base  = 0;
+    status->current  = 0;
+    status->width = 0;
+    status->prec  = EOF;
+
+    /* First come 0..n flags */
+    do
+    {
+        switch ( *spec )
+        {
+            case '-':
+                /* left-aligned output */
+                status->flags |= E_minus;
+                ++spec;
+                break;
+            case '+':
+                /* positive numbers prefixed with '+' */
+                status->flags |= E_plus;
+                ++spec;
+                break;
+            case '#':
+                /* alternative format (leading 0x for hex, 0 for octal) */
+                status->flags |= E_alt;
+                ++spec;
+                break;
+            case ' ':
+                /* positive numbers prefixed with ' ' */
+                status->flags |= E_space;
+                ++spec;
+                break;
+            case '0':
+                /* right-aligned padding done with '0' instead of ' ' */
+                status->flags |= E_zero;
+                ++spec;
+                break;
+            default:
+                /* not a flag, exit flag parsing */
+                status->flags |= E_done;
+                break;
+        }
+    } while ( ! ( status->flags & E_done ) );
+
+    /* Optional field width */
+    if ( *spec == '*' )
+    {
+        /* Retrieve width value from argument stack */
+        int width = va_arg( status->arg, int );
+        if ( width < 0 )
+        {
+            status->flags |= E_minus;
+            status->width = abs( width );
+        }
+        else
+        {
+            status->width = width;
+        }
+        ++spec;
+    }
+    else
+    {
+        /* If a width is given, strtol() will return its value. If not given,
+           strtol() will return zero. In both cases, endptr will point to the
+           rest of the conversion specifier - just what we need.
+        */
+        status->width = (int)strtol( spec, (char**)&spec, 10 );
+    }
+
+    /* Optional precision */
+    if ( *spec == '.' )
+    {
+        ++spec;
+        if ( *spec == '*' )
+        {
+            /* Retrieve precision value from argument stack. A negative value
+               is as if no precision is given - as precision is initalized to
+               EOF (negative), there is no need for testing for negative here.
+            */
+            status->prec = va_arg( status->arg, int );
+            ++spec;
+        }
+        else
+        {
+            status->prec = (int)strtol( spec, (char**) &spec, 10 );
+        }
+        /* Having a precision cancels out any zero flag. */
+        status->flags &= ~E_zero;
+    }
+
+    /* Optional length modifier
+       We step one character ahead in any case, and step back only if we find
+       there has been no length modifier (or step ahead another character if it
+       has been "hh" or "ll").
+    */
+    switch ( *(spec++) )
+    {
+        case 'h':
+            if ( *spec == 'h' )
+            {
+                /* hh -> char */
+                status->flags |= E_char;
+                ++spec;
+            }
+            else
+            {
+                /* h -> short */
+                status->flags |= E_short;
+            }
+            break;
+        case 'l':
+            if ( *spec == 'l' )
+            {
+                /* ll -> long long */
+                status->flags |= E_llong;
+                ++spec;
+            }
+            else
+            {
+                /* k -> long */
+                status->flags |= E_long;
+            }
+            break;
+        case 'j':
+            /* j -> intmax_t, which might or might not be long long */
+            status->flags |= E_intmax;
+            break;
+        case 'z':
+            /* z -> size_t, which might or might not be unsigned int */
+            status->flags |= E_size;
+            break;
+        case 't':
+            /* t -> ptrdiff_t, which might or might not be long */
+            status->flags |= E_ptrdiff;
+            break;
+        case 'L':
+            /* L -> long double */
+            status->flags |= E_ldouble;
+            break;
+        default:
+            --spec;
+            break;
+    }
+
+    /* Conversion specifier */
+    switch ( *spec )
+    {
+        case 'd':
+            /* FALLTHROUGH */
+        case 'i':
+            status->base = 10;
+            break;
+        case 'o':
+            status->base = 8;
+            status->flags |= E_unsigned;
+            break;
+        case 'u':
+            status->base = 10;
+            status->flags |= E_unsigned;
+            break;
+        case 'x':
+            status->base = 16;
+            status->flags |= ( E_lower | E_unsigned );
+            break;
+        case 'X':
+            status->base = 16;
+            status->flags |= E_unsigned;
+            break;
+        case 'f':
+        case 'F':
+        case 'e':
+        case 'E':
+        case 'g':
+        case 'G':
+            break;
+        case 'a':
+        case 'A':
+            break;
+        case 'c':
+            /* TODO: wide chars. */
+            printchar( va_arg( status->arg, int ), status );
+            return ++spec;
+        case 's':
+            /* TODO: wide chars. */
+            {
+                char * s = va_arg( status->arg, char * );
+                printstr( s, status );
+                return ++spec;
+            }
+        case 'p':
+            status->base = 16;
+            status->flags |= ( E_lower | E_unsigned | E_alt | E_intptr );
+            break;
+        case 'n':
+           {
+               int * val = va_arg( status->arg, int * );
+               *val = status->i;
+               return ++spec;
+           }
+        default:
+            /* No conversion specifier. Bad conversion. */
+            return orig_spec;
+    }
+    /* Do the actual output based on our findings */
+    if ( status->base != 0 )
+    {
+        /* Integer conversions */
+        /* TODO: Check for invalid flag combinations. */
+        if ( status->flags & E_unsigned )
+        {
+            uintmax_t value;
+            switch ( status->flags & E_TYPES )
+            {
+                case E_char:
+                    value = (uintmax_t)(unsigned char)va_arg( status->arg, int );
+                    break;
+                case E_short:
+                    value = (uintmax_t)(unsigned short)va_arg( status->arg, int );
+                    break;
+                case 0:
+                    value = (uintmax_t)va_arg( status->arg, unsigned int );
+                    break;
+                case E_long:
+                    value = (uintmax_t)va_arg( status->arg, unsigned long );
+                    break;
+                case E_llong:
+                    value = (uintmax_t)va_arg( status->arg, unsigned long long );
+                    break;
+                case E_size:
+                    value = (uintmax_t)va_arg( status->arg, size_t );
+                    break;
+                case E_intptr:
+                    value = (uintmax_t)va_arg( status->arg, uintptr_t );
+                    break;
+                case E_ptrdiff:
+                    value = (uintmax_t)va_arg( status->arg, ptrdiff_t );
+                    break;
+                case E_intmax:
+                    value = va_arg( status->arg, uintmax_t );
+            }
+            int2base( value, status );
+        }
+        else
+        {
+            switch ( status->flags & E_TYPES )
+            {
+                case E_char:
+                    int2base( (intmax_t)(char)va_arg( status->arg, int ), status );
+                    break;
+                case E_short:
+                    int2base( (intmax_t)(short)va_arg( status->arg, int ), status );
+                    break;
+                case 0:
+                    int2base( (intmax_t)va_arg( status->arg, int ), status );
+                    break;
+                case E_long:
+                    int2base( (intmax_t)va_arg( status->arg, long ), status );
+                    break;
+                case E_llong:
+                    int2base( (intmax_t)va_arg( status->arg, long long ), status );
+                    break;
+                case E_size:
+                    int2base( (intmax_t)va_arg( status->arg, size_t ), status );
+                    break;
+                case E_intptr:
+                    int2base( (intmax_t)va_arg( status->arg, intptr_t ), status );
+                    break;
+                case E_ptrdiff:
+                    int2base( (intmax_t)va_arg( status->arg, ptrdiff_t ), status );
+                    break;
+                case E_intmax:
+                    int2base( va_arg( status->arg, intmax_t ), status );
+                    break;
+            }
+        }
+        if ( status->flags & E_minus )
+        {
+            while ( status->current < status->width )
+            {
+                PUT( ' ' );
+                ++(status->current);
+            }
+        }
+        if ( status->i >= status->n && status->n > 0 )
+        {
+            status->s[status->n - 1] = '\0';
+        }
+    }
+    return ++spec;
+}

--- a/lib/xlibc/src/stdio/snprintf.c
+++ b/lib/xlibc/src/stdio/snprintf.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdarg.h>
+
+int snprintf (char * restrict s, size_t n, const char * restrict format, ...)
+{
+    va_list al;
+    va_start(al, format);
+    int rv = vsnprintf(s, n, format, al);
+    va_end(al);
+    return rv;
+}

--- a/lib/xlibc/src/stdio/sprintf.c
+++ b/lib/xlibc/src/stdio/sprintf.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+#include <stdarg.h>
+
+int sprintf (char * restrict s, const char * restrict format, ...)
+{
+    va_list al;
+    va_start(al, format);
+    int rv = vsprintf(s, format, al);
+    va_end(al);
+    return rv;
+}

--- a/lib/xlibc/src/stdio/vsnprintf.c
+++ b/lib/xlibc/src/stdio/vsnprintf.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include "_print.h"
+
+int vsnprintf (char * XLIBC_RESTRICT s, size_t n, const char * XLIBC_RESTRICT format, va_list arg)
+{
+    /* TODO: This function should interpret format as multibyte characters.  */
+    struct _XLIBC_status_t status;
+    status.base = 0;
+    status.flags = 0;
+    status.n = n;
+    status.i = 0;
+    status.current = 0;
+    status.s = s;
+    status.width = 0;
+    status.prec = 0;
+    status.stream = NULL;
+    va_copy( status.arg, arg );
+
+    while ( *format != '\0' )
+    {
+        const char * rc;
+        if ( ( *format != '%' ) || ( ( rc = _XLIBC_print( format, &status ) ) == format ) )
+        {
+            /* No conversion specifier, print verbatim */
+            if ( status.i < n )
+            {
+                s[ status.i ] = *format;
+            }
+            status.i++;
+            format++;
+        }
+        else
+        {
+            /* Continue parsing after conversion specifier */
+            format = rc;
+        }
+    }
+    if ( status.i  < n )
+    {
+        s[ status.i ] = '\0';
+    }
+    va_end( status.arg );
+    return status.i;
+}

--- a/lib/xlibc/src/stdio/vsprintf.c
+++ b/lib/xlibc/src/stdio/vsprintf.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdint.h>
+
+int vsprintf (char * restrict s, const char * restrict format, va_list arg)
+{
+    return vsnprintf(s, SIZE_MAX, format, arg);
+}


### PR DESCRIPTION
**Note: I plan to submit a PR that will supersede this soon.**

This adds the stdio.h header and brings over PDCLib's formatted printing with minimal changes. I built and ran all the nxdk-samples on my Xbox to make sure nothing broke due to the changes, as well as [this small sample](https://gist.github.com/thrimbor/348acca0932f1f10e2650e7d845517d3) based on [cppreference example code](https://en.cppreference.com/w/c/io/fprintf). The indentation in my sample code is off, but this is a separate issue in `debugPrint`.
This does not support printing floats yet.

~~**Important:** This requires 845f4056caac25355fe725a10728b41774ffe3cd from #74. One solution would be to merge #74 first and rebase this PR, but I'd suggest cherry-picking the relevant commit into master and rebasing both PRs.~~