### PR TITLE
fp20compiler: Report nvparse errors

### DIFF
--- a/tools/fp20compiler/main.cpp
+++ b/tools/fp20compiler/main.cpp
@@ -136,6 +136,9 @@ void translate(const char* s) {
         size_t shader_len = shader_end - shader;
         char* shader_str = copy_string(shader, shader_len);
 
+        // Prepare error reporting
+        errors.set_line_number_offset(shader_line_number-1);
+
         // Process shader
         if (is_ts10(shader_str)) {
             ts10_init(shader_str);
@@ -145,6 +148,16 @@ void translate(const char* s) {
             rc10_parse();
         } else {
             fprintf(stderr, "unknown shader type \"%s\"\n", shader_magic_str);
+        }
+
+        // Show all errors
+        int num_errors = errors.get_num_errors();
+        if (num_errors > 0) {
+            fprintf(stderr, "errors in shader \"%s\" (line %d):\n",
+                    shader_magic_str, shader_line_number);
+            for(int i = 0; i < num_errors; i++) {
+                fprintf(stderr, "error: %s\n", errors.get_errors()[i]);
+            }
         }
 
         // Free temporary string copies

--- a/tools/fp20compiler/main.cpp
+++ b/tools/fp20compiler/main.cpp
@@ -56,7 +56,8 @@ static char* find_at_line_start(const char* haystack, const char* cursor,
     return NULL;
 }
 
-void translate(const char* s) {
+int translate(const char* s) {
+    int ret = 0;
 
     // Keep a cursor for line-counting
     const char* line_cursor = s;
@@ -68,6 +69,7 @@ void translate(const char* s) {
     // Warn the user if we couldn't find any shader at all
     if (shader_magic == NULL) {
         fprintf(stderr, "no shaders found\n");
+        ret = 1;
     }
 
     // Loop until we can't find a shader anymore
@@ -158,6 +160,7 @@ void translate(const char* s) {
             for(int i = 0; i < num_errors; i++) {
                 fprintf(stderr, "error: %s\n", errors.get_errors()[i]);
             }
+            ret = 1;
         }
 
         // Free temporary string copies
@@ -167,6 +170,8 @@ void translate(const char* s) {
         // Continue with next shader by jumping to its magic
         shader_magic = next_shader_magic;
     }
+
+    return ret;
 }
 
 int main(int argc, char** argv) {
@@ -193,10 +198,10 @@ int main(int argc, char** argv) {
     fread(buffer, size, 1, fh);
     buffer[size] = '\0';
 
-    translate(buffer);
+    int ret = translate(buffer);
 
     fclose(fh);
     free(buffer);
 
-    return 0;
+    return ret;
 }

--- a/tools/fp20compiler/nvparse_errors.cpp
+++ b/tools/fp20compiler/nvparse_errors.cpp
@@ -9,6 +9,7 @@
 nvparse_errors::nvparse_errors()
 {
 	num_errors = 0;
+	line_number_offset = 0;
 	reset();
 }
 
@@ -36,7 +37,7 @@ void nvparse_errors::set(const char * e)
 void nvparse_errors::set(const char * e, int line_number)
 {
 	char buff[256];
-	sprintf(buff, "error on line %d: %s", line_number, e);
+	sprintf(buff, "line %d: %s", line_number_offset + line_number, e);
 	if(num_errors < NVPARSE_MAX_ERRORS)
 		elist[num_errors++] = strdup(buff);
 }

--- a/tools/fp20compiler/nvparse_errors.h
+++ b/tools/fp20compiler/nvparse_errors.h
@@ -16,10 +16,12 @@ public:
 	void set(const char * e);
 	void set(const char * e, int line_number);
 	char * const * const get_errors();
-    inline int  get_num_errors() { return num_errors; }
+	inline int  get_num_errors() { return num_errors; }
+	void set_line_number_offset(int offset) { line_number_offset = offset; }
 private:
-        char* elist [NVPARSE_MAX_ERRORS+1];
+	char* elist [NVPARSE_MAX_ERRORS+1];
 	int num_errors;
+	int line_number_offset;
 };
 
 #endif

--- a/tools/fp20compiler/rc1.0_final.cpp
+++ b/tools/fp20compiler/rc1.0_final.cpp
@@ -113,7 +113,7 @@ void FinalCombinerStruct::Validate()
 
 static void GenerateFinalInput(char var, MappedRegisterStruct reg) {
     int num = (var >= 'E') ? 1 : 0;
-    printf("MASK(NV097_SET_COMBINER_SPECULAR_FOG_CW%d_%c_SOURCE, 0x%x)", num, var, reg.reg.bits.name);
+    printf("MASK(NV097_SET_COMBINER_SPECULAR_FOG_CW%d_%c_SOURCE, %s)", num, var, GetRegisterNameString(reg.reg.bits.name));
     printf(" | MASK(NV097_SET_COMBINER_SPECULAR_FOG_CW%d_%c_ALPHA, %d)", num, var,
             reg.reg.bits.channel == RCP_ALPHA);
     printf(" | MASK(NV097_SET_COMBINER_SPECULAR_FOG_CW%d_%c_INVERSE, %d)", num, var,

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -254,7 +254,7 @@ void GeneralFunctionStruct::Validate(int stage, int portion)
 
 static void GenerateInput(int portion, char variable, MappedRegisterStruct reg) {
     const char* portion_s = portion == RCP_RGB ? "COLOR" : "ALPHA";
-    printf("MASK(NV097_SET_COMBINER_%s_ICW_%c_SOURCE, 0x%x)", portion_s, variable, reg.reg.bits.name);
+    printf("MASK(NV097_SET_COMBINER_%s_ICW_%c_SOURCE, %s)", portion_s, variable, GetRegisterNameString(reg.reg.bits.name));
     printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_ALPHA, %d)", portion_s, variable,
             reg.reg.bits.channel == RCP_ALPHA);
     printf(" | MASK(NV097_SET_COMBINER_%s_ICW_%c_MAP, 0x%x)", portion_s, variable, reg.map);
@@ -306,9 +306,9 @@ void GeneralFunctionStruct::Invoke(int stage, int portion, BiasScaleEnum bs)
     //     MAP_CHANNEL(op[1].reg[2].reg.bits.channel));
 
     printf("pb_push1(p, NV097_SET_COMBINER_%s_OCW + %d * 4,\n", portion_s, stage);
-    printf("    MASK(NV097_SET_COMBINER_%s_OCW_AB_DST, 0x%x)\n", portion_s, op[0].reg[0].reg.bits.name);
-    printf("    | MASK(NV097_SET_COMBINER_%s_OCW_CD_DST, 0x%x)\n", portion_s, op[1].reg[0].reg.bits.name);
-    printf("    | MASK(NV097_SET_COMBINER_%s_OCW_SUM_DST, 0x%x)\n", portion_s, op[2].reg[0].reg.bits.name);
+    printf("    MASK(NV097_SET_COMBINER_%s_OCW_AB_DST, %s)\n", portion_s, GetRegisterNameString(op[0].reg[0].reg.bits.name));
+    printf("    | MASK(NV097_SET_COMBINER_%s_OCW_CD_DST, %s)\n", portion_s, GetRegisterNameString(op[1].reg[0].reg.bits.name));
+    printf("    | MASK(NV097_SET_COMBINER_%s_OCW_SUM_DST, %s)\n", portion_s, GetRegisterNameString(op[2].reg[0].reg.bits.name));
     printf("    | MASK(NV097_SET_COMBINER_%s_OCW_MUX_ENABLE, %d)\n", portion_s, (op[2].op == RCP_MUX));
 
     const char* scale_s = NULL;

--- a/tools/fp20compiler/rc1.0_register.h
+++ b/tools/fp20compiler/rc1.0_register.h
@@ -8,7 +8,9 @@
 #endif
 
 
-#include <stdlib.h>
+#include <cstdlib>
+#include <cstdio>
+#include <cassert>
 
 
 #define RCP_NUM_GENERAL_COMBINERS 8
@@ -18,24 +20,69 @@
 #define RCP_BLUE  2
 #define RCP_NONE  3
 
+enum RegisterName {
+    REG_ZERO,
+    REG_CONSTANT_COLOR0,
+    REG_CONSTANT_COLOR1,
+    REG_FOG,
+    REG_PRIMARY_COLOR,
+    REG_SECONDARY_COLOR,
+    REG_TEXTURE0,
+    REG_TEXTURE1,
+    REG_TEXTURE2,
+    REG_TEXTURE3,
+    REG_SPARE0,
+    REG_SPARE1,
+    REG_SPARE0_PLUS_SECONDARY_COLOR,
+    REG_E_TIMES_F,
+    REG_DISCARD,
+    REG_ONE
+};
 
-#define REG_ZERO            0x0
-#define REG_CONSTANT_COLOR0 0x1
-#define REG_CONSTANT_COLOR1 0x2
-#define REG_FOG             0x3
-#define REG_PRIMARY_COLOR   0x4
-#define REG_SECONDARY_COLOR 0x5
-#define REG_TEXTURE0        0x8
-#define REG_TEXTURE1        0x9
-#define REG_TEXTURE2        0xa
-#define REG_TEXTURE3        0xb
-#define REG_SPARE0          0xc
-#define REG_SPARE1          0xd
-#define REG_SPARE0_PLUS_SECONDARY_COLOR 0xe
-#define REG_E_TIMES_F       0xf
-
-#define REG_DISCARD         0x0
-#define REG_ONE             0x12
+#ifdef __GNUC__
+__attribute__ ((unused))
+#endif
+static const char* GetRegisterNameString(unsigned int reg_name) {
+    switch(reg_name) {
+    case REG_ZERO:
+        return "0x0";
+    case REG_CONSTANT_COLOR0:
+        return "0x1";
+    case REG_CONSTANT_COLOR1:
+        return "0x2";
+    case REG_FOG:
+        return "0x3";
+    case REG_PRIMARY_COLOR:
+        return "0x4";
+    case REG_SECONDARY_COLOR:
+        return "0x5";
+    case REG_TEXTURE0:
+        return "0x8";
+    case REG_TEXTURE1:
+        return "0x9";
+    case REG_TEXTURE2:
+        return "0xa";
+    case REG_TEXTURE3:
+        return "0xb";
+    case REG_SPARE0:
+        return "0xc";
+    case REG_SPARE1:
+        return "0xd";
+    case REG_SPARE0_PLUS_SECONDARY_COLOR:
+        return "0xe";
+    case REG_E_TIMES_F:
+        return "0xf";
+    case REG_DISCARD:
+        return "0x0";
+    case REG_ONE:
+        return "0x12";
+    default:
+        fprintf(stderr, "unknown register name index %d\n", reg_name);
+        assert(false);
+        break;
+    }
+    return "UNKNOWN";
+}
 
 #define BIAS_NONE 0
 #define BIAS_BY_NEGATIVE_ONE_HALF 1
@@ -57,7 +104,7 @@
 typedef union _RegisterEnum {
   struct {
 #if BYTE_ORDER != BIG_ENDIAN
-    unsigned int name          :16; // OpenGL enum for register
+    unsigned int name          :16; // RegisterName enum for register
     unsigned int channel       : 2; // RCP_RGB, RCP_ALPHA, etc
     unsigned int readOnly      : 1; // true or false
     unsigned int finalOnly     : 1; // true or false
@@ -67,7 +114,7 @@ typedef union _RegisterEnum {
     unsigned int finalOnly     : 1; // true or false
     unsigned int readOnly      : 1; // true or false
     unsigned int channel       : 2; // RCP_RGB, RCP_ALPHA, RCP_BLUE, RCP_NONE
-    unsigned int name          :16; // OpenGL enum for register
+    unsigned int name          :16; // RegisterName enum for register
 #endif
   } bits;
   unsigned int word;


### PR DESCRIPTION
**Avoid sharing of token for ZERO and DISCARD register**

We currently don't report fp20compiler (nvparse) errors.
However, if we enable error reporting, we'd always get `error: reading from discard` and `error: invalid input register for final rgb`. These errors result from modifcations for Xbox.

nvparse uses `RCP_*` structs to describe details of a hardware register (register-number, read-only, ...). The original GL code in nvparse used different register numbers (`GL_ZERO=0` and `GL_DISCARD=0x8530`) for `REG_ZERO` and `REG_DISCARD` (used in the respective `RCP_*` struct).
In fp20compiler, the `GL_` constants have been replaced by `REG_ZERO=0` and `REG_DISCARD=0` (so `RCP_ZERO` and `RCP_DISCARD` share the same `REG_*` register-number).

This was done because Xbox hardware register 0 discards writes and reads as 0.
This also simplifies the emitter as the `RCP_` register-number can be emitted into pbkit code.

However, the nvparse code checks for errors using only the register-number portion (not the entire RCP struct). So it doesn't differentiate `REG_DISCARD` (using `RCP_DISCARD`) and `REG_ZERO` (using `RCP_ZERO`). This causes errors because `RCP_DISCARD` is not allowed to be read, and `RCP_ZERO` is not allowed to be written.

To fix this, we separate `REG_ZERO` and `REG_DISCARD` by assigning arbitrary numbers. We only map them back to hardware registers when emitting code for pbkit.
I decided to make an array of register names, which is also good for when we want to use pbkit constants in the emitted code for readability.

*There's also other ways to fix this, by modifying all checks so they look for  `RCP_ZERO` and `RCP_DISCARD` (which can be differentiated by read-only flag) - however, that would require many changes in the original nvparse code. It also could have other side-effects. So I opted to modify our custom emitter.*

**Report compilation errors (the other commits)**

Now that we fixed the mentioned errors in the previous commit, we can enable error reporting.

I also extended it so it will print the absolute line number if the user has more than 1 shader section in their input file (using some offset setter).

I'll do more improvements to nvparse error checking / reporting in a follow-up PR.