### PR TITLE
Fix macOS CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ $(SRCS): $(SHADER_OBJS)
 
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
-	$(VE) $(LD) $(LDFLAGS) -subsystem:windows -dll -out:'$@' -entry:XboxCRTEntry -stack:$(NXDK_STACKSIZE) $^
+	$(VE) $(LD) $(LDFLAGS) -subsystem:windows -dll -out:'$@' -entry:XboxCRTEntry -stack:$(NXDK_STACKSIZE) -safeseh:no $^
 
 %.obj: %.cpp
 	@echo "[ CXX      ] $@"

--- a/samples/httpd/Makefile
+++ b/samples/httpd/Makefile
@@ -1,4 +1,3 @@
-DEBUG=y
 XBE_TITLE=httpd
 GEN_XISO = $(XBE_TITLE).iso
 SRCS += $(wildcard $(CURDIR)/*.c)

--- a/samples/sdl/Makefile
+++ b/samples/sdl/Makefile
@@ -1,4 +1,3 @@
-DEBUG = y
 XBE_TITLE = sdl
 GEN_XISO = $(XBE_TITLE).iso
 SRCS += $(wildcard $(CURDIR)/*.c)

--- a/samples/sdl_ttf/Makefile
+++ b/samples/sdl_ttf/Makefile
@@ -1,4 +1,3 @@
-DEBUG = y
 XBE_TITLE = sdl_ttf
 GEN_XISO = $(XBE_TITLE).iso
 SRCS += $(CURDIR)/main.c


### PR DESCRIPTION
The update to LLVM 9 on macOS broke CI. Problem described [here](https://github.com/XboxDev/nxdk/pull/154#issuecomment-535107218).

There are two underlying issues here:
1. LLVM 9 seems to default to enforcing [Safe SEH](https://docs.microsoft.com/de-de/cpp/build/reference/safeseh-image-has-safe-exception-handlers?view=vs-2019). It's meant to prevent hijacking of the control flow by overwriting the exception handling record (which resides on the stack) and then triggering an exception. Safe SEH protects against that by checking the handler address in the exception handling record against a list containing all the handlers. nxdk doesn't support Safe SEH (we don't even have normal SEH yet), so my solution is to disable Safe SEH in the linker (which doesn't prevent using or implementing Safe SEH, it only allows the linker to generate images that don't guarantee Safe SEH everywhere).
2. LLVM 9 crashes on macOS when linking in debug mode. I work around this by removing `DEBUG = y` from the Makefiles of the few samples that use it. While this fixes CI, this being broken is obviously not a good long-term solution (especially if it's a universal problem and not specific to macOS).