### PR TITLE
fp20compiler: Fix corrupted output on Windows

### DIFF
--- a/tools/fp20compiler/main.cpp
+++ b/tools/fp20compiler/main.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
         exit(1);
     }
 
-    FILE* fh = fopen(argv[1], "r");
+    FILE* fh = fopen(argv[1], "rb");
     if (!fh) {
         fprintf(stderr, "unable to open %s\n", argv[1]);
         exit(1);
@@ -75,13 +75,14 @@ int main(int argc, char** argv) {
     fseek(fh, 0L, SEEK_END);
     long size = ftell(fh);
     rewind(fh);
-    char* buffer = (char*)malloc(size);
+    char* buffer = (char*)malloc(size+1);
     if (buffer == NULL) {
         fprintf(stderr, "failed to allocate buffer\n");
         exit(1);
     }
 
     fread(buffer, size, 1, fh);
+    buffer[size] = '\0';
 
     translate(buffer);
 


### PR DESCRIPTION
Fix for corruption at the end of fp20compiler's output when running under Windows (as ranted about on Discord). The changes are:
1. Open input stream as binary to avoid line ending conversion issues.
2. Reserve an additional byte to make space for a null-terminator.
3. Add a null-terminator after reading the input.

Tested and working on msys2 on Windows 10.