### PR TITLE
hal: Allow xbox paths in XConvertDOSFilenameToXBOX

### DIFF
--- a/lib/hal/fileio.c
+++ b/lib/hal/fileio.c
@@ -89,6 +89,12 @@ static char *getCurrentDirString()
  */
 int XConvertDOSFilenameToXBOX(const char *dosFilename, char *xboxFilename)
 {
+	// Allow Xbox filenames directly
+	if (!memcmp(dosFilename, "\\Device\\", 8)) {
+		strcpy(xboxFilename, dosFilename);
+		return STATUS_SUCCESS;
+	}
+
 	// path contains the qualified pathname from the root
 	// directory without the leading slash.  eg. "foo\bar.txt"
 	const char *path;

--- a/lib/hal/fileio.c
+++ b/lib/hal/fileio.c
@@ -75,7 +75,9 @@ static char *getCurrentDirString()
 
 /**
  * Converts a DOS-style path (eg. "c:/foo/bar.txt") to a XBOX-style
- * path (eg. "\Device\Harddisk0\Partition2\foo\bar.txt")
+ * path (eg. "\Device\Harddisk0\Partition2\foo\bar.txt").
+ * Returns early if the path is alread in XBOX-style - will use the
+ * input path as-is.
  *
  * We handle the following scenarios (back/forward slashes are handled
  * in all cases):


### PR DESCRIPTION
This helper function is useful but when not needed it gets in the way.
By checking if the input filename already is in Xbox format, we might return early with a STATUS_SUCCESS.

This code was originally written by @JayFoxRox for JayFoxRox/nxdk#7