### PR TITLE
fp20compiler: Fix input component selection

### DIFF
--- a/tools/fp20compiler/rc1.0_final.cpp
+++ b/tools/fp20compiler/rc1.0_final.cpp
@@ -115,7 +115,7 @@ static void GenerateFinalInput(char var, MappedRegisterStruct reg) {
     int num = (var >= 'E') ? 1 : 0;
     printf("MASK(NV097_SET_COMBINER_SPECULAR_FOG_CW%d_%c_SOURCE, 0x%x)", num, var, reg.reg.bits.name);
     printf(" | MASK(NV097_SET_COMBINER_SPECULAR_FOG_CW%d_%c_ALPHA, %d)", num, var,
-            reg.reg.bits.channel == RCP_ALPHA); //TODO: Blue
+            reg.reg.bits.channel == RCP_ALPHA);
     printf(" | MASK(NV097_SET_COMBINER_SPECULAR_FOG_CW%d_%c_INVERSE, %d)", num, var,
             (reg.map == MAP_UNSIGNED_INVERT));
 }

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -234,8 +234,8 @@ void GeneralFunctionStruct::Validate(int stage, int portion)
 static void GenerateInput(int portion, char variable, MappedRegisterStruct reg) {
     const char* portion_s = portion == RCP_RGB ? "COLOR" : "ALPHA";
     printf("MASK(NV097_SET_COMBINER_%s_ICW_%c_SOURCE, 0x%x)", portion_s, variable, reg.reg.bits.name);
-    bool alpha_channel = ((portion == RCP_RGB && reg.reg.bits.channel == RCP_BLUE) || (portion == RCP_ALPHA));
-    printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_ALPHA, %d)", portion_s, variable, alpha_channel);
+    printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_ALPHA, %d)", portion_s, variable,
+            reg.reg.bits.channel == RCP_ALPHA);
     printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_MAP, 0x%x)", portion_s, variable, reg.map);
 }
 


### PR DESCRIPTION
This was already a PR #138 but I got suspicious about my fix and closed it. I have now tested this on hardware and cleaned up my fix. I've [documented my findings in XboxDevWiki](https://xboxdevwiki.net/NV2A/Pixel_Combiner#Encoding_of_input_swizzle) and implemented the described behaviour.

The correct condition for the ALPHA flag should be `reg.reg.bits.channel == RCP_ALPHA`.

This condition is already being used for final-combiner inputs:

https://github.com/XboxDev/nxdk/blob/80315410cfbbee778560f4bb92821970ffe99e4b/tools/fp20compiler/rc1.0_final.cpp#L117-L118

However, the `//TODO: Blue` is misleading as it already handles `RCP_BLUE` correctly (only allowed for scalar input `G`; vector inputs `A`-`E` allow `RCP_RGB` instead); the ALPHA flag would be 0 as expected.

This PR copies the final-combiner code to the general-combiner code and removes the comment from the final-combiner emitter.

---

This is a sample shader which shows all variations. You can just copy the shader into a file (test.inl) and run `fp20compiler test.inl` to confirm expected output (needs modification / recompile to show both variants for `out.a`).

```c
!!RC1.0

// Generic combiner

{
  rgb {
    spare0 = col0.rgb; //expected: NV097_SET_COMBINER_COLOR_ICW_A_ALPHA = 0
    spare1 = col0.a;   //expected: NV097_SET_COMBINER_COLOR_ICW_C_ALPHA = 1
  }
  alpha {
    spare0 = col0.b; //expected: NV097_SET_COMBINER_ALPHA_ICW_A_ALPHA = 0
    spare1 = col0.a; //expected: NV097_SET_COMBINER_ALPHA_ICW_C_ALPHA = 1
  }
}


// Final-combiner

out.rgb = spare0.rgb //expected: NV097_SET_COMBINER_SPECULAR_FOG_CW0_A_ALPHA = 0
        + spare1.a;  //expected: NV097_SET_COMBINER_SPECULAR_FOG_CW0_D_ALPHA = 1

out.a = spare0.b;   //expected: NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 0
//out.a = spare0.a; //expected: NV097_SET_COMBINER_SPECULAR_FOG_CW1_G_ALPHA = 1
```

Additional code for testing, to actually run the generated pbkit functions, can be found in https://github.com/JayFoxRox/nxdk/pull/30.