### PR TITLE
Libraryization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,5 @@
 _*.cpp
 _*.h
 samples/**/*.iso
-samples/**/*.lib
+*.lib
 !tools/cg/win/cgc.exe

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ endif
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
 LD           = lld -flavor link
+LIB          = llvm-lib
 AS           = clang
 CC           = clang
 CXX          = clang++
@@ -24,6 +25,7 @@ CGC          = $(NXDK_DIR)/tools/cg/linux/cgc
 endif
 ifeq ($(UNAME_S),Darwin)
 LD           = /usr/local/opt/llvm/bin/lld -flavor link
+LIB          = /usr/local/opt/llvm/bin/llvm-lib
 AS           = /usr/local/opt/llvm/bin/clang
 CC           = /usr/local/opt/llvm/bin/clang
 CXX          = /usr/local/opt/llvm/bin/clang++
@@ -34,6 +36,7 @@ $(error Please use a MinGW64 shell)
 endif
 ifneq (,$(findstring MINGW,$(UNAME_S)))
 LD           = lld-link
+LIB          = llvm-lib
 AS           = clang
 CC           = clang
 CXX          = clang++
@@ -67,12 +70,14 @@ endif
 NXDK_CFLAGS += $(CFLAGS)
 NXDK_CXXFLAGS += $(CXXFLAGS)
 
-include $(NXDK_DIR)/lib/Makefile
-OBJS = $(addsuffix .obj, $(basename $(SRCS)))
-
 ifneq ($(GEN_XISO),)
 TARGET += $(GEN_XISO)
 endif
+
+all: $(TARGET)
+
+include $(NXDK_DIR)/lib/Makefile
+OBJS = $(addsuffix .obj, $(basename $(SRCS)))
 
 ifneq ($(NXDK_NET),)
 include $(NXDK_DIR)/lib/net/Makefile
@@ -97,8 +102,6 @@ endif
 DEPS := $(filter %.c.d, $(SRCS:.c=.c.d))
 DEPS += $(filter %.cpp.d, $(SRCS:.cpp=.cpp.d))
 
-all: $(TARGET)
-
 $(OUTPUT_DIR)/default.xbe: main.exe $(OUTPUT_DIR) $(CXBE)
 	@echo "[ CXBE     ] $@"
 	$(VE)$(CXBE) -OUT:$@ -TITLE:$(XBE_TITLE) $< $(QUIET)
@@ -117,6 +120,10 @@ $(SRCS): $(SHADER_OBJS)
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
 	$(VE) $(LD) $(LDFLAGS) -subsystem:windows -dll -out:'$@' -entry:XboxCRTEntry -stack:$(NXDK_STACKSIZE) -safeseh:no $^
+
+%.lib:
+	@echo "[ LIB      ] $@"
+	$(VE) $(LIB) -out:'$@' $^
 
 %.obj: %.cpp
 	@echo "[ CXX      ] $@"
@@ -166,7 +173,7 @@ $(EXTRACT_XISO):
 	$(VE)$(MAKE) -C $(NXDK_DIR)/tools/extract-xiso $(QUIET)
 
 .PHONY: clean 
-clean:
+clean: $(CLEANRULES)
 	$(VE)rm -f $(TARGET) \
 	           main.exe main.exe.manifest main.lib \
 	           $(OBJS) $(SHADER_OBJS) $(DEPS) \

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,31 +1,10 @@
-USB_SRCS := \
-	$(NXDK_DIR)/lib/usb/host/ohci-hcd.c \
-	$(NXDK_DIR)/lib/usb/core/message.c \
-	$(NXDK_DIR)/lib/usb/core/hcd.c \
-	$(NXDK_DIR)/lib/usb/core/hcd-pci.c \
-	$(NXDK_DIR)/lib/usb/core/hub.c \
-	$(NXDK_DIR)/lib/usb/core/usb.c \
-	$(NXDK_DIR)/lib/usb/core/config.c \
-	$(NXDK_DIR)/lib/usb/core/urb.c \
-	$(NXDK_DIR)/lib/usb/core/buffer_simple.c \
-	$(NXDK_DIR)/lib/usb/core/usb-debug.c \
-	$(NXDK_DIR)/lib/usb/sys/BootUSB.c \
-	$(NXDK_DIR)/lib/usb/sys/linuxwrapper.c \
-	$(NXDK_DIR)/lib/usb/sys/xpad.c \
-	$(NXDK_DIR)/lib/usb/sys/xremote.c \
-	$(NXDK_DIR)/lib/usb/sys/usbkey.c \
-	$(NXDK_DIR)/lib/usb/sys/usbmouse.c \
-	$(NXDK_DIR)/lib/usb/misc/misc.c \
-	$(NXDK_DIR)/lib/usb/misc/pci.c \
-	$(NXDK_DIR)/lib/usb/misc/malloc.c
-
 SRCS += \
 	$(shell find $(NXDK_DIR)/lib/pdclib/functions/ -name "*.c") \
 	$(shell find $(NXDK_DIR)/lib/pdclib/platform/xbox/ -name "*.c") \
 	$(shell find $(NXDK_DIR)/lib/pdclib/platform/xbox/ -name "*.s") \
 	$(wildcard $(NXDK_DIR)/lib/hal/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/winapi/*.c) \
-	$(wildcard $(NXDK_DIR)/lib/pbkit/*.c) \
-	$(USB_SRCS)
+	$(wildcard $(NXDK_DIR)/lib/pbkit/*.c)
 
+include $(NXDK_DIR)/lib/usb/Makefile
 include $(NXDK_DIR)/lib/xboxrt/Makefile

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,10 +1,8 @@
 SRCS += \
-	$(shell find $(NXDK_DIR)/lib/pdclib/functions/ -name "*.c") \
-	$(shell find $(NXDK_DIR)/lib/pdclib/platform/xbox/ -name "*.c") \
-	$(shell find $(NXDK_DIR)/lib/pdclib/platform/xbox/ -name "*.s") \
 	$(wildcard $(NXDK_DIR)/lib/winapi/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/pbkit/*.c)
 
+include $(NXDK_DIR)/lib/Makefile-pdclib
 include $(NXDK_DIR)/lib/hal/Makefile
 include $(NXDK_DIR)/lib/usb/Makefile
 include $(NXDK_DIR)/lib/xboxrt/Makefile

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -2,9 +2,9 @@ SRCS += \
 	$(shell find $(NXDK_DIR)/lib/pdclib/functions/ -name "*.c") \
 	$(shell find $(NXDK_DIR)/lib/pdclib/platform/xbox/ -name "*.c") \
 	$(shell find $(NXDK_DIR)/lib/pdclib/platform/xbox/ -name "*.s") \
-	$(wildcard $(NXDK_DIR)/lib/hal/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/winapi/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/pbkit/*.c)
 
+include $(NXDK_DIR)/lib/hal/Makefile
 include $(NXDK_DIR)/lib/usb/Makefile
 include $(NXDK_DIR)/lib/xboxrt/Makefile

--- a/lib/Makefile-pdclib
+++ b/lib/Makefile-pdclib
@@ -1,0 +1,16 @@
+PDCLIB_SRCS := \
+	$(shell find $(NXDK_DIR)/lib/pdclib/functions/ -name "*.c") \
+	$(shell find $(NXDK_DIR)/lib/pdclib/platform/xbox/ -name "*.c") \
+	$(shell find $(NXDK_DIR)/lib/pdclib/platform/xbox/ -name "*.s")
+
+PDCLIB_OBJS = $(addsuffix .obj, $(basename $(PDCLIB_SRCS)))
+
+$(NXDK_DIR)/lib/libpdclib.lib: $(PDCLIB_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libpdclib.lib
+
+CLEANRULES += clean-pdclib
+
+.PHONY: clean-pdclib
+clean-pdclib:
+	$(VE)rm -f $(PDCLIB_OBJS) $(NXDK_DIR)/lib/libpdclib.lib

--- a/lib/hal/Makefile
+++ b/lib/hal/Makefile
@@ -1,0 +1,21 @@
+HAL_SRCS := \
+	$(NXDK_DIR)/lib/hal/audio.c \
+	$(NXDK_DIR)/lib/hal/debug.c \
+	$(NXDK_DIR)/lib/hal/fileio.c \
+	$(NXDK_DIR)/lib/hal/input.c \
+	$(NXDK_DIR)/lib/hal/io.c \
+	$(NXDK_DIR)/lib/hal/led.c \
+	$(NXDK_DIR)/lib/hal/video.c \
+	$(NXDK_DIR)/lib/hal/xbox.c
+
+HAL_OBJS = $(addsuffix .obj, $(basename $(HAL_SRCS)))
+
+$(NXDK_DIR)/lib/libnxdk_hal.lib: $(HAL_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libnxdk_hal.lib
+
+CLEANRULES += clean-hal
+
+.PHONY: clean-hal
+clean-hal:
+	$(VE)rm -f $(HAL_OBJS) $(NXDK_DIR)/lib/libnxdk_hal.lib

--- a/lib/sdl/Makefile
+++ b/lib/sdl/Makefile
@@ -1,5 +1,8 @@
 SDL_TTF_DIR = $(NXDK_DIR)/lib/sdl/SDL_ttf
 SDL_TTF_SRCS += $(SDL_TTF_DIR)/SDL_ttf.c
+SDL_TTF_OBJS = $(addsuffix .obj, $(basename $(SDL_TTF_SRCS)))
+
+$(NXDK_DIR)/lib/libSDL_ttf.lib: $(SDL_TTF_OBJS)
 
 FREETYPE_DIR = $(NXDK_DIR)/lib/sdl/SDL_ttf/external/freetype-2.4.12
 FREETYPE_SRCS += $(FREETYPE_DIR)/src/base/ftbase.c
@@ -13,9 +16,22 @@ FREETYPE_SRCS += $(FREETYPE_DIR)/src/raster/raster.c
 FREETYPE_SRCS += $(FREETYPE_DIR)/src/smooth/smooth.c
 FREETYPE_SRCS += $(FREETYPE_DIR)/src/autofit/autofit.c
 FREETYPE_SRCS += $(FREETYPE_DIR)/src/sfnt/sfnt.c
+FREETYPE_OBJS = $(addsuffix .obj, $(basename $(FREETYPE_SRCS)))
 
-SRCS += $(SDL_TTF_SRCS) $(FREETYPE_SRCS)
+$(NXDK_DIR)/lib/libfreetype.lib: $(FREETYPE_OBJS)
+
 CFLAGS += -I$(NXDK_DIR)/lib/sdl \
           -I$(SDL_TTF_DIR) \
           -I$(FREETYPE_DIR)/include \
           -DXBOX
+
+main.exe: $(NXDK_DIR)/lib/libSDL_ttf.lib $(NXDK_DIR)/lib/libfreetype.lib
+
+CLEANRULES += clean-sdl_ttf
+
+.PHONY: clean-sdl_ttf
+clean-sdl_ttf:
+	$(VE)rm -f $(SDL_TTF_OBJS) \
+	           $(FREETYPE_OBJS) \
+	           $(NXDK_DIR)/lib/libSDL_ttf.lib \
+	           $(NXDK_DIR)/lib/libfreetype.lib

--- a/lib/usb/Makefile
+++ b/lib/usb/Makefile
@@ -1,0 +1,32 @@
+USB_SRCS := \
+	$(NXDK_DIR)/lib/usb/host/ohci-hcd.c \
+	$(NXDK_DIR)/lib/usb/core/message.c \
+	$(NXDK_DIR)/lib/usb/core/hcd.c \
+	$(NXDK_DIR)/lib/usb/core/hcd-pci.c \
+	$(NXDK_DIR)/lib/usb/core/hub.c \
+	$(NXDK_DIR)/lib/usb/core/usb.c \
+	$(NXDK_DIR)/lib/usb/core/config.c \
+	$(NXDK_DIR)/lib/usb/core/urb.c \
+	$(NXDK_DIR)/lib/usb/core/buffer_simple.c \
+	$(NXDK_DIR)/lib/usb/core/usb-debug.c \
+	$(NXDK_DIR)/lib/usb/sys/BootUSB.c \
+	$(NXDK_DIR)/lib/usb/sys/linuxwrapper.c \
+	$(NXDK_DIR)/lib/usb/sys/xpad.c \
+	$(NXDK_DIR)/lib/usb/sys/xremote.c \
+	$(NXDK_DIR)/lib/usb/sys/usbkey.c \
+	$(NXDK_DIR)/lib/usb/sys/usbmouse.c \
+	$(NXDK_DIR)/lib/usb/misc/misc.c \
+	$(NXDK_DIR)/lib/usb/misc/pci.c \
+	$(NXDK_DIR)/lib/usb/misc/malloc.c
+
+USB_OBJS = $(addsuffix .obj, $(basename $(USB_SRCS)))
+
+$(NXDK_DIR)/lib/libnxdk_usb.lib: $(USB_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libnxdk_usb.lib
+
+CLEANRULES += clean-usb
+
+.PHONY: clean-usb
+clean-usb:
+	$(VE)rm -f $(USB_OBJS) $(NXDK_DIR)/lib/libnxdk_usb.lib


### PR DESCRIPTION
This splits out `PDCLib`, `hal`, `Freetype` and `SDL_ttf` to be built as libraries (others are untouched to avoid getting too many merge conflicts).

I am well aware that this is still far from being a complete solution (everything is built with the same compiler flags, libs are automatically added by makefiles instead of the samples specifying their requirements, still the one large main Makefile, sub-Makefiles adding cleaning rules to the main Makefile via a variable etc.) - I consider this only a first step and, most importantly, a fix to get nxdk to build on msys2 again.