### PR TITLE
libc: Provide isascii() and required macros via ctype.h

### DIFF
--- a/lib/xboxrt/libc_extensions/ctype_ext_.h
+++ b/lib/xboxrt/libc_extensions/ctype_ext_.h
@@ -1,0 +1,24 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// (obsolete) POSIX function, but required by libc++
+static int isascii (int c)
+{
+    return c >= 0 && c < 128;
+}
+
+// Defined as on Win32
+#define _UPPER   0x01
+#define _LOWER   0x02
+#define _DIGIT   0x04
+#define _SPACE   0x08
+#define _PUNCT   0x10
+#define _CONTROL 0x20
+#define _BLANK   0x40
+#define _HEX     0x80
+#define _ALPHA   (0x0100 | _UPPER | _LOWER)
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This adds the (obsolete but required by libc++) function `isascii()`, as well as some macros libc++ expects `ctype.h` to provide. The actual values of these defines were retrieved by running tests in VS 2019.