### PR TITLE
makefile: Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,6 @@ NXDK_CXXFLAGS += -g -gdwarf-4
 NXDK_LDFLAGS += -debug
 endif
 
-NXDK_CFLAGS += $(CFLAGS)
-NXDK_CXXFLAGS += $(CXXFLAGS)
-
 ifneq ($(GEN_XISO),)
 TARGET += $(GEN_XISO)
 endif
@@ -130,11 +127,11 @@ main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 
 %.obj: %.cpp
 	@echo "[ CXX      ] $@"
-	$(VE) $(CXX) $(NXDK_CXXFLAGS) -MD -MT '$@' -MF '$(patsubst %.cpp,%.cpp.d,$<)' -c -o '$@' '$<'
+	$(VE) $(CXX) $(NXDK_CXXFLAGS) $(CXXFLAGS) -MD -MT '$@' -MF '$(patsubst %.cpp,%.cpp.d,$<)' -c -o '$@' '$<'
 
 %.obj: %.c
 	@echo "[ CC       ] $@"
-	$(VE) $(CC) $(NXDK_CFLAGS) -MD -MT '$@' -MF '$(patsubst %.c,%.c.d,$<)' -c -o '$@' '$<'
+	$(VE) $(CC) $(NXDK_CFLAGS) $(CFLAGS) -MD -MT '$@' -MF '$(patsubst %.c,%.c.d,$<)' -c -o '$@' '$<'
 
 %.obj: %.s
 	@echo "[ AS       ] $@"

--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 
 %.obj: %.s
 	@echo "[ AS       ] $@"
-	$(VE) $(AS) $(NXDK_ASFLAGS) -c -o '$@' '$<'
+	$(VE) $(AS) $(NXDK_ASFLAGS) $(ASFLAGS) -c -o '$@' '$<'
 
 %.inl: %.vs.cg $(VP20COMPILER)
 	@echo "[ CG       ] $@"

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,14 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = $(NXDK_CFLAGS)
+NXDK_LDFLAGS = -subsystem:windows -dll -entry:XboxCRTEntry \
+               -stack:$(NXDK_STACKSIZE) -safeseh:no
+
 
 ifeq ($(DEBUG),y)
 NXDK_CFLAGS += -g -gdwarf-4
 NXDK_CXXFLAGS += -g -gdwarf-4
-LDFLAGS += -debug
+NXDK_LDFLAGS += -debug
 endif
 
 NXDK_CFLAGS += $(CFLAGS)
@@ -119,7 +122,7 @@ $(SRCS): $(SHADER_OBJS)
 
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
-	$(VE) $(LD) $(LDFLAGS) -subsystem:windows -dll -out:'$@' -entry:XboxCRTEntry -stack:$(NXDK_STACKSIZE) -safeseh:no $^
+	$(VE) $(LD) $(NXDK_LDFLAGS) $(LDFLAGS) -out:'$@' $^
 
 %.lib:
 	@echo "[ LIB      ] $@"

--- a/Makefile
+++ b/Makefile
@@ -127,11 +127,11 @@ main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 
 %.obj: %.cpp
 	@echo "[ CXX      ] $@"
-	$(VE) $(CXX) $(NXDK_CXXFLAGS) $(CXXFLAGS) -MD -MT '$@' -MF '$(patsubst %.cpp,%.cpp.d,$<)' -c -o '$@' '$<'
+	$(VE) $(CXX) $(NXDK_CXXFLAGS) $(CXXFLAGS) -MD -MP -MT '$@' -MF '$(patsubst %.cpp,%.cpp.d,$<)' -c -o '$@' '$<'
 
 %.obj: %.c
 	@echo "[ CC       ] $@"
-	$(VE) $(CC) $(NXDK_CFLAGS) $(CFLAGS) -MD -MT '$@' -MF '$(patsubst %.c,%.c.d,$<)' -c -o '$@' '$<'
+	$(VE) $(CC) $(NXDK_CFLAGS) $(CFLAGS) -MD -MP -MT '$@' -MF '$(patsubst %.c,%.c.d,$<)' -c -o '$@' '$<'
 
 %.obj: %.s
 	@echo "[ AS       ] $@"


### PR DESCRIPTION
The idea is so that if someone includes our makefile, they can use `NXDK_*FLAGS` if they want to call the tools themselves.

Additionally, the nxdk makefile can then be interacted with using standard `*FLAGS` variables, without them being modified by nxdk (in case the makefile that included nxdk makefile wants to use them again).
This is still very dirty, but a bit more consistent and predictable.

I've also added the `-MP` flag to avoid errors which would appear after building with a feature-branch (which had headers which are missing when switching back to master): 
```
$ make
make: *** No rule to make target 'nxdk/samples/triangle/../../lib/xgu/xgu.h', needed by 'nxdk/samples/triangle/main.obj'.  Stop.
$
```