### PR TITLE
git: Ignore more build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,11 @@
 *.xbe
 *.inl
 *.d
+*.i
+*.bc
+*.pdb
 _*.cpp
 _*.h
+samples/**/*.iso
+samples/**/*.lib
 !tools/cg/win/cgc.exe


### PR DESCRIPTION
This adds a few more patterns to .gitignore to reduce clutter when using `git status` or `git diff` (and to avoid adding them to the repository accidentally). .i, .bc and .pdb can be generated when instructing clang to save intermediate results, while .lib and .iso files in the samples-subdirectory are generated during a normal build but still shouldn't end up in the repository.