### PR TITLE
WinAPI error and memory functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt \
                -isystem $(NXDK_DIR)/lib/pdclib/include \
                -I$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
+               -I$(NXDK_DIR)/lib/winapi \
                -Wno-ignored-attributes -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -27,5 +27,6 @@ SRCS += \
 	$(wildcard $(NXDK_DIR)/lib/xlibc-rt/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/xlibc-rt/*.s) \
 	$(wildcard $(NXDK_DIR)/lib/hal/*.c) \
+	$(wildcard $(NXDK_DIR)/lib/winapi/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/pbkit/*.c) \
 	$(USB_SRCS)

--- a/lib/winapi/error.c
+++ b/lib/winapi/error.c
@@ -1,0 +1,14 @@
+#include <winbase.h>
+#include <threads.h>
+
+static thread_local DWORD lastError = 0;
+
+DWORD GetLastError (void)
+{
+    return lastError;
+}
+
+void SetLastError (DWORD error)
+{
+    lastError = error;
+}

--- a/lib/winapi/memory.c
+++ b/lib/winapi/memory.c
@@ -1,0 +1,49 @@
+#include <memoryapi.h>
+#include <winbase.h>
+#include <hal/winerror.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+LPVOID VirtualAlloc (LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect)
+{
+    NTSTATUS status;
+
+    status = NtAllocateVirtualMemory(&lpAddress, 0, &dwSize, flAllocationType, flProtect);
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return NULL;
+    }
+
+    return lpAddress;
+}
+
+BOOL VirtualFree (LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType)
+{
+    NTSTATUS status;
+
+    if ((dwFreeType & MEM_RELEASE) && dwSize != 0) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    status = NtFreeVirtualMemory(&lpAddress, &dwSize, dwFreeType);
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+SIZE_T VirtualQuery (LPCVOID lpAddress, PMEMORY_BASIC_INFORMATION lpBuffer, SIZE_T dwLength)
+{
+    NTSTATUS status;
+
+    status = NtQueryVirtualMemory((LPVOID)lpAddress, lpBuffer);
+
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return 0;
+    }
+
+    return sizeof(MEMORY_BASIC_INFORMATION);
+}

--- a/lib/winapi/memoryapi.h
+++ b/lib/winapi/memoryapi.h
@@ -1,0 +1,19 @@
+#ifndef __MEMORYAPI_H__
+#define __MEMORYAPI_H__
+
+#include <windef.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+LPVOID VirtualAlloc (LPVOID lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect);
+BOOL VirtualFree (LPVOID lpAddress, SIZE_T dwSize, DWORD dwFreeType);
+SIZE_T VirtualQuery (LPCVOID lpAddress, PMEMORY_BASIC_INFORMATION lpBuffer, SIZE_T dwLength);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/winapi/winbase.h
+++ b/lib/winapi/winbase.h
@@ -1,0 +1,18 @@
+#ifndef __WINBASE_H__
+#define __WINBASE_H__
+
+#include <windef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+DWORD GetLastError (void);
+void SetLastError (DWORD error);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/winapi/windef.h
+++ b/lib/winapi/windef.h
@@ -1,0 +1,6 @@
+#ifndef __WINDEF_H__
+#define __WINDEF_H__
+
+#include <xboxkrnl/xboxdef.h>
+
+#endif

--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -1,0 +1,29 @@
+#ifndef __XBOXDEF_H__
+#define __XBOXDEF_H__
+
+typedef const void *LPCVOID;
+typedef void VOID, *PVOID, *LPVOID;
+typedef PVOID HANDLE, *PHANDLE;
+
+typedef unsigned char BOOLEAN, *PBOOLEAN;
+
+typedef signed char SCHAR, *PSCHAR;
+
+typedef char CHAR, *PCHAR, CCHAR, *LPCH, *PCH, OCHAR, *POCHAR;
+typedef short SHORT, *PSHORT;
+typedef long LONG, *PLONG;
+typedef long long LONGLONG, *PLONGLONG;
+
+typedef unsigned char UCHAR, *PUCHAR;
+typedef unsigned short USHORT, *PUSHORT, CSHORT;
+typedef unsigned short WORD, WCHAR, *PWSTR;
+typedef unsigned int DWORD, *PDWORD, *LPDWORD;
+typedef unsigned long ULONG, *PULONG;
+typedef unsigned long long ULONGLONG;
+
+typedef unsigned int SIZE_T, *PSIZE_T;
+
+typedef int BOOL, *PBOOL;
+typedef const char *PCSZ, *PCSTR, *LPCSTR;
+
+#endif

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <xboxkrnl/xboxdef.h>
+
 /* stop clang from crying */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wlanguage-extension-token"
@@ -33,15 +35,6 @@ extern "C"
 
 #define CONST const
 
-typedef unsigned int SIZE_T, *PSIZE_T;
-typedef unsigned char BOOLEAN, *PBOOLEAN;
-typedef int BOOL, *PBOOL;
-typedef void VOID, *PVOID, *LPVOID;
-typedef unsigned char UCHAR, *PUCHAR;
-typedef unsigned short USHORT, *PUSHORT, CSHORT;
-typedef unsigned long ULONG, *PULONG;
-typedef unsigned long long ULONGLONG;
-
 #ifndef NULL
     #define NULL ((PVOID)0)
 #endif
@@ -51,13 +44,6 @@ typedef unsigned long long ULONGLONG;
 #ifndef FALSE
     #define FALSE 0
 #endif
-
-typedef char CHAR, *PCHAR, CCHAR, *LPCH, *PCH, OCHAR, *POCHAR;
-typedef short SHORT, *PSHORT;
-typedef long LONG, *PLONG;
-typedef long long LONGLONG, *PLONGLONG;
-
-typedef signed char SCHAR, *PSCHAR;
 
 typedef LONG NTSTATUS;
 #define NT_SUCCESS(Status) ((NTSTATUS)(Status) >= 0)


### PR DESCRIPTION
This adds some simple parts of the WinAPI, namely error handling and virtual memory handling.

This originally was part of my work on the file finding API (mentioned in Discord), but I decided to split it out as I required it for my current work on integrating dlmalloc (which recently got added to PDCLib to replace the old primitive malloc) - since dlmalloc already supports Win32, this makes it much easier to build for nxdk.

The code has received testing as part of my work on my other branches.