### PR TITLE
fp20compiler: Refactor translation function

### DIFF
--- a/tools/fp20compiler/main.cpp
+++ b/tools/fp20compiler/main.cpp
@@ -58,6 +58,10 @@ static char* find_at_line_start(const char* haystack, const char* cursor,
 
 void translate(const char* s) {
 
+    // Keep a cursor for line-counting
+    const char* line_cursor = s;
+    unsigned int shader_line_number = 1;
+
     // Look for the first shader magic
     const char* shader_magic = find_at_line_start(s, s, "!!");
 
@@ -68,6 +72,14 @@ void translate(const char* s) {
 
     // Loop until we can't find a shader anymore
     while (shader_magic != NULL) {
+
+        // Move line cursor until we found the line of the shader magic
+        while (line_cursor < shader_magic) {
+            line_cursor = strchr(line_cursor, '\n');
+            assert(line_cursor != NULL);
+            line_cursor++;
+            shader_line_number++;
+        }
 
         // Find end of shader magic line (whitespace or comment)
         const char* shader_magic_end = shader_magic+2;
@@ -97,6 +109,9 @@ void translate(const char* s) {
         // Copy the magic
         size_t shader_magic_len = shader_magic_end - shader_magic;
         char* shader_magic_str = copy_string(shader_magic, shader_magic_len);
+
+        // Add information about shader section to output
+        printf("/* %s (line %u) */\n", shader_magic_str, shader_line_number);
 
         // Shader magic marks shader start
         const char* shader = shader_magic;


### PR DESCRIPTION
Refactor of #115 
Closes #113 

**Motivation:**

- Makes it easier to write shader assembly from scratch, without cgc (old code used cryptic end-of-shader markers).
- Allows us to more easily add more shaders (like adding further pipeline state shaders).
- Output is annotated, which will help when supporting more shaders per file.
- Allow us to more easily add per-shader things in the future (like error reporting, see #189).
- Line counting allows us to offset the existing line-in-shader `line_number` with the line-in-input `shader_line_number` (also good for error reporting).

**Changes from #115:**

- Correctly escapes comments and `\r` in shader magic line now (See https://github.com/XboxDev/nxdk/pull/115#issuecomment-543362108).
- Copies strings instead of temporarily modifying a global copy of the input buffer (See https://github.com/XboxDev/nxdk/pull/115#discussion_r336049290).
- Code moved into helper functions, which might also benefit vp20compiler (which I'd potentially like to merge with fp20compiler).


I hope this gets a quick review. I would like to have this merged as soon as possible, as I have a lot of work which depends on this (and a variation of this in #115 has been in review since May).