### PR TITLE
wchar stubs & PDCLib update

### DIFF
--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -2,6 +2,7 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/stat.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/strings.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/wchar.c \
+	$(NXDK_DIR)/lib/xboxrt/libc_extensions/wchar_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/stdlib_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/string_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_alldiv.s \

--- a/lib/xboxrt/libc_extensions/wchar.c
+++ b/lib/xboxrt/libc_extensions/wchar.c
@@ -1,4 +1,5 @@
 #include "wchar.h"
+#include <assert.h>
 
 wchar_t * wcscat( wchar_t * XBOXRT_RESTRICT s1, const wchar_t * XBOXRT_RESTRICT s2 )
 {
@@ -322,4 +323,98 @@ wchar_t * wmemmove( wchar_t * dest, const wchar_t * src, size_t n )
         }
     }
     return rv;
+}
+
+wchar_t * wmemset(wchar_t *wcs, wchar_t wc, size_t n)
+{
+    wchar_t * p = wcs;
+    while ( n-- )
+    {
+        *p++ = wc;
+    }
+    return wcs;
+}
+
+size_t wcrtomb (char *mbchar, wchar_t wchar, mbstate_t *mbstate)
+{
+    assert(0);
+    return 0;
+}
+
+size_t mbrtowc (wchar_t *wchar, const char *mbchar, size_t count, mbstate_t *mbstate)
+{
+    assert(0);
+    return 0;
+}
+
+double wcstod(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr)
+{
+    assert(0);
+    return 0.0;
+}
+
+float wcstof(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr)
+{
+    assert(0);
+    return 0.0;
+}
+
+long double wcstold(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr)
+{
+    assert(0);
+    return 0.0;
+}
+
+long wcstol(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr, int base)
+{
+    assert(0);
+    return 0;
+}
+
+long long wcstoll(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr, int base)
+{
+    assert(0);
+    return 0;
+}
+
+unsigned long wcstoul(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr, int base)
+{
+    assert(0);
+    return 0;
+}
+
+unsigned long long wcstoull(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr, int base)
+{
+    assert(0);
+    return 0;
+}
+
+size_t mbrlen(const char *s, size_t n, mbstate_t *ps)
+{
+    assert(0);
+    return 0;
+}
+
+wint_t btowc(int c)
+{
+    assert(0);
+    return 0;
+}
+
+size_t mbsrtowcs(wchar_t *dest, const char **src, size_t len, mbstate_t *ps)
+{
+    assert(0);
+    return 0;
+}
+
+int wctob(wint_t c)
+{
+    assert(0);
+    return 0;
+}
+
+int wcrtomb_s(size_t * XBOXRT_RESTRICT retval, char * XBOXRT_RESTRICT s, size_t ssz, wchar_t wc, mbstate_t * XBOXRT_RESTRICT ps)
+{
+    assert(0);
+    return 0;
 }

--- a/lib/xboxrt/libc_extensions/wchar.h
+++ b/lib/xboxrt/libc_extensions/wchar.h
@@ -28,6 +28,8 @@ typedef struct XBOXRT_mbstate {
 
 typedef XBOXRT_mbstate_t mbstate_t;
 
+struct tm;
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/lib/xboxrt/libc_extensions/wchar.h
+++ b/lib/xboxrt/libc_extensions/wchar.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <wctype.h>
 
 #ifdef __cplusplus
     #define XBOXRT_RESTRICT __restrict
@@ -54,6 +55,19 @@ size_t wcslen( const wchar_t * s );
 int mbsinit( const mbstate_t * ps );
 size_t mbrtowc( wchar_t * XBOXRT_RESTRICT pwc, const char * XBOXRT_RESTRICT s, size_t n, mbstate_t * XBOXRT_RESTRICT ps );
 size_t wcrtomb( char * XBOXRT_RESTRICT s, wchar_t wc, mbstate_t * XBOXRT_RESTRICT ps );
+wchar_t *wmemset(wchar_t *wcs, wchar_t wc, size_t n);
+double wcstod(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr);
+float wcstof(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr);
+long double wcstold(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr);
+long wcstol(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr, int base);
+long long wcstoll(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr, int base);
+unsigned long wcstoul(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr, int base);
+unsigned long long wcstoull(const wchar_t * XBOXRT_RESTRICT nptr, wchar_t ** XBOXRT_RESTRICT endptr, int base);
+size_t mbrlen(const char *s, size_t n, mbstate_t *ps);
+wint_t btowc(int c);
+size_t mbsrtowcs(wchar_t *dest, const char **src, size_t len, mbstate_t *ps);
+int wctob(wint_t c);
+int wcrtomb_s(size_t * XBOXRT_RESTRICT retval, char * XBOXRT_RESTRICT s, size_t ssz, wchar_t wc, mbstate_t * XBOXRT_RESTRICT ps);
 
 #ifdef __cplusplus
 }

--- a/lib/xboxrt/libc_extensions/wchar.h
+++ b/lib/xboxrt/libc_extensions/wchar.h
@@ -73,4 +73,6 @@ int wcrtomb_s(size_t * XBOXRT_RESTRICT retval, char * XBOXRT_RESTRICT s, size_t 
 }
 #endif
 
+#include <wchar_ext_.h>
+
 #endif /* end of include guard: _XBOXRT_WCHAR_H */

--- a/lib/xboxrt/libc_extensions/wchar_ext_.c
+++ b/lib/xboxrt/libc_extensions/wchar_ext_.c
@@ -1,0 +1,8 @@
+#include <wchar.h>
+#include <assert.h>
+
+int _snwprintf(wchar_t *buffer, size_t count, const wchar_t *format, ...)
+{
+    assert(0);
+    return 0;
+}

--- a/lib/xboxrt/libc_extensions/wchar_ext_.h
+++ b/lib/xboxrt/libc_extensions/wchar_ext_.h
@@ -1,0 +1,10 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Windows-specific extension required by libc++
+int _snwprintf(wchar_t *buffer, size_t count, const wchar_t *format, ...);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This adds all the stubs in `wchar.h` required by libc++. The PDCLib update is included, because it's required for this to work (the PDCLib update includes the typedefs in `wctype.h`).

This probably is the last preparation PR for libc++.