### PR TITLE
Make improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ $(EXTRACT_XISO):
 clean:
 	$(VE)rm -f $(TARGET) \
 	           main.exe main.exe.manifest main.lib \
-	           $(OBJS) $(SHADER_OBJS) \
+	           $(OBJS) $(SHADER_OBJS) $(DEPS) \
 	           $(GEN_XISO)
 
 .PHONY: distclean 
@@ -176,6 +176,5 @@ distclean: clean
 	$(VE)$(MAKE) -C $(NXDK_DIR)/tools/vp20compiler distclean $(QUIET)
 	$(VE)$(MAKE) -C $(NXDK_DIR)/tools/cxbe clean $(QUIET)
 	$(VE)bash -c "if [ -d $(OUTPUT_DIR) ]; then rmdir $(OUTPUT_DIR); fi"
-	$(VE)rm -f $(DEPS)
 
 -include $(DEPS)

--- a/Makefile
+++ b/Makefile
@@ -109,33 +109,23 @@ $(GEN_XISO): $(OUTPUT_DIR)/default.xbe $(EXTRACT_XISO)
 	$(VE) $(EXTRACT_XISO) -c $(OUTPUT_DIR) $(XISO_FLAGS) $@ $(QUIET)
 endif
 
+$(SRCS): $(SHADER_OBJS)
+
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
 	$(VE) $(LD) $(LDFLAGS) -subsystem:windows -dll -out:'$@' -entry:XboxCRTEntry -stack:$(NXDK_STACKSIZE) $^
 
 %.obj: %.cpp
 	@echo "[ CXX      ] $@"
-	$(VE) $(CXX) $(NXDK_CXXFLAGS) -c -o '$@' '$<'
+	$(VE) $(CXX) $(NXDK_CXXFLAGS) -MD -MT '$@' -MF '$(patsubst %.cpp,%.cpp.d,$<)' -c -o '$@' '$<'
 
 %.obj: %.c
 	@echo "[ CC       ] $@"
-	$(VE) $(CC) $(NXDK_CFLAGS) -c -o '$@' '$<'
+	$(VE) $(CC) $(NXDK_CFLAGS) -MD -MT '$@' -MF '$(patsubst %.c,%.c.d,$<)' -c -o '$@' '$<'
 
 %.obj: %.s
 	@echo "[ AS       ] $@"
 	$(VE) $(AS) $(NXDK_ASFLAGS) -c -o '$@' '$<'
-
-%.c.d: %.c
-	@echo "[ DEP      ] $@"
-	$(VE) set -e; rm -f $@; \
-	$(CC) -M -MM -MG -MT '$*.obj' -MF $@ $(NXDK_CFLAGS) $<; \
-	echo "\n$@ : $^\n" >> $@
-
-%.cpp.d: %.cpp
-	@echo "[ DEP      ] $@"
-	$(VE) set -e; rm -f $@; \
-	$(CXX) -M -MM -MG -MT '$*.obj' -MF $@ $(NXDK_CXXFLAGS) $<; \
-	echo "\n$@ : $^\n" >> $@
 
 %.inl: %.vs.cg $(VP20COMPILER)
 	@echo "[ CG       ] $@"

--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ $(EXTRACT_XISO):
 .PHONY: clean 
 clean:
 	$(VE)rm -f $(TARGET) \
-	           main.exe main.exe.manifest \
+	           main.exe main.exe.manifest main.lib \
 	           $(OBJS) $(SHADER_OBJS) \
 	           $(GEN_XISO)
 

--- a/tools/fp20compiler/Makefile
+++ b/tools/fp20compiler/Makefile
@@ -2,9 +2,9 @@ MAIN = fp20compiler
 CXXFLAGS= -DYY_NO_UNPUT -Wall -g
 
 INCLUDES = $(wildcard *.h) \
-	_ps1.0_parser.h \
-	_rc1.0_parser.h \
-	_ts1.0_parser.h
+	_ps1.0_parser.hpp \
+	_rc1.0_parser.hpp \
+	_ts1.0_parser.hpp
 
 SRCS = main.cpp \
 	nvparse_errors.cpp \
@@ -29,17 +29,14 @@ $(MAIN): $(OBJS)
 %.o: %.cpp ${INCLUDES}
 	$(CXX) $(CXXFLAGS) -c -o '$@' '$<'
 
-_ps1.0_parser.cpp _ps1.0_parser.h: ps1.0_grammar.y
-	bison -d -o _ps1.0_parser.c -p ps10_ ps1.0_grammar.y
-	mv -f _ps1.0_parser.c _ps1.0_parser.cpp
+_ps1.0_parser.cpp _ps1.0_parser.hpp: ps1.0_grammar.y
+	bison -d -o _ps1.0_parser.cpp -p ps10_ ps1.0_grammar.y
 
-_rc1.0_parser.cpp _rc1.0_parser.h: rc1.0_grammar.y
-	bison -d -o _rc1.0_parser.c -p rc10_ rc1.0_grammar.y
-	mv -f _rc1.0_parser.c _rc1.0_parser.cpp
+_rc1.0_parser.cpp _rc1.0_parser.hpp: rc1.0_grammar.y
+	bison -d -o _rc1.0_parser.cpp -p rc10_ rc1.0_grammar.y
 
-_ts1.0_parser.cpp _ts1.0_parser.h: ts1.0_grammar.y
-	bison -d -o _ts1.0_parser.c -p ts10_ ts1.0_grammar.y
-	mv -f _ts1.0_parser.c _ts1.0_parser.cpp
+_ts1.0_parser.cpp _ts1.0_parser.hpp: ts1.0_grammar.y
+	bison -d -o _ts1.0_parser.cpp -p ts10_ ts1.0_grammar.y
 
 _ps1.0_lexer.cpp: ps1.0_tokens.l
 	flex -Pps10_ -o_ps1.0_lexer.cpp ps1.0_tokens.l
@@ -52,9 +49,9 @@ _ts1.0_lexer.cpp: ts1.0_tokens.l
 
 .PHONY: clean
 clean:
-	rm -f _ps1.0_parser.cpp _ps1.0_parser.h _ps1.0_lexer.cpp
-	rm -f _rc1.0_parser.cpp _rc1.0_parser.h _rc1.0_lexer.cpp
-	rm -f _ts1.0_parser.cpp _ts1.0_parser.h _ts1.0_lexer.cpp
+	rm -f _ps1.0_parser.cpp _ps1.0_parser.hpp _ps1.0_lexer.cpp
+	rm -f _rc1.0_parser.cpp _rc1.0_parser.hpp _rc1.0_lexer.cpp
+	rm -f _ts1.0_parser.cpp _ts1.0_parser.hpp _ts1.0_lexer.cpp
 	rm -f $(OBJS)
 
 .PHONY: distclean

--- a/tools/fp20compiler/ps1.0_tokens.l
+++ b/tools/fp20compiler/ps1.0_tokens.l
@@ -14,7 +14,7 @@ alphanum [0-9a-zA-Z_]
 using namespace std;
 using namespace ps10;
 
-#include "_ps1.0_parser.h"
+#include "_ps1.0_parser.hpp"
 
 #include "nvparse_errors.h"
 #include "nvparse_externs.h"

--- a/tools/fp20compiler/rc1.0_tokens.l
+++ b/tools/fp20compiler/rc1.0_tokens.l
@@ -7,7 +7,7 @@ alphanum [0-9a-zA-Z_]
 
 #include <stdlib.h>
 #include "rc1.0_combiners.h"
-#include "_rc1.0_parser.h"
+#include "_rc1.0_parser.hpp"
 
 #include "nvparse_errors.h"
 #include "nvparse_externs.h"

--- a/tools/fp20compiler/ts1.0_tokens.l
+++ b/tools/fp20compiler/ts1.0_tokens.l
@@ -6,7 +6,7 @@ alphanum [0-9a-zA-Z_]
 #include <stdlib.h>
 #include "ts1.0_inst.h"
 #include "ts1.0_inst_list.h"
-#include "_ts1.0_parser.h"
+#include "_ts1.0_parser.hpp"
 #ifdef _WIN32
 # include <windows.h>
 #endif


### PR DESCRIPTION
This fixes #96 (although removing the `.iso` should work already) as well as some other issues such as broken parallel make. It also combines the rules for dependency file generation and compilation to avoid running the compiler twice - this also resolves the issue of `make distclean` generating dependency files only to immediately remove them again.