### PR TITLE
fp20compiler: Add `MASK` macro to output

### DIFF
--- a/tools/fp20compiler/rc1.0_combiners.cpp
+++ b/tools/fp20compiler/rc1.0_combiners.cpp
@@ -21,6 +21,11 @@ void CombinersStruct::Validate()
 
 void CombinersStruct::Invoke()
 {
+    printf("#pragma push_macro(\"MASK\")\n");
+    printf("#undef MASK\n");
+    printf("#define MASK(mask, val) (((val) << (__builtin_ffs(mask)-1)) & (mask))\n");
+    printf("\n");
+
     assert(numConsts <= 2);
     for (int i = 0; i < numConsts; i++) {
     //     glCombinerParameterfvNV(cc[i].reg.bits.name, &(cc[i].v[0]));
@@ -77,6 +82,9 @@ void CombinersStruct::Invoke()
     generals.Invoke();
 
     final.Invoke();
+
+    printf("\n");
+    printf("#pragma pop_macro(\"MASK\")\n");
 }
 
 bool is_rc10(const char * s)

--- a/tools/fp20compiler/ts1.0_inst_list.cpp
+++ b/tools/fp20compiler/ts1.0_inst_list.cpp
@@ -42,6 +42,11 @@ void InstList::Invoke()
 {
     int i;
 
+    printf("#pragma push_macro(\"MASK\")\n");
+    printf("#undef MASK\n");
+    printf("#define MASK(mask, val) (((val) << (__builtin_ffs(mask)-1)) & (mask))\n");
+    printf("\n");
+
     assert(size > 1);
     printf("pb_push1(p, NV097_SET_SHADER_OTHER_STAGE_INPUT,\n    ");
     for (i=1; i<size; i++) {
@@ -89,6 +94,9 @@ void InstList::Invoke()
     }
     printf(");\n");
     printf("p += 2;\n");
+
+    printf("\n");
+    printf("#pragma pop_macro(\"MASK\")\n");
 }
 
 void InstList::Validate()


### PR DESCRIPTION
Generated output from fp20compiler always depended on a user defined `MASK` macro.
This PR adds the macro to the shader.

The macro uses `__builtin_ffs` so that the user doesn't need to include `strings.h`, however, the user still has to include `pbkit.h`.

*(Another implementation would be to add a new function: `pb_mask` for example. However, I wanted a lightweight solution for now - we can improve it later)*