### PR TITLE
samples: Add XVideoSetMode()

### DIFF
--- a/samples/hello++/main.cpp
+++ b/samples/hello++/main.cpp
@@ -1,5 +1,6 @@
 #include <xboxrt/debug.h>
 #include <pbkit/pbkit.h>
+#include <hal/video.h>
 #include <hal/xbox.h>
 
 class NumberClass{
@@ -12,6 +13,8 @@ public:
 };
 
 int main() {
+  XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
   int ret = pb_init();
   if (ret != 0) {
     XSleep(2000);

--- a/samples/hello/main.c
+++ b/samples/hello/main.c
@@ -1,11 +1,12 @@
 #include <xboxrt/debug.h>
 #include <pbkit/pbkit.h>
+#include <hal/video.h>
 #include <hal/xbox.h>
 #include "stdio.h"
 
 void main(void)
 {
-    int i;
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
     switch(pb_init())
     {

--- a/samples/httpd/main.c
+++ b/samples/httpd/main.c
@@ -8,6 +8,7 @@
 #include "netif/etharp.h"
 #include "pktdrv.h"
 #include <hal/input.h>
+#include <hal/video.h>
 #include <hal/xbox.h>
 #include <pbkit/pbkit.h>
 #include <xboxkrnl/xboxkrnl.h>
@@ -66,6 +67,8 @@ void main(void)
 	tcpip_init(tcpip_init_done, &init_complete);
 	sys_sem_wait(&init_complete);
 	sys_sem_free(&init_complete);
+
+	XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
 	pb_init();
 	pb_show_debug_screen();

--- a/samples/mesh/main.c
+++ b/samples/mesh/main.c
@@ -73,6 +73,8 @@ void main(void)
     int       fps, frames, frames_total;
     float     m_viewport[4][4];
 
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
     pb_extra_buffers(2);
     if ((status = pb_init())) {
         debugPrint("pb_init Error %d\n", status);

--- a/samples/sdl/main.c
+++ b/samples/sdl/main.c
@@ -365,6 +365,7 @@ void demo(void)
 
 void main(void)
 {
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
     if (pb_init() != 0)
     {
         XSleep(2000);

--- a/samples/sdl_ttf/main.c
+++ b/samples/sdl_ttf/main.c
@@ -17,6 +17,8 @@ void main() {
   SDL_Renderer *renderer = NULL;
   SDL_Texture  *texture  = NULL;
 
+  XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
   initialized_pbkit = pb_init();
   if (initialized_pbkit != 0) {
     debugPrint("pb_init() failed!");

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -52,6 +52,8 @@ void main(void)
     int       start, last, now;
     int       fps, frames, frames_total;
 
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
     if ((status = pb_init())) {
         debugPrint("pb_init Error %d\n", status);
         XSleep(2000);

--- a/samples/winapi_filefind/main.c
+++ b/samples/winapi_filefind/main.c
@@ -3,10 +3,12 @@
 #include <hal/winerror.h>
 #include <xboxrt/debug.h>
 #include <pbkit/pbkit.h>
+#include <hal/video.h>
 #include <hal/xbox.h>
 
 int main()
 {
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
     int ret = pb_init();
     if (ret != 0) {
         XSleep(2000);


### PR DESCRIPTION
This will be required when XboxDev/nxdk-pdclib#3 is merged and
`XVideoSetMode()` in `crt0.c` has been removed.

Not suitable for merge before then, do want to update the submodule in this same PR.