### PR TITLE
xboxrt: Add include-guard to string_ext_.h

### DIFF
--- a/lib/xboxrt/libc_extensions/string_ext_.h
+++ b/lib/xboxrt/libc_extensions/string_ext_.h
@@ -1,3 +1,6 @@
+#ifndef XBOXRT_STRING_EXT
+#define XBOXRT_STRING_EXT
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -11,4 +14,6 @@ static char *_strdup (const char *s)
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif


### PR DESCRIPTION
Including `string_ext_.h` results in compilation errors due to redefinition of `_strdup`.
Let's fix that.