### PR TITLE
Update BOOL type to be correct size according to Microsoft Documentation

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -34,7 +34,8 @@ extern "C"
 #define CONST const
 
 typedef unsigned int SIZE_T, *PSIZE_T;
-typedef unsigned char BOOLEAN, *PBOOLEAN, BOOL;
+typedef unsigned char BOOLEAN, *PBOOLEAN;
+typedef int BOOL, *PBOOL;
 typedef void VOID, *PVOID, *LPVOID;
 typedef unsigned char UCHAR, *PUCHAR;
 typedef unsigned short USHORT, *PUSHORT, CSHORT;


### PR DESCRIPTION
BOOL should be a typedef of size int according to Microsoft Documentation: https://docs.microsoft.com/en-us/windows/desktop/winprog/windows-data-types#BOOL