### PR TITLE
ci: Fix Travis on Windows by ignoring whether taskkill failed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -qq flex bison clang lld-6.0; fi
     - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then cmd /c\ .travis_win_deps.bat; fi
     # Build hang workaround (https://travis-ci.community/t/build-times-out-when-msys-was-installed/3498)
-    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then taskkill -IM "gpg-agent.exe" -F; fi
+    - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then taskkill -IM "gpg-agent.exe" -F || true; fi
 
 language: c
 


### PR DESCRIPTION
Apparently something changed in Travis CI, chocolatey or msys2, which results in `gpg-agent.exe` no longer being around. This makes `taskkill` fail, which fails our builds currently.
Since I'm not sure why this is the case and whether it's going to stay that way, I added `|| true` to make it no longer fail the build instead of removing it completely.

I expect this to get replaced by #168 anyway.