### PR TITLE
Sdl: update submodule

### DIFF
--- a/samples/sdl_ttf/main.c
+++ b/samples/sdl_ttf/main.c
@@ -9,10 +9,6 @@
 const extern int SCREEN_WIDTH;
 const extern int SCREEN_HEIGHT;
 
-// SDL requires this symbol to exist
-void _exit() {
-}
-
 void main() {
   int initialized_pbkit = -1;
   int initialized_SDL   = -1;


### PR DESCRIPTION
Updated the SDL2 submodule.
The sdl_ttf sample received an update too in order to reflect these changes.
The main SDL sample did not change however as its `_exit` differs in functionality from the PDClib one.