### PR TITLE
build: Explicitly request embedded DWARF debug info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,8 +58,8 @@ NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
 NXDK_CXXFLAGS = $(NXDK_CFLAGS)
 
 ifeq ($(DEBUG),y)
-NXDK_CFLAGS += -g
-NXDK_CXXFLAGS += -g
+NXDK_CFLAGS += -g -gdwarf-4
+NXDK_CXXFLAGS += -g -gdwarf-4
 LDFLAGS += -debug
 endif
 


### PR DESCRIPTION
LLVM's default behavior seems to have changed, making it necessary to explicitly request DWARF debug info for source level debugging as described in the wiki.
Tested with clang 8.0.

/edit:
This specifies DWARF 4, which is the most recent working version - attempting to use DWARF 5 crashes clang 8.0.