### PR TITLE
Cpp build fix for SDL_TTF and friends

### DIFF
--- a/lib/sdl/Makefile
+++ b/lib/sdl/Makefile
@@ -25,6 +25,11 @@ CFLAGS += -I$(NXDK_DIR)/lib/sdl \
           -I$(FREETYPE_DIR)/include \
           -DXBOX
 
+CXXFLAGS += -I$(NXDK_DIR)/lib/sdl \
+          -I$(SDL_TTF_DIR) \
+          -I$(FREETYPE_DIR)/include \
+          -DXBOX
+
 main.exe: $(NXDK_DIR)/lib/libSDL_ttf.lib $(NXDK_DIR)/lib/libfreetype.lib
 
 CLEANRULES += clean-sdl_ttf


### PR DESCRIPTION
Closes #201 
This fixes building C++ apps with SDL_ttf and freetype.
We'd need an update to the nxdk-sdl repo too for it to work all out though.
XboxDev/nxdk-sdl#12 could be that fix.