### PR TITLE
Fix some cxbe bugs

### DIFF
--- a/tools/cxbe/Main.cpp
+++ b/tools/cxbe/Main.cpp
@@ -113,7 +113,7 @@ int main(int argc, char *argv[])
             }
             else if(strcmp(szOptionU, "TITLE") == 0)
             {
-                if(dwParamSize > 256)
+                if(dwParamSize > 40)
                     printf("WARNING: Title too long, using default title\n");
                 else
                     strcpy(szXbeTitle, szParam);

--- a/tools/cxbe/Main.cpp
+++ b/tools/cxbe/Main.cpp
@@ -166,15 +166,14 @@ int main(int argc, char *argv[])
 
             char *szWorking = szFilename;
 
-            strncpy(szWorkingU, szWorking, 265);
-
             for(int c=0;szFilename[c] != 0;c++)
                 if(szFilename[c] == '.')
                     szWorking = &szFilename[c];
 
-            MakeUpper(szWorking);
+            strncpy(szWorkingU, szWorking, 265);
+            MakeUpper(szWorkingU);
 
-            if(strcmp(szWorkingU, ".exe") == 0)
+            if(strcmp(szWorkingU, ".EXE") == 0)
                 strcpy(szWorking, ".xbe");
             else
                 strcat(szXbeFilename, ".xbe");

--- a/tools/cxbe/Main.cpp
+++ b/tools/cxbe/Main.cpp
@@ -55,7 +55,6 @@ int main(int argc, char *argv[])
     {
         char *szOption    = 0;
         char *szParam     = 0;
-        uint  dwParamSize = 0;
 
         // if this isn't an option, it must be the Exe file
         if(argv[v][0] != '-')
@@ -87,9 +86,6 @@ int main(int argc, char *argv[])
 
             szOption = &argv[v][1];
             szParam  = &argv[v][dwColon + 1];
-
-            while(szParam[dwParamSize] != 0)
-                dwParamSize++;
         }
 
         // interpret the current switch
@@ -113,10 +109,7 @@ int main(int argc, char *argv[])
             }
             else if(strcmp(szOptionU, "TITLE") == 0)
             {
-                if(dwParamSize > 40)
-                    printf("WARNING: Title too long, using default title\n");
-                else
-                    strcpy(szXbeTitle, szParam);
+                strcpy(szXbeTitle, szParam);
             }
             else if(strcmp(szOptionU, "MODE") == 0)
             {
@@ -138,6 +131,12 @@ int main(int argc, char *argv[])
                 goto cleanup;
             }
         }
+    }
+
+    if(strlen(szXbeTitle) > 40)
+    {
+        printf("WARNING: Title too long, trimming\n");
+        szXbeTitle[40] = '\0';
     }
 
     // verify we recieved the required parameters

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -1082,10 +1082,13 @@ void Xbe::ConstructorInit()
     m_bzSection            = 0;
 }
 
-// better time
-static char *BetterTime(char *x_ctime)
+// returns xbe timestamp date as string (reuses ctime buffer)
+static char *XbeTime(uint32 timestamp)
 {
     int v=0;
+
+    time_t time = timestamp;
+    char *x_ctime = ctime(&time);
 
     for(v=0;x_ctime[v] != '\n';v++);
 
@@ -1126,7 +1129,7 @@ void Xbe::DumpInformation(FILE *x_file)
     fprintf(x_file, "Size of Headers                  : 0x%.08X\n", m_Header.dwSizeofHeaders);
     fprintf(x_file, "Size of Image                    : 0x%.08X\n", m_Header.dwSizeofImage);
     fprintf(x_file, "Size of Image Header             : 0x%.08X\n", m_Header.dwSizeofImageHeader);
-    fprintf(x_file, "TimeDate Stamp                   : 0x%.08X (%s)\n", m_Header.dwTimeDate, BetterTime(ctime(&dwTimeDate)));
+    fprintf(x_file, "TimeDate Stamp                   : 0x%.08X (%s)\n", m_Header.dwTimeDate, XbeTime(dwTimeDate));
     fprintf(x_file, "Certificate Address              : 0x%.08X\n", m_Header.dwCertificateAddr);
     fprintf(x_file, "Number of Sections               : 0x%.08X\n", m_Header.dwSections);
     fprintf(x_file, "Section Headers Address          : 0x%.08X\n", m_Header.dwSectionHeadersAddr);
@@ -1176,7 +1179,7 @@ void Xbe::DumpInformation(FILE *x_file)
     fprintf(x_file, "(PE) Base Address                : 0x%.08X\n", m_Header.dwPeBaseAddr);
     fprintf(x_file, "(PE) Size of Image               : 0x%.08X\n", m_Header.dwPeSizeofImage);
     fprintf(x_file, "(PE) Checksum                    : 0x%.08X\n", m_Header.dwPeChecksum);
-    fprintf(x_file, "(PE) TimeDate Stamp              : 0x%.08X (%s)\n", m_Header.dwPeTimeDate, BetterTime(ctime((time_t*)&m_Header.dwPeTimeDate)));
+    fprintf(x_file, "(PE) TimeDate Stamp              : 0x%.08X (%s)\n", m_Header.dwPeTimeDate, XbeTime(m_Header.dwPeTimeDate));
     fprintf(x_file, "Debug Pathname Address           : 0x%.08X (\"%s\")\n", m_Header.dwDebugPathnameAddr, GetAddr(m_Header.dwDebugPathnameAddr));
     fprintf(x_file, "Debug Filename Address           : 0x%.08X (\"%s\")\n", m_Header.dwDebugFilenameAddr, GetAddr(m_Header.dwDebugFilenameAddr));
     fprintf(x_file, "Debug Unicode filename Address   : 0x%.08X (L\"%s\")\n", m_Header.dwDebugUnicodeFilenameAddr, AsciiFilename);
@@ -1192,7 +1195,7 @@ void Xbe::DumpInformation(FILE *x_file)
     fprintf(x_file, "Dumping XBE Certificate...\n");
     fprintf(x_file, "\n");
     fprintf(x_file, "Size of Certificate              : 0x%.08X\n", m_Certificate.dwSize);
-    fprintf(x_file, "TimeDate Stamp                   : 0x%.08X (%s)\n", m_Certificate.dwTimeDate, BetterTime(ctime((time_t*)&m_Certificate.dwTimeDate)));
+    fprintf(x_file, "TimeDate Stamp                   : 0x%.08X (%s)\n", m_Certificate.dwTimeDate, XbeTime(m_Certificate.dwTimeDate));
     fprintf(x_file, "Title ID                         : 0x%.08X\n", m_Certificate.dwTitleId);
     fprintf(x_file, "Title                            : L\"%s\"\n", m_szAsciiTitle);
 

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -538,7 +538,7 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail)
             m_Certificate.dwTitleId = 0xFFFF0002;
 
             // title name
-            memset(m_Certificate.wszTitleName, 0, 40);
+            memset(m_Certificate.wszTitleName, 0, sizeof(m_Certificate.wszTitleName));
             //mbstowcs(m_Certificate.wszTitleName, x_szTitle, 40);
             const char *p = x_szTitle;
             char *q = (char *) m_Certificate.wszTitleName;

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -131,16 +131,16 @@ Xbe::Xbe(const char *x_szFilename)
             goto cleanup;
         }
 
+        // generate ascii title from certificate title name
         setlocale( LC_ALL, "English" );
-
         //wcstombs(m_szAsciiTitle, m_Certificate.wszTitleName, 40);
         char *c = m_szAsciiTitle;
         char *d = (char *) m_Certificate.wszTitleName;
-        while (*d) {
+        while ((uint16*)d < &m_Certificate.wszTitleName[40] && *d) {
            *c++ = *d++;
            d++;
         }
-
+        *c = '\0';
 
         printf("OK\n");
 
@@ -592,13 +592,14 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail)
 
         // generate ascii title from certificate title name
         setlocale( LC_ALL, "English" );
-        ///wcstombs(m_szAsciiTitle, m_Certificate.wszTitleName, 40);
+        //wcstombs(m_szAsciiTitle, m_Certificate.wszTitleName, 40);
         char *c = m_szAsciiTitle;
         char *d = (char *) m_Certificate.wszTitleName;
-        while (*d) {
+        while ((uint16*)d < &m_Certificate.wszTitleName[40] && *d) {
            *c++ = *d++;
            d++;
         }
+        *c = '\0';
 
 
 

--- a/tools/cxbe/Xbe.h
+++ b/tools/cxbe/Xbe.h
@@ -216,7 +216,7 @@ class Xbe : public Error
         char m_szPath[260];
 
         // Xbe ascii title, translated from certificate title
-        char m_szAsciiTitle[40];
+        char m_szAsciiTitle[40+1];
 
         // retrieve thread local storage data address
         uint08 *GetTLSData() { if(m_TLS == 0) return 0; else return GetAddr(m_TLS->dwDataStartAddr); }


### PR DESCRIPTION
This fixes some of the worst bugs in cxbe:

* Fixes dates, as cxbe uses `time_t` pointers to read from the XBE. `time_t` is larger than 4 bytes value on my platform, but the XBE only stored 4 byte timestamps. This meant we also read neighboring fields (and got bad timestamps).
* Fixes bug where our stubbed conversion from UCS-2 to ASCII left the string without zero-termination (causing buggy output on terminal). This is just a hotfix - we'll eventually have to fix the conversion routines and factor out common code (the code exists 2 times).
* Fixes bug where UCS-2 name was only zero-terminated in the first 20 symbols, after that, garbage could have followed, so any name above 20 symbols might have expanded to up to 40 symbols.
* Fixes bug where 256 symbols could be entered for XBE name, and it would overrun the 40 symbol space in the XBE certificate (and user got no warning).
* Changes behaviour so long names will be trimmed, rather than the XBE title-name being "Untitled". I assume we'll eventually cause hard-errors instead of warnings.
* Fixes bug where the generated output-filename for `main.exe` became `main.EXE.xbe`; now behaves as expected (`main.exe` &rarr; `main.xbe` / `main.bin` &rarr; `main.bin.xbe`).

I intend to do further refactors in cxbe afterwards (for eventually adding XDK DXT support).