### PR TITLE
Travis CI for Windows/msys2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
     - linux
     - osx
+    - windows
 
 dist: xenial
 
@@ -9,12 +10,18 @@ sudo: required
 before_install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get update -qq; fi
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install msys2; fi
 
 install:
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install llvm; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq flex bison clang lld-6.0; fi
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmd /c\ .travis_win_deps.bat; fi
+    # Build hang workaround (https://travis-ci.community/t/build-times-out-when-msys-was-installed/3498)
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then taskkill -IM "gpg-agent.exe" -F; fi
 
 language: c
 
 script:
-    - sh ./.ci_build_samples.sh
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sh ./.ci_build_samples.sh; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then sh ./.ci_build_samples.sh; fi
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmd /c\ .travis_win_build.bat; fi

--- a/.travis_win_build.bat
+++ b/.travis_win_build.bat
@@ -1,0 +1,4 @@
+PATH C:\tools\msys64\MINGW64\bin;C:\tools\msys64\usr\bin;%PATH%
+set MSYS2_ARCH=x86_64
+set MSYSTEM=MINGW64
+C:\tools\msys64\usr\bin\bash.exe -lc "sh ./.ci_build_samples.sh"

--- a/.travis_win_deps.bat
+++ b/.travis_win_deps.bat
@@ -1,0 +1,1 @@
+C:\tools\msys64\usr\bin\bash.exe -lc "pacman --needed --noconfirm -S cmake make bison flex mingw-w64-x86_64-llvm mingw-w64-x86_64-clang mingw-w64-x86_64-lld"


### PR DESCRIPTION
Based on #156.

The only change compared to #156 is b9f3204d6eac7c762cf4c4e2cf7ce03005be8505, which adds support for building with msys2 on Windows with Travis CI. It uses the Chocolatey package manager for msys2 installation (also includes a hang workaround, see https://travis-ci.community/t/build-times-out-when-msys-was-installed/3498), the additional batch files were required because of whitespace issues when calling bash directly from `.travis.yml`.

Due to slower building and the time required to install msys2, this runs quite a bit slower than the Linux build and is even about a minute slower than the macOS build, but it works.