### PR TITLE
pbkit: Allow setting color surface format

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -30,7 +30,7 @@ static const unsigned char systemFont[] =
 static void drawChar(unsigned char c, int x, int y, int fgColour, int bgColour)
 {
 	unsigned char *videoBuffer = XVideoGetFB();
-	videoBuffer += (y * SCREEN_WIDTH + x) * (SCREEN_BPP >> 3);
+	videoBuffer += (y * SCREEN_WIDTH + x) * ((SCREEN_BPP+7)/8);
 
 	unsigned char mask;
 	const unsigned char *font = systemFont + (c * FONT_WIDTH);
@@ -60,6 +60,7 @@ static void drawChar(unsigned char c, int x, int y, int fgColour, int bgColour)
 					videoBuffer += sizeof(int);
 					break;
 				case 16:
+				case 15:
 					*((short*)videoBuffer) = colourToDraw & 0xFFFF;
 					videoBuffer += sizeof(short);
 					break;
@@ -71,7 +72,7 @@ static void drawChar(unsigned char c, int x, int y, int fgColour, int bgColour)
 #endif
 		}
 		
-		videoBuffer += (SCREEN_WIDTH-FONT_WIDTH)  * (SCREEN_BPP >> 3);
+		videoBuffer += (SCREEN_WIDTH-FONT_WIDTH)  * ((SCREEN_BPP+7)/8);
 		font++;
 	}
 }
@@ -155,6 +156,10 @@ void debugPrint(const char *format, ...)
 	case 16:
 		fgColour = WHITE_16BPP;
 		bgColour = BLACK_16BPP;
+		break;
+	case 15:
+		fgColour = WHITE_15BPP;
+		bgColour = BLACK_15BPP;
 	}
 
 	unsigned char *s = (unsigned char*)	buffer;
@@ -188,7 +193,7 @@ void debugPrint(const char *format, ...)
 
 void advanceScreen( void )
 {
-	int pixelSize = SCREEN_BPP >> 3;
+	int pixelSize = (SCREEN_BPP+7)/8;
 	int screenSize  = SCREEN_WIDTH * (SCREEN_HEIGHT - MARGINS)  * pixelSize;
 	int lineSize    = SCREEN_WIDTH * (FONT_HEIGHT + 1) * pixelSize;
 	
@@ -205,7 +210,7 @@ void debugClearScreen( void )
 {
 	unsigned char* videoBuffer = XVideoGetFB();
 
-	memset( videoBuffer, 0, (SCREEN_BPP >> 3) * (SCREEN_WIDTH * SCREEN_HEIGHT) );
+	memset( videoBuffer, 0, ((SCREEN_BPP+7)/8) * (SCREEN_WIDTH * SCREEN_HEIGHT) );
 	nextRow = MARGIN;
 	nextCol = MARGIN; 
 }

--- a/lib/hal/debug.h
+++ b/lib/hal/debug.h
@@ -19,6 +19,9 @@ extern "C"
 #define WHITE_16BPP   0xFFFF
 #define BLACK_16BPP  0x0000
 
+#define WHITE_15BPP   0x7FFF
+#define BLACK_15BPP  0x0000
+
 /**
  * Prints a message to whatever debug facilities might
  * be available.

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -21,6 +21,9 @@ extern "C"
 #endif
 
 #include <xboxkrnl/xboxkrnl.h>
+#if !defined(__cplusplus)
+#include <stdbool.h>
+#endif
 
 #include "outer.h"
 #include "nv_objects.h"
@@ -89,6 +92,7 @@ void    pb_end(DWORD *pEnd);    //end a block with this (triggers the data sendi
 
 void    pb_extra_buffers(int n);//requests additional back buffers (default is 0) (call it before pb_init)
 void    pb_size(DWORD size);    //sets push buffer size (default is 512Kb) (call it before pb_init)
+void    pb_set_color_format(unsigned int fmt, bool swizzled); // sets color surface format (call it before pb_init)
 int     pb_init(void);      //returns 0 if everything went well (starts Dma engine)
 void    pb_kill(void);      //stops Dma engine and releases push buffer
 


### PR DESCRIPTION
This allows users to control the pbkit framebuffer color format (prior to `pb_init`). To make this more useful, R5G5B5 output is added to our video code.
The `debugPrint` code also wasn't aware of this mode, so I added some code to handle it.

This is a temporary API, as we'll have to make many more changes to the pbkit surface API in the future (as it doesn't really allow non-framebuffer rendertargets except the flawed `extra_buffer` code). However, such refactors will be in future PRs.

A similar PR for the zeta buffer will follow in the near future.