### PR TITLE
libc: Add extension to always define errno_t in errno.h

### DIFF
--- a/lib/xboxrt/libc_extensions/errno_ext_.h
+++ b/lib/xboxrt/libc_extensions/errno_ext_.h
@@ -1,0 +1,6 @@
+// Make sure errno_t is always defined when including errno.h, mimicking the
+// behavior of Win32 headers as expected by libc++.
+#ifndef _PDCLIB_ERRNO_T_DEFINED
+#define _PDCLIB_ERRNO_T_DEFINED _PDCLIB_ERRNO_T_DEFINED
+typedef int errno_t;
+#endif


### PR DESCRIPTION
This adds `errno_ext_.h`, which, with the help of the extension hook system, ensures that `errno_t` always defined when including `errno.h` (as expected by libc++).