### PR TITLE
xboxkrnl: DbgPrint() takes a constant string parameter

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -4202,7 +4202,7 @@ XBAPI ULONG NTAPI DbgPrompt
  */
 XBAPI ULONG CDECL DbgPrint
 (
-    PCH Format,
+    PCSTR Format,
     ...
 );
 


### PR DESCRIPTION
Title pretty much says it all. Fixes a warning when passing a string literal to the function.