### PR TITLE
usb: Don't consume events at startup

### DIFF
--- a/lib/usb/sys/BootUSB.c
+++ b/lib/usb/sys/BootUSB.c
@@ -60,11 +60,6 @@ void BootStartUSB(void)
 	XRemoteInit();	
 	UsbKeyBoardInit();
 	UsbMouseInit();
-
-	for(n=0;n<200;n++) {
-		USBGetEvents();
-		wait_ms(1);
-	}
 }
 /*------------------------------------------------------------------------*/ 
 void USBGetEvents(void)


### PR DESCRIPTION
`BootStartUSB` consumes important events during 200ms of the startup; these events are probably meant to register connected devices in the previously loaded drivers.

However, our code currently doesn't remember already-connected devices. So if a device driver is not registered as part of `BootStartUSB` it will never see events which announce the device (as they have been consumed already).
So the only way to get these events / support devices is to re-plug them to get another announcement.

Therefore, this PR removes the initial packet consumption, which means you must call `USBGetEvents` yourself (after `BootStartUSB`), to make sure that the devices are actually found. This already happens as part of the `XInput_Init` function anyway, so I assume no changes are necessary for most programs.

With this change, our USB stack works for custom drivers (which are not part of nxdk), and it also avoids a 200ms delay at startup.

*(There's something similar in `BootStopUSB`; it's not as problematic, but will probably be removed in the future)*

---

I have barely tested this, and I did not try it on Xbox 1.0.

It's possible that the intention behind the 200ms delay is a different one, such as removing garbage from the event queue during startup or similar. If that's the case, a different solution will be necessary. However, that's unlikely as it would probably cause issues with existing drivers.