### PR TITLE
vp20compiler: Forward comments from input to output

### DIFF
--- a/tools/vp20compiler/main.c
+++ b/tools/vp20compiler/main.c
@@ -296,6 +296,24 @@ void translate(const char* str)
 
 //     printf("num_instructions: %u\n", num_instructions);
 
+    const char* cur = str;
+    const char* end = &str[strlen(str) - 1];
+    while(cur < end) {
+
+        const char* lf = strchr(cur + 1, '\n');
+        const char* cr = strchr(cur + 1, '\r');
+        if (lf == NULL) { lf = end; }
+        if (cr == NULL) { cr = end; }
+        const char* line_end = (lf < cr ? lf : cr) + 1;
+
+        if (*cur == '#') {
+            printf("//%.*s\n", line_end - &cur[1] - 1, &cur[1]);
+        }
+
+        cur = line_end;
+
+    }
+
     uint32_t vsh_buf[136*4];
     memset(vsh_buf, 0, sizeof(vsh_buf));
 


### PR DESCRIPTION
The final vs.inl currently doesn't contain the VS variable / constant locations that the Cg vertex program uses. That's an issue as it's necessary to set up a working program.

This adds a small loop, which collects all comments, and forwards them from input to output.

Unfortunately, this is not position aware, so it won't interleave encoded instructions and comments. But it's still good enough to read back the `#var` and `#const` lines.

It isn't really secure, and it's probably easy to write malicious code which outputs garbage C code (like introducing `/*` as part of the comment).
Ideally we'd parse only those important lines and generate a `float c[][4];` and code which uploads it; however, this will have to do for now.

This was barely tested, but should work fine.

---

As an alternative for this PR, we could also remove the deletion step for the intermediate shader files.