### PR TITLE
fp20compiler: Avoid overflow bug with duplicated constant-colors

### DIFF
--- a/tools/fp20compiler/rc1.0_combiners.cpp
+++ b/tools/fp20compiler/rc1.0_combiners.cpp
@@ -11,8 +11,11 @@
 void CombinersStruct::Validate()
 {
     if (2 == numConsts &&
-        cc[0].reg.bits.name == cc[1].reg.bits.name)
+        cc[0].reg.bits.name == cc[1].reg.bits.name) {
         errors.set("global constant set twice");
+        cc[0] = cc[1];
+        numConsts = 1;
+    }
 
     generals.Validate(numConsts, &cc[0]);
 


### PR DESCRIPTION
Closes #216 

I was originally going to send another PR right now, but then I noticed that the planned PR hides the bug explained in #216 (but does not fix it).

This PR aims to fix #216 and adds more asserts to catch such errors in the future.

If a constant-color is set twice, the later one is used; the first color value is discarded.
*(Although the error message should discourage the user from setting colors twice anyway)*