### PR TITLE
xpad: Match interface instead of VID/PID

### DIFF
--- a/lib/usb/sys/xpad.c
+++ b/lib/usb/sys/xpad.c
@@ -13,6 +13,8 @@
 #include "../usb_wrapper.h"
 #include "usb/include/config.h"
 
+#include <xboxkrnl/xboxkrnl.h>
+
 // history for the Rising - falling events
 unsigned char xpad_button_history[7];
 
@@ -72,8 +74,8 @@ static void xpad_irq(struct urb *urb, struct pt_regs *regs)
 
 static int GetPadNum(const char* szDevPath)
 {
-	int pos			= strlen(szDevPath) - 3;
-	int portchar	= szDevPath[pos];
+	int pos = (XboxHardwareInfo.Flags & XBOX_HW_FLAG_INTERNAL_USB_HUB) ? 2 : 0;
+	int portchar = szDevPath[pos];
 
 	switch(portchar)
 	{

--- a/lib/usb/sys/xpad.c
+++ b/lib/usb/sys/xpad.c
@@ -156,37 +156,7 @@ static void xpad_disconnect(struct usb_interface *intf)
 }
 /*------------------------------------------------------------------------*/ 
 static struct usb_device_id xpad_ids [] = {
-	{ USB_DEVICE(0x044f, 0x0f07) },//Thrustmaster, Inc. Controller
-	{ USB_DEVICE(0x045e, 0x0202) },//Microsoft Xbox Controller
-	{ USB_DEVICE(0x045e, 0x0285) },//Microsoft Xbox Controller S
-	{ USB_DEVICE(0x045e, 0x0287) },//Microsoft Xbox Controller S
-	{ USB_DEVICE(0x045e, 0x0289) },//Microsoft Xbox Controller S
-	{ USB_DEVICE(0x046d, 0xca84) },//Logitech Cordless Controller for Xbox
-	{ USB_DEVICE(0x046d, 0xca88) },//Logitech Compact Controller for Xbox
-	{ USB_DEVICE(0x05fd, 0x1007) },//???Mad Catz Controller???
-	{ USB_DEVICE(0x05fd, 0x107a) },//InterAct PowerPad Pro
-	{ USB_DEVICE(0x0738, 0x4516) },//Mad Catz Control Pad
-	{ USB_DEVICE(0x0738, 0x4522) },//Mad Catz LumiCON
-	{ USB_DEVICE(0x0738, 0x4526) },//Mad Catz Control Pad Pro
-	{ USB_DEVICE(0x0738, 0x4536) },//Mad Catz MicroCON
-	{ USB_DEVICE(0x0738, 0x4540) },//Mad Catz Beat Pad
-	{ USB_DEVICE(0x0738, 0x4556) },//Mad Catz Lynx Wireless Controller
-	{ USB_DEVICE(0x0c12, 0x8802) },//Zeroplus Xbox Controller
-	{ USB_DEVICE(0x0c12, 0x8809) },//Level Six Xbox DDR Dancepad
-	{ USB_DEVICE(0x0c12, 0x8810) },//Zeroplus Xbox Controller
-	{ USB_DEVICE(0x0c12, 0x9902) },//HAMA VibraX - *FAULTY HARDWARE*
-	{ USB_DEVICE(0x0e4c, 0x1097) },//Radica Gamester Controller
-	{ USB_DEVICE(0x0e4c, 0x2390) },//Radica Games Jtech Controller
-	{ USB_DEVICE(0x0e6f, 0x0003) },//Logic3 Freebird wireless Controller
-	{ USB_DEVICE(0x0e6f, 0x0005) },//Eclipse wireless Controlle
-	{ USB_DEVICE(0x0e6f, 0x0006) },//Edge wireless Controller
-	{ USB_DEVICE(0x0e8f, 0x0201) },//Smartjoy Frag PS2/Xpad adaptor
-	{ USB_DEVICE(0x0f30, 0x0202) },//Joytech Advanced Controller 
-	{ USB_DEVICE(0x0f30, 0x8888) },//BigBen XBMiniPad Controller
-	{ USB_DEVICE(0x102c, 0xff0c) },//Joytech Wireless Advanced Controller
-	{ USB_DEVICE(0x12ab, 0x8809) },//Xbox DDR dancepad 
-	{ USB_DEVICE(0xffff, 0xffff) },//Chinese-made Xbox Controller 
-	{ USB_DEVICE(0x0000, 0x0000) }, // nothing detected - FAIL
+	{ USB_INTERFACE_INFO(88, 66, 0) }, /* Xbox Controller Interfaces */
         { }                            /* Terminating entry */   
 };
 


### PR DESCRIPTION
As kindly explained by JFR, this change ought to enable most (if not all) Xbox compatible controllers instead of just the few identified earlier.