### PR TITLE
xlibc: Add wchar.h

### DIFF
--- a/lib/xboxrt/wchar.c
+++ b/lib/xboxrt/wchar.c
@@ -1,0 +1,43 @@
+#include "wchar.h"
+
+#include <stdint.h>
+
+wchar_t *wcscpy(wchar_t *dst, const wchar_t *src) {
+    return wcsncpy(dst, src, SIZE_MAX);
+}
+
+wchar_t *wcsncpy(wchar_t *dst, const wchar_t *src, size_t n) {
+    size_t i = 0;
+    do dst[i] = *src; while (*src++ != L'\0' && i++ < n);
+    return dst;
+}
+
+wchar_t *wcscat(wchar_t *s1, const wchar_t *s2) {
+    return wcsncat(s1, s2, SIZE_MAX);
+}
+
+wchar_t *wcsncat(wchar_t *s1, const wchar_t *s2, size_t n) {
+    wcsncpy(s1 + wcslen(s1), s2, n);
+    return s1;
+}
+
+size_t wcslen(const wchar_t *s1) {
+    size_t len = 0;
+    while(s1[len] != L'\0') { len++; }
+    return len;
+}
+
+int wcscmp(const wchar_t *s1, const wchar_t *s2) {
+    return wcsncmp(s1, s2, SIZE_MAX);
+}
+
+int wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n) {
+    for (size_t pos = 0; pos < n; pos++) {
+        wchar_t c1 = *s1++;
+        wchar_t c2 = *s2++;
+        if (c1 < c2) return -1;
+        if (c1 > c2) return 1;
+        if (c1 == 0 || c2 == 0) break;
+    }
+    return 0;
+}

--- a/lib/xboxrt/wchar.h
+++ b/lib/xboxrt/wchar.h
@@ -1,0 +1,14 @@
+#ifndef XBOXRT_WCHAR
+#define XBOXRT_WCHAR
+
+#include <stddef.h>
+
+wchar_t *wcscat(wchar_t *s1, const wchar_t *s2);
+wchar_t *wcscpy(wchar_t *dst, const wchar_t *src);
+wchar_t *wcsncat(wchar_t *s1, const wchar_t *s2, size_t n);
+wchar_t *wcsncpy(wchar_t *dst, const wchar_t *src, size_t n);
+size_t wcslen(const wchar_t *s1);
+int wcscmp(const wchar_t *s1, const wchar_t *s2);
+int wcsncmp(const wchar_t *s1, const wchar_t *s2, size_t n);
+
+#endif


### PR DESCRIPTION
Add a subset of wchar.h functions that I need for the xbox kernel test suite. Most functions were copied from string.h/string.c and modified to work with wchar_t.