### PR TITLE
samples: Fix VP upload

### DIFF
--- a/samples/mesh/main.c
+++ b/samples/mesh/main.c
@@ -308,17 +308,22 @@ static void init_shader(void)
     pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_CXT_WRITE_EN, 0);
     p += 2;
 
-    /* Set cursor and begin copying program */
+    pb_end(p);
+
+    /* Set cursor for program upload */
+    p = pb_begin();
     pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_LOAD, 0);
     p += 2;
+    pb_end(p);
 
-    for (i=0; i<sizeof(vs_program)/8; i++) {
+    /* Copy program instructions (16-bytes each) */
+    for (i=0; i<sizeof(vs_program)/16; i++) {
+        p = pb_begin();
         pb_push(p++, NV097_SET_TRANSFORM_PROGRAM, 4);
         memcpy(p, &vs_program[i*4], 4*4);
         p+=4;
+        pb_end(p);
     }
-
-    pb_end(p);
 
     /* Setup fragment shader */
     p = pb_begin();

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -204,17 +204,22 @@ static void init_shader(void)
     pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_CXT_WRITE_EN, 0);
     p += 2;
 
-    /* Set cursor and begin copying program */
+    pb_end(p);
+
+    /* Set cursor for program upload */
+    p = pb_begin();
     pb_push1(p, NV097_SET_TRANSFORM_PROGRAM_LOAD, 0);
     p += 2;
+    pb_end(p);
 
-    for (i=0; i<sizeof(vs_program)/8; i++) {
+    /* Copy program instructions (16-bytes each) */
+    for (i=0; i<sizeof(vs_program)/16; i++) {
+        p = pb_begin();
         pb_push(p++, NV097_SET_TRANSFORM_PROGRAM, 4);
         memcpy(p, &vs_program[i*4], 4*4);
         p+=4;
+        pb_end(p);
     }
-
-    pb_end(p);
 
     /* Setup fragment shader */
     p = pb_begin();


### PR DESCRIPTION
Closes #184 

Fixes VP upload errors in the samples:

**Uploads the correct number of instructions now.**
This used to be miscalculated which caused overflows.

**Uploads each instruction in its own `pb_begin` / `pb_end` block.**
This avoids long pbkit blocks; pbkit warnings suggest that 128 DWORDs is the maximum number of DWORD per block. I believe this is the GPU cache size, although I don't think the hardware would struggle when submitting more. For now, we'll just respect this pbkit limit (it will be enforced using `assert` by #158), but we should eventually review why it exists.

---

I've only tested this in XQEMU