### PR TITLE
docs: Update OpenXDK link on readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 nxdk - *the new open source xdk*
 ================================
-nxdk is a software development kit for the original Xbox. nxdk is a revitalization of [OpenXDK](http://openxdk.maturion.de/).
+nxdk is a software development kit for the original Xbox. nxdk is a revitalization of [OpenXDK](https://web.archive.org/web/20170624051336/http://openxdk.sourceforge.net:80/).
 
 Notable features:
 - No complicated cross-compiling or big library dependencies! Builds with `make` and just needs standard tools and llvm.
@@ -95,7 +95,7 @@ correct place. Then, in the directory, you can simply run `make`.
 
 Credits
 -------
-- [OpenXDK](http://openxdk.maturion.de/) is the inspiration for nxdk, and large parts of it have been reused. (License: GPLv2)
+- [OpenXDK](https://web.archive.org/web/20170624051336/http://openxdk.sourceforge.net:80/) is the inspiration for nxdk, and large parts of it have been reused. (License: GPLv2)
 - Large parts of [pbkit](http://forums.xbox-scene.com/index.php?/topic/573524-pbkit), by openxdkman, are included, with modifications. (License: LGPL)
 - A very barebones libc is included based on [lib43](https://github.com/lunixbochs/lib43) (License: MIT)
 - vp20compiler is based on nvvertparse.c from [Mesa](http://www.mesa3d.org/) (License: MIT)


### PR DESCRIPTION
Unfortunately OpenXDKs sourceforge page has been hacked (for some time), this will instead provide a link to a archive.org snapshot.

This has already been updated on https://xboxdevwiki.net/.