### PR TITLE
libc: Add stubs for strtod(), strtof(), strtold()

### DIFF
--- a/lib/xboxrt/libc_extensions/stdlib_ext_.c
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.c
@@ -65,3 +65,23 @@ int rand_s (unsigned int *randomValue)
 
     return 0;
 }
+
+
+double strtod( const char * _PDCLIB_restrict nptr, char * * _PDCLIB_restrict endptr )
+{
+    assert(0);
+    return 0.0;
+}
+
+float strtof( const char * _PDCLIB_restrict nptr, char * * _PDCLIB_restrict endptr )
+{
+    assert(0);
+    return 0.0;
+}
+
+long double strtold( const char * _PDCLIB_restrict nptr, char * * _PDCLIB_restrict endptr )
+{
+    assert(0);
+    return 0.0;
+}
+


### PR DESCRIPTION
libc++ depends on the presence of these three functions. PDCLib doesn't provide them yet, so this provides stubs until the functionality is in place. I added asserts to catch calls to these functions instead of silently returning invalid results, but these functions were never called by libc++ itself during my tests.