### PR TITLE
CI: Add Travis CI support for Linux and macOS

### DIFF
--- a/.ci_build_samples.sh
+++ b/.ci_build_samples.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+cd samples
+for dir in */
+do
+    cd "$dir"
+    make
+    cd ..
+done

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+os:
+    - linux
+    - osx
+
+dist: xenial
+
+sudo: required
+
+before_install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+
+install:
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq flex bison clang lld-6.0; fi
+
+language: c
+
+script:
+    - sh ./.ci_build_samples.sh


### PR DESCRIPTION
Basically the same as #72, but with Travis instead of Appveyor and additional macOS support and without storing artifacts. macOS builds are rather slow compared to Linux builds (~8m vs ~1m) due to homebrew. It seems caching can be used to improve that, but messing with homebrew in that way is complicated and error-prone, so I didn't bother.

Travis doesn't seem to support msys ootb, therefore I didn't try adding Windows support.

Also addresses #36.