### PR TITLE
Implement rand_s

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -1685,6 +1685,12 @@ XBAPI VOID NTAPI XcUpdateCrypto
     OUT PCRYPTO_VECTOR pROMVector OPTIONAL
 );
 
+/**
+ * Updates the internal state of the SHA-1 algorithm by hashing some input data.
+ * @param pbSHAContext A pointer to the buffer holding the internal state of the algorithm
+ * @param pbInput A pointer to the bytes which are to get hashed
+ * @oaram dwInputLength The number of bytes in the buffer given in the pbInput parameter
+ */
 XBAPI VOID NTAPI XcSHAUpdate
 (
     IN OUT PUCHAR pbSHAContext,
@@ -1692,11 +1698,20 @@ XBAPI VOID NTAPI XcSHAUpdate
     IN ULONG dwInputLength
 );
 
+/**
+ * Initializes a buffer which will get used to generate a SHA-1 hash.
+ * @param pbSHAContext A pointer to a 116-byte buffer to be used as storage for the internal state of the algorithm
+ */
 XBAPI VOID NTAPI XcSHAInit
 (
     OUT PUCHAR pbSHAContext
 );
 
+/**
+ * Extracts the final SHA-1 hash from the buffer used to calculate the hash.
+ * @param pbSHAContext A pointer to the buffer used to hold the internal state of the algorithm
+ * @param pbDigest A pointer to a 20-byte buffer in which the hash will be stored
+ */
 XBAPI VOID NTAPI XcSHAFinal
 (
     IN PUCHAR pbSHAContext,

--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -2,6 +2,7 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/stat.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/strings.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/wchar.c \
+	$(NXDK_DIR)/lib/xboxrt/libc_extensions/stdlib_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/string_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_alldiv.s \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_allmul.s \

--- a/lib/xboxrt/libc_extensions/stdlib_ext_.c
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.c
@@ -1,0 +1,67 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <threads.h>
+#include <windows.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+once_flag init_flag = ONCE_FLAG_INIT;
+mtx_t rand_mutex;
+unsigned char rand_buffer[116];
+
+void update_rand_buffer (void)
+{
+    LARGE_INTEGER performanceCounter;
+    QueryPerformanceCounter(&performanceCounter);
+    XcSHAUpdate(rand_buffer, (PUCHAR)&performanceCounter, sizeof(performanceCounter));
+}
+
+void init_rand_s (void)
+{
+    mtx_init(&rand_mutex, mtx_plain);
+
+    XcSHAInit(rand_buffer);
+
+    // Hash the EEPROM
+    unsigned char eeprom_buffer[256];
+    ULONG bytes_read;
+    ULONG eeprom_type;
+    ExQueryNonVolatileSetting(0xFFFF, &eeprom_type, eeprom_buffer, 256, &bytes_read);
+    assert(bytes_read == 256);
+    XcSHAUpdate(rand_buffer, eeprom_buffer, 256);
+
+    update_rand_buffer();
+}
+
+// While rand_s is supposed to be cryptographically secure, this is not a very secure
+// implementation. The choice of SHA-1 as the algorithm is not ideal, but convenient,
+// as the kernel provides that for us. As the kernel doesn't help in collecting
+// entropy, though, we're very limited in that regard.
+int rand_s (unsigned int *randomValue)
+{
+    call_once(&init_flag, init_rand_s);
+
+    // Microsoft's CRT has special handling for invalid parameters, which
+    // nxdk doesn't have. We just act as if the invalid parameter handler
+    // allowed continuing execution and make sure to assert in debug builds.
+    assert(randomValue != NULL);
+    if (!randomValue) {
+        errno = EINVAL;
+        return EINVAL;
+    }
+
+    mtx_lock(&rand_mutex);
+
+    update_rand_buffer();
+
+    // Extract four bytes from the hash as our random value, and feed it back
+    // into the SHA algorithm
+    unsigned char output_buffer[20];
+    XcSHAFinal(rand_buffer, output_buffer);
+    *randomValue = *((unsigned int *)output_buffer);
+    XcSHAUpdate(rand_buffer, (PUCHAR)randomValue, sizeof(unsigned int));
+
+    mtx_unlock(&rand_mutex);
+
+    return 0;
+}

--- a/lib/xboxrt/libc_extensions/stdlib_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.h
@@ -1,0 +1,11 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _CRT_RAND_S
+int rand_s (unsigned int *randomValue);
+#endif
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This implements the rand_s function, which is a MS-specific function required by libc++. To keep the executable size small and the code simple, it uses the kernel's SHA-1functions which are fed with the EEPROM contents, the TSC and the tick counter (the latter two are also used each time a new random number is requested).
The global state is initialized once by using `call_once` and protected by a mutex. Each time a random number is requested the hash is updated by feeding in the TSC and the tick counter, then the first four bytes of the output hash are extracted and returned as the random number, while also being fed back into the hash.

Security could of course be improved by adding additional entropy sources.

This PR conflicts with #185 as they touch the same file.

The CI failure is unrelated and described in #218.