### PR TITLE
libc: Add extension to provide _vsnprintf alias

### DIFF
--- a/lib/xboxrt/libc_extensions/stdio_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdio_ext_.h
@@ -1,0 +1,3 @@
+// Define required MS-specific aliases
+#define _vsnprintf vsnprintf
+


### PR DESCRIPTION
This adds `stdio_ext_.h`, which, with the help of the extension hook system, defines `_vsnprintf`, which is a Microsoft-specific alias for `vsnprintf`, and is required by libc++.