### PR TITLE
pktdrv: PktdrvInterrupt and MmioBase as extern instead of macros

### DIFF
--- a/lib/net/pktdrv/pktdrv.c
+++ b/lib/net/pktdrv/pktdrv.c
@@ -345,9 +345,9 @@ enum {
 
 
 //Register access macros for XBOX
-#define REG(x)	(*((DWORD *)((ULONG_PTR)PktdrvMmioBase+(x))))
-#define REGW(x)	(*((WORD *)((ULONG_PTR)PktdrvMmioBase+(x))))
-#define REGB(x)	(*((BYTE *)((ULONG_PTR)PktdrvMmioBase+(x))))
+#define REG(x)	(*((DWORD volatile *)((ULONG_PTR)PktdrvMmioBase+(x))))
+#define REGW(x)	(*((WORD volatile *)((ULONG_PTR)PktdrvMmioBase+(x))))
+#define REGB(x)	(*((BYTE volatile *)((ULONG_PTR)PktdrvMmioBase+(x))))
 
 
 

--- a/lib/net/pktdrv/pktdrv.c
+++ b/lib/net/pktdrv/pktdrv.c
@@ -42,6 +42,9 @@
 extern unsigned long times(void *);
 
 //temporary dirty interface
+void* PktdrvMmioBase = (void*)0xFEF00000;
+unsigned int PktdrvInterrupt = 4;
+
 extern int something_to_send;
 extern unsigned char *packet_to_send;
 extern unsigned int size_of_packet_to_send;
@@ -342,10 +345,9 @@ enum {
 
 
 //Register access macros for XBOX
-#define	BASE	0xFEF00000
-#define REG(x)	(*((DWORD *)(BASE+(x))))
-#define REGW(x)	(*((WORD *)(BASE+(x))))
-#define REGB(x)	(*((BYTE *)(BASE+(x))))
+#define REG(x)	(*((DWORD *)((ULONG_PTR)PktdrvMmioBase+(x))))
+#define REGW(x)	(*((WORD *)((ULONG_PTR)PktdrvMmioBase+(x))))
+#define REGB(x)	(*((BYTE *)((ULONG_PTR)PktdrvMmioBase+(x))))
 
 
 
@@ -742,7 +744,7 @@ int Pktdrv_Init(void)
 	}
 	
 
-	g_s->Vector=HalGetInterruptVector(4,&g_s->IrqLevel); 
+	g_s->Vector=HalGetInterruptVector(PktdrvInterrupt,&g_s->IrqLevel);
 	
 	KeInitializeDpc(&g_s->MyPktdrvDpcObject,&MyPktdrvDpc,&g_s->MyContext); 
 

--- a/lib/net/pktdrv/pktdrv.h
+++ b/lib/net/pktdrv/pktdrv.h
@@ -1,6 +1,9 @@
 #ifndef _Pktdrv_
 #define _Pktdrv_
 
+extern void* PktdrvMmioBase;
+extern unsigned int PktdrvInterrupt;
+
 int Pktdrv_Init(void);
 void Pktdrv_Quit(void);
 int Pktdrv_ReceivePackets(void);


### PR DESCRIPTION
Get rid of a magic number and give these values proper types instead of just defining them in macros.

Code originally written by @JayFoxRox for JayFoxRox/nxdk#7.