### PR TITLE
vcruntime exception and type_info classes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -isystem $(NXDK_DIR)/lib/pdclib/include \
                -I$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
                -I$(NXDK_DIR)/lib/winapi \
+               -I$(NXDK_DIR)/lib/xboxrt/vcruntime \
                -Wno-ignored-attributes -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt

--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -15,4 +15,5 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_aullshr.s \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_fltused.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/check_stack.c \
-	$(NXDK_DIR)/lib/xboxrt/c_runtime/chkstk.s
+	$(NXDK_DIR)/lib/xboxrt/c_runtime/chkstk.s \
+	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_exception.cpp

--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -16,4 +16,5 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_fltused.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/check_stack.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/chkstk.s \
-	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_exception.cpp
+	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_exception.cpp \
+	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp

--- a/lib/xboxrt/vcruntime/vcruntime_exception.cpp
+++ b/lib/xboxrt/vcruntime/vcruntime_exception.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2019 Stefan Schmidt
+ *
+ * Licensed under the MIT License
+ */
+
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <vcruntime_exception.h>
+
+extern "C"
+{
+    void __cdecl __std_exception_copy (const __std_exception_data *_From, __std_exception_data *_To)
+    {
+        if (_From->_DoFree) {
+            char *str_copy = strdup(_From->_What);
+            assert(str_copy != NULL);
+            if (!str_copy) {
+                return;
+            }
+            _To->_What = str_copy;
+        } else {
+            _To->_What = _From->_What;
+        }
+
+        _To->_DoFree = _From->_DoFree;
+    }
+
+    void __cdecl __std_exception_destroy (__std_exception_data *_Data)
+    {
+        if (_Data->_DoFree) {
+            free(const_cast<char *>(_Data->_What));
+        }
+
+        _Data->_DoFree = false;
+        _Data->_What = NULL;
+    }
+}

--- a/lib/xboxrt/vcruntime/vcruntime_exception.h
+++ b/lib/xboxrt/vcruntime/vcruntime_exception.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2019 Stefan Schmidt
+ *
+ * Licensed under the MIT License
+ */
+
+#ifndef __VCRUNTIME_EXCEPTION_H__
+#define __VCRUNTIME_EXCEPTION_H__
+
+struct __std_exception_data
+{
+    const char *_What;
+    bool _DoFree;
+};
+
+extern "C"
+{
+    void __cdecl __std_exception_copy (const __std_exception_data *_From, __std_exception_data *_To);
+    void __cdecl __std_exception_destroy (__std_exception_data *_Data);
+}
+
+namespace std
+{
+    class exception
+    {
+    public:
+        exception () noexcept : _Data{NULL, false}
+        {
+        }
+
+        explicit exception (const char *const _Message) noexcept
+        {
+            const __std_exception_data data = {_Message, true};
+            __std_exception_copy(&data, &this->_Data);
+        }
+
+        // MS-specific extension to avoid string allocation
+        explicit exception (const char *const _Message, int) noexcept : _Data{_Message, false}
+        {
+        }
+
+        exception (const exception &rhs) noexcept
+        {
+            __std_exception_copy(&rhs._Data, &this->_Data);
+        }
+
+        exception &operator= (const exception &rhs) noexcept
+        {
+            if (this != &rhs) {
+                __std_exception_destroy(&this->_Data);
+                __std_exception_copy(&rhs._Data, &this->_Data);
+            }
+
+            return *this;
+        }
+
+        virtual ~exception () noexcept
+        {
+            __std_exception_destroy(&this->_Data);
+        }
+
+        virtual const char *what () const noexcept
+        {
+            return this->_Data._What ? this->_Data._What : "Unknown exception";
+        }
+
+    private:
+        __std_exception_data _Data;
+    };
+
+    class bad_exception : public exception
+    {
+    public:
+        bad_exception () noexcept : exception("bad exception", 0)
+        {
+        }
+    };
+
+    class bad_alloc : public exception
+    {
+    public:
+        bad_alloc () noexcept : exception("bad allocation", 0)
+        {
+        }
+    private:
+        friend class bad_array_new_length;
+
+        bad_alloc (const char *const _Message) noexcept : exception(_Message, 0)
+        {
+        }
+    };
+
+    class bad_array_new_length : public bad_alloc
+    {
+    public:
+        bad_array_new_length () noexcept : bad_alloc("bad exception")
+        {
+        }
+    };
+}
+
+#endif

--- a/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp
+++ b/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2019 Stefan Schmidt
+ *
+ * Licensed under the MIT License
+ */
+
+#include <string.h>
+#include <vcruntime_typeinfo.h>
+
+extern "C"
+{
+    int __cdecl __std_type_info_compare (const __std_type_info_data *const lhs, const __std_type_info_data *const rhs)
+    {
+        if (lhs == rhs) {
+            return 0;
+        }
+
+        return strcmp(lhs->_DecoratedName + 1, rhs->_DecoratedName + 1);
+    }
+
+    size_t __cdecl __std_type_info_hash (const __std_type_info_data *const data)
+    {
+        // Computes the FNV-1a hash of the mangled name
+        constexpr size_t fnv_offset_basis = 0x811C9DC5;
+        constexpr size_t fnv_prime = 0x1000193;
+
+        size_t hash = fnv_offset_basis;
+        for (auto *it = reinterpret_cast<const unsigned char *>(data->_DecoratedName + 1); *it != '\0'; ++it) {
+            hash ^= static_cast<size_t>(*it);
+            hash *= fnv_prime;
+        }
+
+        return hash;
+    }
+}

--- a/lib/xboxrt/vcruntime/vcruntime_typeinfo.h
+++ b/lib/xboxrt/vcruntime/vcruntime_typeinfo.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2019 Stefan Schmidt
+ *
+ * Licensed under the MIT License
+ */
+
+#ifndef __VCRUNTIME_TYPEINFO_H__
+#define __VCRUNTIME_TYPEINFO_H__
+
+#include <assert.h>
+#include <vcruntime_exception.h>
+
+struct __std_type_info_data
+{
+    char const *_UndecoratedName;
+    char const _DecoratedName[1];
+};
+
+extern "C"
+{
+    int __cdecl __std_type_info_compare (const __std_type_info_data *const lhs, const __std_type_info_data *const rhs);
+    size_t __cdecl __std_type_info_hash (const __std_type_info_data *const data);
+}
+
+class type_info
+{
+public:
+    virtual ~type_info ();
+
+    const char *name () const noexcept
+    {
+        // FIXME: return human-readable name
+        assert(false);
+        return NULL;
+    }
+
+    const char *raw_name () const noexcept
+    {
+        return this->_Data._DecoratedName;
+    }
+
+    bool before (const type_info &rhs) const noexcept
+    {
+        return __std_type_info_compare(&this->_Data, &rhs._Data) < 0;
+    }
+
+    size_t hash_code () const noexcept
+    {
+        return __std_type_info_hash(&this->_Data);
+    }
+
+    bool operator== (const type_info &rhs) const noexcept
+    {
+        return __std_type_info_compare(&this->_Data, &rhs._Data) == 0;
+    }
+
+    bool operator!= (const type_info &rhs) const noexcept
+    {
+        return !operator==(rhs);
+    }
+
+private:
+    type_info (type_info const &) = delete;
+    type_info &operator= (type_info const &) = delete;
+
+    mutable __std_type_info_data _Data;
+};
+
+namespace std
+{
+    using ::type_info;
+
+    class bad_cast : public exception
+    {
+    public:
+        bad_cast () noexcept : exception("bad cast", 0)
+        {
+        }
+    };
+
+    class bad_typeid : public exception
+    {
+    public:
+        bad_typeid () noexcept : exception("bad typeid", 0)
+        {
+        }
+    };
+}
+
+#endif


### PR DESCRIPTION
Another PR with changes from my libc++ branch.

On Win32, `std::exception` (and a few classes inheriting from that) and `std::type_info` are actually implement as part of vcruntime, and not the C++ standard library. libc++ also relies on these vcruntime implementations, so this implements the required classes and functions.

I copied the behavior of MS's functions as good as I could and copied their naming of private member variables and functions. I also added one MS-specific extension, the `(const char *const, int)` constructor for `std::exception` - this constructor gets a second parameter, which is actually ignored, and only used to overload the constructor in order to be able to avoid string buffer allocations when creating an exception object, which saves memory and allows exceptions to be thrown even when out of memory.

The exception object itself is rather trivial, `*_What` points to the exception message which gets returned by `what()`, and `_DoFree` specifies whether a buffer was allocated to store the exception message. If a buffer was allocated, a new one gets allocated and the content copied when the exception is copied, and the buffer is released upon destruction of the object.

`type_info` is also as close to the MS-version as possible, but with the shortcoming that `name()`, which is supposed to return a string containing the demangled name of the type, isn't implemented yet. This will get resolved when proper RTTI support will be added.