### PR TITLE
libc: Provide _sys_nerr macro via stdlib.h

### DIFF
--- a/lib/xboxrt/libc_extensions/stdlib_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.h
@@ -17,6 +17,10 @@ typedef void (__cdecl *_purecall_handler)(void);
 _purecall_handler __cdecl _get_purecall_handler (void);
 _purecall_handler __cdecl _set_purecall_handler (_purecall_handler function);
 
+// Win32 extension providing the highest valid errno number
+// https://docs.microsoft.com/en-us/cpp/c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr?view=vs-2019
+#define _sys_nerr _PDCLIB_ERRNO_MAX
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Win32 provides a macro called `_sys_nerr` to get the highest valid errno value. libc++ requires this, so this commit provides it.