### PR TITLE
Properly set XBE stack size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ ifeq ($(OUTPUT_DIR),)
 OUTPUT_DIR = bin
 endif
 
+ifeq ($(NXDK_STACKSIZE),)
+NXDK_STACKSIZE = 65536
+endif
+
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 LD           = lld -flavor link
@@ -102,7 +106,7 @@ endif
 
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
-	$(VE) $(LD) $(LDFLAGS) -subsystem:windows -dll -out:'$@' -entry:XboxCRT $^
+	$(VE) $(LD) $(LDFLAGS) -subsystem:windows -dll -out:'$@' -entry:XboxCRT -stack:$(NXDK_STACKSIZE) $^
 
 %.obj: %.c
 	@echo "[ CC       ] $@"

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -376,7 +376,8 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail)
 
         // various PE copies
         {
-            m_Header.dwPeStackCommit = 0x00010000; //x_Exe->m_OptionalHeader.m_sizeof_stack_commit;
+            // StackCommit actually means StackReserve
+            m_Header.dwPeStackCommit = x_Exe->m_OptionalHeader.m_sizeof_stack_reserve;
             m_Header.dwPeHeapReserve = x_Exe->m_OptionalHeader.m_sizeof_heap_reserve;
             m_Header.dwPeHeapCommit  = x_Exe->m_OptionalHeader.m_sizeof_heap_commit;
             m_Header.dwPeSizeofImage = x_Exe->m_OptionalHeader.m_sizeof_image;


### PR DESCRIPTION
Currently, cxbe always sets dwPeStackCommit to 64KiB (which is the default value of Microsoft's XDK), while our intermediate PE files have m_sizeof_stack_commit set to 4KiB and m_sizeof_stack_reserve to 1MiB. This didn't cause us any problems yet afaik, but this commit fixes it anyway.

I already briefly talked about this on Discord last October:

> I think I figured it out
> PE has SizeOfStackCommit and SizeOfStackReserve. SizeOfStackReserve is the maximum stack size, while SizeOfStackCommit is the initial stack size, meaning only SizeOfStackCommit bytes get reserved in the beginning, and the rest is only mapped when required, at least on Windows.
> But the Xbox doesn't allow growing the stack dynamically, so it only has SizeOfStackCommit. So for the Xbox, it's XBE.SizeOfStackCommit = PE.SizeOfStackReserve
> The comment implies they tried to do XBE.SizeOfStackCommit = PE.SizeOfStackCommit, which would lead to an incorrectly small stack and cause problems
> So their solution was to just bump up the stack size to 64KiB to get rid of the problems
> Btw the XBE documentation by caustik makes the same mistake

I verified that the stack size now properly carries over to the XBE and ran the samples on my Xbox to make sure nothing broke.