### PR TITLE
git: Ignore generated C++ headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.bc
 *.pdb
 _*.cpp
+_*.hpp
 _*.h
 samples/**/*.iso
 *.lib


### PR DESCRIPTION
fp20compiler compilation creates all these additional files:
```
_ps1.0_lexer.cpp _ps1.0_lexer.o
_ps1.0_parser.cpp _ps1.0_parser.h _ps1.0_parser.hpp _ps1.0_parser.o
_rc1.0_lexer.cpp _rc1.0_lexer.o
_rc1.0_parser.cpp _rc1.0_parser.h _rc1.0_parser.hpp _rc1.0_parser.o
_ts1.0_lexer.cpp _ts1.0_lexer.o
_ts1.0_parser.cpp _ts1.0_parser.h _ts1.0_parser.hpp _ts1.0_parser.o
```
We caught most files in our existing top-level .gitignore.
However, the .hpp files were not caught by our .gitignore; this PR fixes that.