### PR TITLE
samples: Fix warnings about implicitly declaring debugPrint()

### DIFF
--- a/samples/sdl/main.c
+++ b/samples/sdl/main.c
@@ -10,6 +10,7 @@
   freely.
 */
 /* Simple program:  Create a native window and attach an SDL renderer */
+#include <hal/debug.h>
 #include <hal/xbox.h>
 #include <hal/video.h>
 #include <windows.h>

--- a/samples/sdl_ttf/main.c
+++ b/samples/sdl_ttf/main.c
@@ -1,3 +1,4 @@
+#include <hal/debug.h>
 #include <hal/video.h>
 #include <SDL.h>
 #include <SDL_ttf.h>


### PR DESCRIPTION
The SDL samples weren't including `hal/debug.h` so the compiler warned about implicitly declaring `debugPrint`, this adds the include statement to fix that.