### PR TITLE
vcruntime: Add pure virtual function call handling

### DIFF
--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -16,5 +16,6 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_fltused.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/check_stack.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/chkstk.s \
+	$(NXDK_DIR)/lib/xboxrt/vcruntime/purecall.c \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_exception.cpp \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp

--- a/lib/xboxrt/libc_extensions/stdlib_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.h
@@ -1,3 +1,9 @@
+/*
+ * Copyright (c) 2019 Stefan Schmidt
+ *
+ * Licensed under the MIT License
+ */
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -5,6 +11,11 @@ extern "C" {
 #ifdef _CRT_RAND_S
 int rand_s (unsigned int *randomValue);
 #endif
+
+typedef void (__cdecl *_purecall_handler)(void);
+
+_purecall_handler __cdecl _get_purecall_handler (void);
+_purecall_handler __cdecl _set_purecall_handler (_purecall_handler function);
 
 #ifdef __cplusplus
 }

--- a/lib/xboxrt/vcruntime/purecall.c
+++ b/lib/xboxrt/vcruntime/purecall.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2019 Stefan Schmidt
+ *
+ * Licensed under the MIT License
+ */
+
+#include <stdbool.h>
+#include <stdlib_ext_.h>
+#include <windows.h>
+#include <hal/debug.h>
+
+_purecall_handler current_purecall_handler = NULL;
+
+int __cdecl _purecall ()
+{
+    if (current_purecall_handler) {
+        current_purecall_handler();
+    }
+
+    debugPrint("Pure virtual function called!\n");
+
+    // Make sure the handler doesn't return
+    while(true) {
+        Sleep(1000);
+    }
+
+    // return value is not documented by MS (unreachable anyway)
+    return 0;
+}
+
+_purecall_handler __cdecl _get_purecall_handler (void)
+{
+    return current_purecall_handler;
+}
+
+_purecall_handler __cdecl _set_purecall_handler (_purecall_handler function)
+{
+    _purecall_handler old_handler = current_purecall_handler;
+    current_purecall_handler = function;
+    return old_handler;
+}


### PR DESCRIPTION
This is a very MS and C++ specific piece of code - unfortunately, it's impossible to test this meaningfully without some large parts of my libc++ work (we would need to try and call a pure virtual function, but such code will emit RTTI references we don't provide yet).

As the name suggests, clang will emit code calling `_purecall` whenever the program tries to call a pure virtual function. The program is able to set it's own handler (which should never return), but there also has to be default handling (we're just printing info here and enter an endless loop).

As for the new header: While being considered part of vcruntime, `_get_purecall_handler` and `_set_purecall_handler` are supposed to be provided by `stdlib.h`. To not clutter PDCLib with non-standard stuff, I have spoken with upstream to get extension hooks (which we'll get with the merge of https://github.com/XboxDev/nxdk-pdclib/pull/12) which we can use to include additional stuff into the standard headers.
When the PDCLib update (and this) is merged, we can simply add the option to the PDCLib config to activate this.

/edit:
Using the extension hooks for this can be tested by adding `#define _PDCLIB_EXTEND_STDLIB_H <stdlib_ext_.h>` to `platform/xbox/include/pdclib/_PDCLIB_config.h` in the PDCLib directory after checking out my branch from https://github.com/XboxDev/nxdk-pdclib/pull/12.