### PR TITLE
git: Ignore "bin" directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _*.h
 samples/**/*.iso
 *.lib
 !tools/cg/win/cgc.exe
+bin/


### PR DESCRIPTION
I've noticed that the SDL_ttf samples "bin" directory is found dirty after compilation.
That is because it contains a ".ttf" file.
Other samples aren't considered dirty, because we ignore ".xbe" files, so git considers those other "bin" folders empty.

This adds the "bin" directories to .gitignore to avoid this (and similar issues).