### PR TITLE
samples: Remove pb_* from samples not using pbkit

### DIFF
--- a/samples/hello++/main.cpp
+++ b/samples/hello++/main.cpp
@@ -1,5 +1,4 @@
 #include <hal/debug.h>
-#include <pbkit/pbkit.h>
 #include <hal/video.h>
 #include <windows.h>
 
@@ -15,14 +14,6 @@ public:
 int main(void) {
   XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
-  int ret = pb_init();
-  if (ret != 0) {
-    Sleep(2000);
-    return 1;
-  }
-
-  pb_show_debug_screen();
-
   NumberClass defaultFive;
   NumberClass customSix(6);
 
@@ -32,6 +23,5 @@ int main(void) {
     Sleep(2000);
   }
 
-  pb_kill();
   return 0;
 }

--- a/samples/hello/main.c
+++ b/samples/hello/main.c
@@ -1,29 +1,15 @@
 #include <hal/debug.h>
-#include <pbkit/pbkit.h>
 #include <hal/video.h>
-#include <hal/xbox.h>
 #include <windows.h>
-#include "stdio.h"
 
 int main(void)
 {
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
-
-    switch(pb_init())
-    {
-        case 0: break;
-        default:
-            Sleep(2000);
-            return 1;
-    }
-
-    pb_show_debug_screen();
 
     while(1) {
         debugPrint("Hello NXDK!\n");
         Sleep(2000);
     }
 
-    pb_kill();
     return 0;
 }

--- a/samples/httpd/main.c
+++ b/samples/httpd/main.c
@@ -10,7 +10,6 @@
 #include <hal/input.h>
 #include <hal/video.h>
 #include <hal/xbox.h>
-#include <pbkit/pbkit.h>
 #include <xboxkrnl/xboxkrnl.h>
 #include <debug.h>
 
@@ -69,9 +68,6 @@ int main(void)
 	sys_sem_free(&init_complete);
 
 	XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
-
-	pb_init();
-	pb_show_debug_screen();
 
 	g_pnetif = netif_add(&nforce_netif, &ipaddr, &netmask, &gw,
 	                     NULL, nforceif_init, ethernet_input);

--- a/samples/httpd_bsd/main.c
+++ b/samples/httpd_bsd/main.c
@@ -10,7 +10,6 @@
 #include <hal/video.h>
 #include <hal/input.h>
 #include <hal/xbox.h>
-#include <pbkit/pbkit.h>
 #include <xboxkrnl/xboxkrnl.h>
 #include <debug.h>
 
@@ -68,9 +67,6 @@ int main(void)
     tcpip_init(tcpip_init_done, &init_complete);
     sys_sem_wait(&init_complete);
     sys_sem_free(&init_complete);
-
-    pb_init();
-    pb_show_debug_screen();
 
     g_pnetif = netif_add(&nforce_netif, &ipaddr, &netmask, &gw,
                          NULL, nforceif_init, ethernet_input);

--- a/samples/sdl/main.c
+++ b/samples/sdl/main.c
@@ -10,8 +10,6 @@
   freely.
 */
 /* Simple program:  Create a native window and attach an SDL renderer */
-#include <hal/debug.h>
-#include <pbkit/pbkit.h>
 #include <hal/xbox.h>
 #include <hal/video.h>
 #include <windows.h>
@@ -24,7 +22,6 @@ static void printSDLErrorAndReboot(void)
     debugPrint("SDL_Error: %s\n", SDL_GetError());
     debugPrint("Rebooting in 5 seconds.\n");
     Sleep(5000);
-    pb_kill();
     XReboot();
 }
 
@@ -367,14 +364,7 @@ void demo(void)
 int main(void)
 {
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
-    if (pb_init() != 0)
-    {
-        Sleep(2000);
-        return 1;
-    }
 
-    pb_show_debug_screen();
     demo();
-    pb_kill();
     return 0;
 }

--- a/samples/sdl_ttf/main.c
+++ b/samples/sdl_ttf/main.c
@@ -1,6 +1,3 @@
-#include <hal/debug.h>
-#include <pbkit/pbkit.h>
-#include <hal/xbox.h>
 #include <hal/video.h>
 #include <SDL.h>
 #include <SDL_ttf.h>
@@ -11,7 +8,6 @@ const extern int SCREEN_WIDTH;
 const extern int SCREEN_HEIGHT;
 
 int main(void) {
-  int initialized_pbkit = -1;
   int initialized_SDL   = -1;
   int initialized_TTF   = -1;
   SDL_Window   *window   = NULL;
@@ -19,14 +15,6 @@ int main(void) {
   SDL_Texture  *texture  = NULL;
 
   XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
-
-  initialized_pbkit = pb_init();
-  if (initialized_pbkit != 0) {
-    debugPrint("pb_init() failed!");
-    Sleep(2000);
-    goto cleanup;
-  }
-  pb_show_debug_screen();
   
   initialized_SDL = SDL_VideoInit(NULL);
   if (initialized_SDL != 0) {
@@ -132,9 +120,6 @@ cleanup:
   }
   if (initialized_SDL == 0) {
     SDL_Quit();
-  }
-  if (initialized_pbkit == 0) {
-    pb_kill();
   }
   
   return 0;

--- a/samples/winapi_filefind/main.c
+++ b/samples/winapi_filefind/main.c
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <windows.h>
 #include <hal/debug.h>
-#include <pbkit/pbkit.h>
 #include <hal/video.h>
 #include <hal/xbox.h>
 
@@ -25,16 +24,9 @@ int mount_drive_c ()
 int main(void)
 {
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
-    int ret = pb_init();
-    if (ret != 0) {
-        Sleep(2000);
-        return 1;
-    }
-
-    pb_show_debug_screen();
 
     // Mount C:
-    ret = mount_drive_c();
+    int ret = mount_drive_c();
     if (ret != 0) {
         return 1;
     }
@@ -78,6 +70,5 @@ int main(void)
         Sleep(2000);
     }
 
-    pb_kill();
     return 0;
 }


### PR DESCRIPTION
Closes #212

Edit: Closes #90

Edit2: Copied from 212:
**H**owever, there's one exception why we might still need pbkit (or a minimal GPU driver):
I'm not sure if it can happen, but maybe the GPU can be left in a bad state when switching applications. That could have side-effects in RAM. To avoid that, we'd have to stop the GPU at startup. Currently, pb_init takes care of such things.
Someone should construct a test to see if this is an issue.