### PR TITLE
C++ Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -Wno-ignored-attributes -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
-NXDK_CXXFLAGS = $(NXDK_CFLAGS) -fno-threadsafe-statics
+NXDK_CXXFLAGS = $(NXDK_CFLAGS) -fno-threadsafe-statics -fno-rtti
 NXDK_LDFLAGS = -subsystem:windows -dll -entry:XboxCRTEntry \
                -stack:$(NXDK_STACKSIZE) -safeseh:no
 

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -Wno-ignored-attributes -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
-NXDK_CXXFLAGS = $(NXDK_CFLAGS)
+NXDK_CXXFLAGS = $(NXDK_CFLAGS) -fno-threadsafe-statics
 NXDK_LDFLAGS = -subsystem:windows -dll -entry:XboxCRTEntry \
                -stack:$(NXDK_STACKSIZE) -safeseh:no
 


### PR DESCRIPTION
This upstreams these two necessary changes from my libc++ branch:
* Thread-safe initialization of static variables gets disabled. C++11 by default guarantees that static variables will get initialized in a thread-safe way the first time they're encountered, but this relies on functions we do not provide yet. This should be easy to tackle properly after adding C++11 thread support.
* RTTI generation gets disabled. Generating RTTI causes references to internal data structures that aren't in place yet. This can get re-enabled once we implement these (which will happen together with exception support).

Both changes are necessary to avoid linker errors when using libc++.