### PR TITLE
xboxkrnl fixes

### DIFF
--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -17,7 +17,7 @@ typedef long long LONGLONG, *PLONGLONG;
 typedef unsigned char UCHAR, *PUCHAR;
 typedef unsigned short USHORT, *PUSHORT, CSHORT;
 typedef unsigned short WORD, WCHAR, *PWSTR;
-typedef unsigned int DWORD, *PDWORD, *LPDWORD;
+typedef unsigned long DWORD, *PDWORD, *LPDWORD;
 typedef unsigned long ULONG, *PULONG;
 typedef unsigned long long ULONGLONG;
 

--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -21,6 +21,8 @@ typedef unsigned long DWORD, *PDWORD, *LPDWORD;
 typedef unsigned long ULONG, *PULONG;
 typedef unsigned long long ULONGLONG;
 
+#define MAXDWORD 0xFFFFFFFFUL
+
 typedef unsigned int SIZE_T, *PSIZE_T;
 
 typedef int BOOL, *PBOOL;

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -103,7 +103,6 @@ typedef LONG NTSTATUS;
 #define AV_PACK_VGA 0x00000005
 #define AV_PACK_SVIDEO 0x00000006
 
-typedef PVOID HANDLE, *PHANDLE;
 typedef ULONG PHYSICAL_ADDRESS, *PPHYSICAL_ADDRESS;
 typedef UCHAR KIRQL, *PKIRQL;
 typedef ULONG ULONG_PTR;
@@ -115,8 +114,6 @@ typedef ULONG DEVICE_TYPE;
 typedef ULONG LOGICAL;
 
 typedef unsigned char BYTE;
-typedef unsigned short WORD, WCHAR, *PWSTR;
-typedef unsigned int DWORD, *PDWORD, *LPDWORD;
 typedef const char *PCSZ, *PCSTR, *LPCSTR;
 typedef char *PSZ, *PSTR;
 typedef CONST WCHAR *LPCWSTR, *PCWSTR;


### PR DESCRIPTION
Small number of fixes for `xboxkrnl.h` and `xboxdef.h`.

* Small cleanup of redundant typedefs
* DWORD typedef fix by @mborgerson, cherry-picked from https://github.com/mborgerson/dc27-dooom-nxdk/commit/ac22514420cf9b2f610566d615f570b502d71558
* `MAXDWORD` macro added (needed by libc++)