### PR TITLE
libc: Add strdup / _strdup as extensions

### DIFF
--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -2,6 +2,7 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/stat.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/strings.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/wchar.c \
+	$(NXDK_DIR)/lib/xboxrt/libc_extensions/string_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_alldiv.s \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_allmul.s \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_allrem.s \

--- a/lib/xboxrt/libc_extensions/string_ext_.c
+++ b/lib/xboxrt/libc_extensions/string_ext_.c
@@ -1,0 +1,16 @@
+#include <string.h>
+#include <stdlib.h>
+
+char *strdup (const char *s)
+{
+    if (s == NULL) {
+        return NULL;
+    }
+
+    char *new_s = malloc(strlen(s) + 1);
+    if (new_s != NULL) {
+        strcpy(new_s, s);
+    }
+
+    return new_s;
+}

--- a/lib/xboxrt/libc_extensions/string_ext_.h
+++ b/lib/xboxrt/libc_extensions/string_ext_.h
@@ -1,0 +1,14 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+char *strdup (const char *s);
+
+static char *_strdup (const char *s)
+{
+    return strdup(s);
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Like #185, this is supposed to use the new PDCLib extension hooks once they're merged, see that PR for details.

This adds `strdup` and the MS-specific alias `_strdup`. While not part of the C standard (yet, C2x will probably add it), it's required by libc++.

/edit:
Using the extension hooks for this can be tested by adding `#define _PDCLIB_EXTEND_STRING_H <string_ext_.h>` to `platform/xbox/include/pdclib/_PDCLIB_config.h` in the PDCLib directory after checking out my branch from https://github.com/XboxDev/nxdk-pdclib/pull/12.