### PR TITLE
build: Fix debug option on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ NXDK_CXXFLAGS = $(NXDK_CFLAGS)
 ifeq ($(DEBUG),y)
 NXDK_CFLAGS += -g
 NXDK_CXXFLAGS += -g
-LDFLAGS += /debug
+LDFLAGS += -debug
 endif
 
 NXDK_CFLAGS += $(CFLAGS)


### PR DESCRIPTION
This simply changes the debug parameter from `/debug` to `-debug` which makes it work on Windows.

Tested and working on msys2 on Windows 10.