### PR TITLE
fp20compiler: Fix .a component selection

### DIFF
--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -234,7 +234,7 @@ void GeneralFunctionStruct::Validate(int stage, int portion)
 static void GenerateInput(int portion, char variable, MappedRegisterStruct reg) {
     const char* portion_s = portion == RCP_RGB ? "COLOR" : "ALPHA";
     printf("MASK(NV097_SET_COMBINER_%s_ICW_%c_SOURCE, 0x%x)", portion_s, variable, reg.reg.bits.name);
-    bool alpha_channel = ((portion == RCP_RGB && reg.reg.bits.channel == RCP_BLUE) || (portion == RCP_ALPHA));
+    bool alpha_channel = ((portion == RCP_RGB && reg.reg.bits.channel == RCP_BLUE) || (reg.reg.bits.channel == RCP_ALPHA));
     printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_ALPHA, %d)", portion_s, variable, alpha_channel);
     printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_MAP, 0x%x)", portion_s, variable, reg.map);
 }


### PR DESCRIPTION
There's an issue where using `.a` on textures (and other inputs) does not work.

Example in Cg:

```c
struct vOut {
  float2 uv : TEXCOORD0;
};

float4 main(
  vOut I,
  uniform sampler2D texture
) : COLOR
{
  return tex2D(texture, I.uv).aaaa; // Bug: Will actually return .rgba
}
```

When going from Cg, the intermediate shader result is still correct:

```c
!!TS1.0
texture_2d();
// End of program
!!RC1.0
{
  rgb
  {
    col0 = tex0.a * unsigned_invert(zero.rgb);
  }
}
out.rgb = unsigned(col0.rgb);
out.a = unsigned(tex0.a);
```

The final output will contain something like this:

```c
pb_push1(p, NV097_SET_COMBINER_COLOR_ICW + 0 * 4,
    MASK(NV097_SET_COMBINER_COLOR_ICW_A_SOURCE, 0x8) | MASK(NV097_SET_COMBINER_COLOR_ICW_A_ALPHA, 0) | MASK(NV097_SET_COMBINER_COLOR_ICW_A_MAP, 0x6)
    | MASK(NV097_SET_COMBINER_COLOR_ICW_B_SOURCE, 0x0) | MASK(NV097_SET_COMBINER_COLOR_ICW_B_ALPHA, 0) | MASK(NV097_SET_COMBINER_COLOR_ICW_B_MAP, 0x1)
    | MASK(NV097_SET_COMBINER_COLOR_ICW_C_SOURCE, 0x0) | MASK(NV097_SET_COMBINER_COLOR_ICW_C_ALPHA, 0) | MASK(NV097_SET_COMBINER_COLOR_ICW_C_MAP, 0x0)
    | MASK(NV097_SET_COMBINER_COLOR_ICW_D_SOURCE, 0x0) | MASK(NV097_SET_COMBINER_COLOR_ICW_D_ALPHA, 0) | MASK(NV097_SET_COMBINER_COLOR_ICW_D_MAP, 0x0));
p += 2;
pb_push1(p, NV097_SET_COMBINER_COLOR_OCW + 0 * 4,
    MASK(NV097_SET_COMBINER_COLOR_OCW_AB_DST, 0x4)
    | MASK(NV097_SET_COMBINER_COLOR_OCW_CD_DST, 0x0)
    | MASK(NV097_SET_COMBINER_COLOR_OCW_SUM_DST, 0x0)
    | MASK(NV097_SET_COMBINER_COLOR_OCW_MUX_ENABLE, 0)
    | MASK(NV097_SET_COMBINER_COLOR_OCW_AB_DOT_ENABLE, 0)
    | MASK(NV097_SET_COMBINER_COLOR_OCW_CD_DOT_ENABLE, 0)
    | MASK(NV097_SET_COMBINER_COLOR_OCW_OP, NV097_SET_COMBINER_COLOR_OCW_OP_SHIFTRIGHTBY1));
p += 2;
```

---

I believe the `MASK(NV097_SET_COMBINER_COLOR_ICW_A_ALPHA, 0)` should have been `MASK(NV097_SET_COMBINER_COLOR_ICW_A_ALPHA, 1)`. This change fixes that.

However, the full semantics of those fields still aren't fully known, so this might introduce different bugs.
Therefore it might require additional checks.

Please test with other existing shaders before merge.