### PR TITLE
pbkit: Avoid redundant code for targeting draw-buffers

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1825,10 +1825,10 @@ DWORD *pb_back_buffer(void)
 
 DWORD *pb_extra_buffer(int index_buffer)
 {
-    if (index_buffer>pb_ExtraBuffersCount)
+    if (index_buffer>=pb_ExtraBuffersCount)
     {
-        debugPrint("pb_target_extra_buffer: buffer index out of range\n");
-        return pb_back_buffer();
+        debugPrint("pb_extra_buffer: buffer index out of range\n");
+        return NULL;
     }
 
     return (DWORD *)pb_EXAddr[index_buffer];

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1823,15 +1823,15 @@ DWORD *pb_back_buffer(void)
     return (DWORD *)pb_FBAddr[pb_back_index];
 }
 
-DWORD *pb_extra_buffer(int index_buffer)
+DWORD *pb_extra_buffer(int buffer_index)
 {
-    if (index_buffer>=pb_ExtraBuffersCount)
+    if (buffer_index>=pb_ExtraBuffersCount)
     {
         debugPrint("pb_extra_buffer: buffer index out of range\n");
         return NULL;
     }
 
-    return (DWORD *)pb_EXAddr[index_buffer];
+    return (DWORD *)pb_EXAddr[buffer_index];
 }
 
 
@@ -1954,15 +1954,15 @@ void pb_target_back_buffer(void)
     set_draw_buffer(pb_FBAddr[pb_back_index]&0x03FFFFFF);
 }
 
-void pb_target_extra_buffer(int index_buffer)
+void pb_target_extra_buffer(int buffer_index)
 {
-    if (index_buffer>=pb_ExtraBuffersCount)
+    if (buffer_index>=pb_ExtraBuffersCount)
     {
         debugPrint("pb_target_extra_buffer: buffer index out of range\n");
         return;
     }
     
-    set_draw_buffer(pb_EXAddr[index_buffer]&0x03FFFFFF);
+    set_draw_buffer(pb_EXAddr[buffer_index]&0x03FFFFFF);
 }
 
 DWORD pb_get_vbl_counter(void)


### PR DESCRIPTION
The functions  `pb_target_back_buffer` and `pb_target_extra_buffer` do exactly the same thing, just for different buffers. GL would call these `DrawBuffer`, so I've factored out this code under that name.

The diff between the original functions was this:

```diff
@@ -1,4 +1,4 @@
-void pb_target_back_buffer(void)
+void pb_target_extra_buffer(int index_buffer)
 {
     DWORD           *p;
 
@@ -13,6 +13,12 @@ void pb_target_back_buffer(void)
 
     int         flag;
     int         depth_stencil;
+
+    if (index_buffer>=pb_ExtraBuffersCount)
+    {
+        debugPrint("pb_target_extra_buffer: buffer index out of range\n");
+        return;
+    }
     
     width=pb_FrameBuffersWidth;
     height=pb_FrameBuffersHeight;
@@ -20,7 +26,7 @@ void pb_target_back_buffer(void)
     pitch_depth_stencil=pb_DepthStencilPitch;
 
     //DMA channel 9 is used by GPU in order to render pixels
-    dma_addr=pb_FBAddr[pb_back_index]&0x03FFFFFF;
+    dma_addr=pb_EXAddr[index_buffer]&0x03FFFFFF;
     dma_limit=height*pitch-1; //(last byte)
     dma_flags=DMA_CLASS_3D|0x0000B000;
     dma_addr|=3;
@@ -39,11 +45,11 @@ void pb_target_back_buffer(void)
     pb_end(p);
 
     //DMA channel 11 is used by GPU in order to bitblt images
-    dma_addr=pb_FBAddr[pb_back_index]&0x03FFFFFF;
+    dma_addr=pb_EXAddr[index_buffer]&0x03FFFFFF;
     dma_limit=height*pitch-1; //(last byte)
     dma_flags=DMA_CLASS_3D|0x0000B000;
     dma_addr|=3;
-    
+
     p=pb_begin();
     p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0);
     p=pb_push2(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,NV_PRAMIN+(pb_DmaChID11Inst<<4)+0x08,dma_addr); //set params addr,data
```

*(some more whitespace changes followed)*

The error check was kept in `pb_target_extra_buffer` the name of the variable was turned into a parameter.

---

While I was doing this, I noticed an off-by-one in `pb_extra_buffer` and also improved the error message and removed the unexpected return value.

While fixing that, I then noticed the weird argument name.
"Index buffers" are a standard term that's also used in D3D (in GL it's "element buffers"). However, the argument does not get an index buffer (buffer containing indices for vertices), but a buffer index (index of a buffer). I've renamed the argument to avoid ambiguity.

---

All of the changes in this PR should be safe. I've recompiled the triangle sample, which still worked.
We don't have any examples for extra buffers, so that wasn't tested.