### PR TITLE
Add (rudimentary!) C++ support

### DIFF
--- a/lib/hal/audio.h
+++ b/lib/hal/audio.h
@@ -1,6 +1,11 @@
 #ifndef HAL_AUDIO_H
 #define HAL_AUDIO_H
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 // This is the signature for the function that the audio
 // subsystem will call back to when it has run out of data
 typedef void (*XAudioCallback)(void *pac97Device, void *data);
@@ -33,5 +38,9 @@ void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, 
 void XAudioPlay();
 void XAudioPause();
 void XAudioProvideSamples(unsigned char *buffer, unsigned short bufferLength, int isFinal);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/hal/fileio.h
+++ b/lib/hal/fileio.h
@@ -4,6 +4,11 @@
 #include "xboxkrnl/xboxkrnl.h"
 #include "winerror.h"
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 #define	INVALID_HANDLE_VALUE                    -1
 
 // sharedMode
@@ -127,5 +132,9 @@ int XFindNextFile(
 
 int XFindClose(
 	unsigned int handle);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/hal/input.h
+++ b/lib/hal/input.h
@@ -5,6 +5,11 @@
 #include "mouse.h"
 #include "keyboard.h"
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 /* General input functions */
 void XInput_Init(void);
 void XInput_Init_Polling(void);
@@ -19,5 +24,9 @@ int XInputGetKeystroke(XKEYBOARD_STROKE *pStroke);
 
 /* Mouse specific functions */
 XMOUSE_INPUT XInputGetMouseData(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/hal/io.h
+++ b/lib/hal/io.h
@@ -1,11 +1,20 @@
 #ifndef HAL_IO_H
 #define HAL_IO_H
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 void IoOutputByte(unsigned short address, unsigned char value);
 void IoOutputWord(unsigned short address, unsigned short value);
 void IoOutputDword(unsigned short address, unsigned int value);
 unsigned char IoInputByte(unsigned short address);
 unsigned short IoInputWord(unsigned short address);
 unsigned int IoInputDword(unsigned short address);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/hal/mouse.h
+++ b/lib/hal/mouse.h
@@ -1,6 +1,11 @@
 #ifndef HAL_MOUSE_H
 #define HAL_MOUSE_H
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 struct xmouse_data
 {
 	unsigned char	buttons;
@@ -25,5 +30,9 @@ typedef struct _XMOUSE_INPUT
 } XMOUSE_INPUT;
 
 extern XMOUSE_INPUT g_Mouse;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/hal/pad.h
+++ b/lib/hal/pad.h
@@ -1,6 +1,11 @@
 #ifndef HAL_PAD_H
 #define HAL_PAD_H
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 struct xpad_data
 {
 	unsigned char hPresent;
@@ -58,5 +63,9 @@ typedef struct _XPAD_INPUT
 
 extern XPAD_INPUT g_Pads[4];
 extern XPAD_INPUT g_DefaultPad;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -3,6 +3,11 @@
 
 #include <xboxkrnl/xboxkrnl.h>
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 // Defines for frame buffer
 #define VIDEO_BASE				0xFD000000
 #define VIDEO_FRAMEBUFFER			0x03c00000
@@ -59,5 +64,9 @@ void XVideoWaitForVBlank();
 void XVideoSetDisplayStart(unsigned int offset);
 unsigned char* XVideoGetVideoBase();
 int XVideoVideoMemorySize();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/hal/xbox.h
+++ b/lib/hal/xbox.h
@@ -1,6 +1,12 @@
 #ifndef HAL_XBOX_H
 #define HAL_XBOX_H
 
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 void XReboot();
 int  XGetTickCount();
 void XSleep(int milliseconds);
@@ -10,5 +16,10 @@ void XLaunchXBE(char *xbePath);
 // the thread callback function
 typedef void (*XThreadCallback)(void *args1, void *args2);
 int XCreateThread(XThreadCallback callback, void *args1, void *args2);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -15,6 +15,11 @@
 #ifndef _PBKIT_H_
 #define _PBKIT_H_
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
 #include <xboxkrnl/xboxkrnl.h>
 
 #include "outer.h"
@@ -106,5 +111,10 @@ void    pb_fill(int x,int y,int w,int h, DWORD color);  //rectangle fill
 void    pb_set_viewport(int dwx,int dwy,int width,int height,float zmin,float zmax);
 
 int pb_busy(void);
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -895,12 +895,12 @@ typedef struct _KQUEUE
     LIST_ENTRY ThreadListHead;
 } KQUEUE, *PKQUEUE, *RESTRICTED_POINTER PRKQUEUE;
 
-struct KTHREAD;
+struct _KTHREAD;
 
 typedef struct _KWAIT_BLOCK
 {
     LIST_ENTRY WaitListEntry;
-    struct KTHREAD *Thread;
+    struct _KTHREAD *Thread;
     PVOID Object;
     struct _KWAIT_BLOCK *NextWaitBlock;
     SHORT WaitKey;
@@ -912,7 +912,7 @@ typedef struct _KAPC
     SHORT Type;
     CHAR ApcMode;
     UCHAR Inserted;
-    struct KTHREAD *Thread;
+    struct _KTHREAD *Thread;
     LIST_ENTRY ApcListEntry;
     PVOID KernelRoutine;
     PVOID RundownRoutine;

--- a/lib/xboxrt/debug.h
+++ b/lib/xboxrt/debug.h
@@ -5,6 +5,10 @@
 #ifndef XBOXRT_DEBUG
 #define XBOXRT_DEBUG
 
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
 
 #define WHITE   0x00FFFFFF
 #define BLACK   0x00000000
@@ -25,5 +29,10 @@ void debugPrintBinary( int num );
 void debugPrintHex(const char *buffer, int length);
 void debugClearScreen( void );
 void advanceScreen( void );
+
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/xboxrt/stat.h
+++ b/lib/xboxrt/stat.h
@@ -1,6 +1,10 @@
 #ifndef XBOXRT_STAT
 #define XBOXRT_STAT
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #if 0
 int fstat(int fd, struct stat *st);
 int stat(const char *filename, struct stat *st);
@@ -8,5 +12,9 @@ int stat(const char *filename, struct stat *st);
 
 #include <stdint.h>
 typedef uint32_t mode_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/lib/xboxrt/strings.h
+++ b/lib/xboxrt/strings.h
@@ -4,6 +4,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int ffs(int);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This adds basic C++ support by adding rules to the Makefile, adding `extern "C"` where necessary to get the name mangling right and renaming struct fields in the xboxkrnl-header.

Global constructors are already handled by my PDCLib-additions, so when this PR is combined with https://github.com/XboxDev/nxdk-pdclib/pull/2, simple code like [this](https://gist.github.com/thrimbor/62a550b36cb5ab65a7b6ceacc4fbd084) already works.

Note that CI on macOS currently fails due to the problem described in https://github.com/XboxDev/nxdk-pdclib/pull/1, this affects Arch Linux now, too. It works on the Ubuntu CI, though.