### PR TITLE
Remove XReboot and return value from main

### DIFF
--- a/samples/hello++/main.cpp
+++ b/samples/hello++/main.cpp
@@ -12,13 +12,13 @@ public:
   int getValue() { return hiddenValue; };
 };
 
-int main() {
+int main(void) {
   XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
   int ret = pb_init();
   if (ret != 0) {
     Sleep(2000);
-    return -1;
+    return 1;
   }
 
   pb_show_debug_screen();
@@ -33,6 +33,5 @@ int main() {
   }
 
   pb_kill();
-
   return 0;
 }

--- a/samples/hello/main.c
+++ b/samples/hello/main.c
@@ -5,7 +5,7 @@
 #include <windows.h>
 #include "stdio.h"
 
-void main(void)
+int main(void)
 {
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
@@ -14,8 +14,7 @@ void main(void)
         case 0: break;
         default:
             Sleep(2000);
-            XReboot();
-            return;
+            return 1;
     }
 
     pb_show_debug_screen();
@@ -26,5 +25,5 @@ void main(void)
     }
 
     pb_kill();
-    XReboot();
+    return 0;
 }

--- a/samples/httpd/main.c
+++ b/samples/httpd/main.c
@@ -39,7 +39,7 @@ static void packet_timer(void *arg)
   sys_timeout(PKT_TMR_INTERVAL, packet_timer, NULL);
 }
 
-void main(void)
+int main(void)
 {
 	sys_sem_t init_complete;
 	const ip4_addr_t *ip;
@@ -77,7 +77,7 @@ void main(void)
 	                     NULL, nforceif_init, ethernet_input);
 	if (!g_pnetif) {
 		debugPrint("netif_add failed\n");
-		return;
+		return 1;
 	}
 
 	netif_set_default(g_pnetif);
@@ -105,5 +105,5 @@ void main(void)
 	http_server_netconn_init();
 	while (1) NtYieldExecution();
 	Pktdrv_Quit();
-	return;
+	return 0;
 }

--- a/samples/httpd_bsd/main.c
+++ b/samples/httpd_bsd/main.c
@@ -39,7 +39,7 @@ static void packet_timer(void *arg)
     sys_timeout(PKT_TMR_INTERVAL, packet_timer, NULL);
 }
 
-void main(void)
+int main(void)
 {
     XVideoSetMode(640,480,32,REFRESH_DEFAULT);
     sys_sem_t init_complete;
@@ -76,7 +76,7 @@ void main(void)
                          NULL, nforceif_init, ethernet_input);
     if (!g_pnetif) {
         debugPrint("netif_add failed\n");
-        return;
+        return 1;
     }
 
     netif_set_default(g_pnetif);
@@ -103,5 +103,5 @@ void main(void)
 
     http_server_bsd();
     Pktdrv_Quit();
-    return;
+    return 0;
 }

--- a/samples/led/main.c
+++ b/samples/led/main.c
@@ -1,7 +1,7 @@
 #include <hal/led.h>
 #include <windows.h>
 
-void main(void)
+int main(void)
 {
     // Set front LEDs to shine green, red and then turned off in a repeating pattern.
     XSetCustomLED(XLED_GREEN, XLED_RED, XLED_OFF, XLED_OFF);
@@ -12,4 +12,6 @@ void main(void)
     while(1) {
         Sleep(1000);
     }
+    
+    return 0;
 }

--- a/samples/mesh/main.c
+++ b/samples/mesh/main.c
@@ -64,7 +64,7 @@ static void draw_arrays(unsigned int mode, int start, int count);
 static void draw_indices(void);
 
 /* Main program function */
-void main(void)
+int main(void)
 {
     uint32_t *p;
     int       i, status;
@@ -78,8 +78,7 @@ void main(void)
     if ((status = pb_init())) {
         debugPrint("pb_init Error %d\n", status);
         Sleep(2000);
-        XReboot();
-        return;
+        return 1;
     }
 
     pb_show_front_screen();
@@ -267,7 +266,7 @@ void main(void)
     MmFreeContiguousMemory(alloc_vertices);
     pb_show_debug_screen();
     pb_kill();
-    XReboot();
+    return 0;
 }
 
 /* Construct a viewport transformation matrix */

--- a/samples/sdl/main.c
+++ b/samples/sdl/main.c
@@ -364,18 +364,17 @@ void demo(void)
     SDL_VideoQuit();
 }
 
-void main(void)
+int main(void)
 {
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
     if (pb_init() != 0)
     {
         Sleep(2000);
-        XReboot();
-        return;
+        return 1;
     }
 
     pb_show_debug_screen();
     demo();
     pb_kill();
-    XReboot();
+    return 0;
 }

--- a/samples/sdl_ttf/main.c
+++ b/samples/sdl_ttf/main.c
@@ -10,7 +10,7 @@
 const extern int SCREEN_WIDTH;
 const extern int SCREEN_HEIGHT;
 
-void main() {
+int main(void) {
   int initialized_pbkit = -1;
   int initialized_SDL   = -1;
   int initialized_TTF   = -1;
@@ -136,5 +136,6 @@ cleanup:
   if (initialized_pbkit == 0) {
     pb_kill();
   }
-  return;
+  
+  return 0;
 }

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -45,7 +45,7 @@ static void set_attrib_pointer(unsigned int index, unsigned int format, unsigned
 static void draw_arrays(unsigned int mode, int start, int count);
 
 /* Main program function */
-void main(void)
+int main(void)
 {
     uint32_t *p;
     int       i, status;
@@ -58,8 +58,7 @@ void main(void)
     if ((status = pb_init())) {
         debugPrint("pb_init Error %d\n", status);
         Sleep(2000);
-        XReboot();
-        return;
+        return 1;
     }
 
     pb_show_front_screen();
@@ -162,7 +161,7 @@ void main(void)
     MmFreeContiguousMemory(alloc_vertices);
     pb_show_debug_screen();
     pb_kill();
-    HalReturnToFirmware(HalQuickRebootRoutine);
+    return 0;
 }
 
 /* Construct a viewport transformation matrix */

--- a/samples/winapi_filefind/main.c
+++ b/samples/winapi_filefind/main.c
@@ -22,13 +22,13 @@ int mount_drive_c ()
     return 0;
 }
 
-int main()
+int main(void)
 {
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
     int ret = pb_init();
     if (ret != 0) {
         Sleep(2000);
-        return -1;
+        return 1;
     }
 
     pb_show_debug_screen();
@@ -36,7 +36,7 @@ int main()
     // Mount C:
     ret = mount_drive_c();
     if (ret != 0) {
-        return ret;
+        return 1;
     }
 
     debugPrint("Content of C:\\\n");
@@ -50,7 +50,7 @@ int main()
     if (hFind == INVALID_HANDLE_VALUE) {
         debugPrint("FindFirstHandle() failed!\n");
         Sleep(5000);
-        return -1;
+        return 1;
     }
 
     do {
@@ -79,5 +79,5 @@ int main()
     }
 
     pb_kill();
-    XReboot();
+    return 0;
 }


### PR DESCRIPTION
This PR

1. changes samples to int main() from void
2. removes XReboot() from main as pdclib handles this after returning form main

Fixes #91 

Some of the samples were returning -1 on pb_init() failure, @JayFoxRox suggested returning 1 for failure so I've made that change, but that can be up for discussion if others disagree
