### PR TITLE
libc: Add _snprintf alias

### DIFF
--- a/lib/xboxrt/libc_extensions/stdio_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdio_ext_.h
@@ -1,3 +1,3 @@
 // Define required MS-specific aliases
 #define _vsnprintf vsnprintf
-
+#define _snprintf snprintf


### PR DESCRIPTION
Tiny change to add the MS-specific `_snprintf` alias. This requirement came up when I experimented with TinyXML2.