### PR TITLE
fp20compiler: Improve error messages for register-combiners

### DIFF
--- a/tools/fp20compiler/ps1.0_grammar.y
+++ b/tools/fp20compiler/ps1.0_grammar.y
@@ -309,5 +309,5 @@ Newlines :
 
 void yyerror(const char* s)
 {
-	errors.set("parser: syntax error", line_number);
+	errors.set("syntax error", line_number);
 }

--- a/tools/fp20compiler/rc1.0_combiners.cpp
+++ b/tools/fp20compiler/rc1.0_combiners.cpp
@@ -12,7 +12,7 @@ void CombinersStruct::Validate()
 {
     if (2 == numConsts &&
         cc[0].reg.bits.name == cc[1].reg.bits.name) {
-        errors.set("global constant set twice");
+        errors.set("global constant set twice", cc[1].line_number);
         cc[0] = cc[1];
         numConsts = 1;
     }

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -119,7 +119,7 @@ void GeneralCombinerStruct::Validate(int stage)
         // Fallthru
     case 2:
         if (portion[0].designator == portion[1].designator)
-            errors.set("portion declared twice");
+            errors.set("portion declared twice", portion[1].line_number);
         break;
     }
     int i;
@@ -225,13 +225,13 @@ void GeneralFunctionStruct::Validate(int stage, int portion)
     // Check if multiple ops are writing to same register (and it's not DISCARD)
     if (numOps > 1 &&
         op[0].reg[0].reg.bits.name == op[1].reg[0].reg.bits.name &&
-        REG_DISCARD != op[0].reg[0].reg.bits.name)
-        errors.set("writing to same register twice");
+        REG_DISCARD != op[1].reg[0].reg.bits.name)
+        errors.set("writing to same register twice", op[1].reg[0].reg.line_number);
     if (numOps > 2 &&
         (op[0].reg[0].reg.bits.name == op[2].reg[0].reg.bits.name ||
          op[1].reg[0].reg.bits.name == op[2].reg[0].reg.bits.name) &&
         REG_DISCARD != op[2].reg[0].reg.bits.name)
-        errors.set("writing to same register twice");
+        errors.set("writing to same register twice", op[2].reg[0].reg.line_number);
 
     // Set unused outputs to discard, unused inputs to zero/unsigned_identity
     if (numOps < 2) {
@@ -374,24 +374,24 @@ void OpStruct::Validate(int stage, int portion)
         args = 1;
 
     if (reg[0].reg.bits.readOnly)
-        errors.set("writing to a read-only register");
+        errors.set("writing to a read-only register", reg[0].reg.line_number);
 
     if (RCP_ALPHA == portion &&
         RCP_DOT == op)
-        errors.set("dot used in alpha portion");
+        errors.set("dot can not be used in alpha portion", reg[0].reg.line_number);
     int i;
     for (i = 0; i < args; i++) {
         ConvertRegister(reg[i].reg, portion);
         if (reg[i].reg.bits.finalOnly)
-            errors.set("final register used in general combiner");
+            errors.set("final-combiner register can not be used in general-combiner", reg[i].reg.line_number);
         if (RCP_RGB == portion &&
             RCP_BLUE == reg[i].reg.bits.channel)
-            errors.set("blue register used in rgb portion");
+            errors.set("blue component can not be used in rgb portion", reg[i].reg.line_number);
         if (RCP_ALPHA == portion &&
             RCP_RGB == reg[i].reg.bits.channel)
-            errors.set("rgb register used in alpha portion");
+            errors.set("rgb component can not be used in alpha portion", reg[i].reg.line_number);
         if (i > 0 &&
             REG_DISCARD == reg[i].reg.bits.name)
-            errors.set("reading from discard");
+            errors.set("reading from discard", reg[i].reg.line_number);
     }
 }

--- a/tools/fp20compiler/rc1.0_general.cpp
+++ b/tools/fp20compiler/rc1.0_general.cpp
@@ -104,7 +104,7 @@ void GeneralCombinerStruct::Validate(int stage)
 {
     if (2 == numConsts &&
         cc[0].reg.bits.name == cc[1].reg.bits.name) {
-        errors.set("local constant set twice");
+        errors.set("local constant set twice", cc[1].line_number);
         cc[0] = cc[1];
         numConsts = 1;
     }

--- a/tools/fp20compiler/rc1.0_general.h
+++ b/tools/fp20compiler/rc1.0_general.h
@@ -15,7 +15,8 @@ enum {
 class ConstColorStruct {
 public:
     void Init(RegisterEnum _reg, float _v0, float _v1, float _v2, float _v3)
-    { reg = _reg; v[0] = _v0; v[1] = _v1; v[2] = _v2; v[3] = _v3; }
+    { line_number = ::line_number; reg = _reg; v[0] = _v0; v[1] = _v1; v[2] = _v2; v[3] = _v3; }
+    int line_number;
     RegisterEnum reg;
     float v[4];
 };

--- a/tools/fp20compiler/rc1.0_general.h
+++ b/tools/fp20compiler/rc1.0_general.h
@@ -48,11 +48,12 @@ public:
 class GeneralPortionStruct {
 public:
     void Init(int _designator, GeneralFunctionStruct _gf, BiasScaleEnum _bs)
-    { designator = _designator; gf = _gf; bs = _bs; }
+    { line_number = ::line_number; designator = _designator; gf = _gf; bs = _bs; }
 
     void Validate(int stage);
     void Invoke(int stage);
     void ZeroOut();
+    int line_number;
     int designator;
     GeneralFunctionStruct gf;
     BiasScaleEnum bs;
@@ -93,7 +94,7 @@ public:
         if (num < RCP_NUM_GENERAL_COMBINERS)
             general[num++] = _gc;
         else
-            errors.set("Too many general combiners.");
+            errors.set("too many general-combiners", ::line_number);
         return *this;
     }
     void Validate(int numConsts, ConstColorStruct *cc);

--- a/tools/fp20compiler/rc1.0_grammar.y
+++ b/tools/fp20compiler/rc1.0_grammar.y
@@ -678,5 +678,5 @@ Register : constVariable
 %%
 void yyerror(const char* s)
 {
-     errors.set("unrecognized token");
+     errors.set("syntax error", line_number);
 }

--- a/tools/fp20compiler/rc1.0_register.h
+++ b/tools/fp20compiler/rc1.0_register.h
@@ -101,23 +101,26 @@ static const char* GetRegisterNameString(unsigned int reg_name) {
 #define MAP_SIGNED_IDENTITY 6
 #define MAP_SIGNED_NEGATE 7
 
-typedef union _RegisterEnum {
-  struct {
+typedef struct _RegisterEnum {
+  union {
+    struct {
 #if BYTE_ORDER != BIG_ENDIAN
-    unsigned int name          :16; // RegisterName enum for register
-    unsigned int channel       : 2; // RCP_RGB, RCP_ALPHA, etc
-    unsigned int readOnly      : 1; // true or false
-    unsigned int finalOnly     : 1; // true or false
-    unsigned int unused        :12;
+      unsigned int name          :16; // RegisterName enum for register
+      unsigned int channel       : 2; // RCP_RGB, RCP_ALPHA, etc
+      unsigned int readOnly      : 1; // true or false
+      unsigned int finalOnly     : 1; // true or false
+      unsigned int unused        :12;
 #else
-    unsigned int unused        :12;
-    unsigned int finalOnly     : 1; // true or false
-    unsigned int readOnly      : 1; // true or false
-    unsigned int channel       : 2; // RCP_RGB, RCP_ALPHA, RCP_BLUE, RCP_NONE
-    unsigned int name          :16; // RegisterName enum for register
+      unsigned int unused        :12;
+      unsigned int finalOnly     : 1; // true or false
+      unsigned int readOnly      : 1; // true or false
+      unsigned int channel       : 2; // RCP_RGB, RCP_ALPHA, RCP_BLUE, RCP_NONE
+      unsigned int name          :16; // RegisterName enum for register
 #endif
-  } bits;
-  unsigned int word;
+    } bits;
+    unsigned int word;
+  };
+  int line_number;
 } RegisterEnum;
 // No need for writeOnly flag, since DISCARD is the only register in that category
 

--- a/tools/fp20compiler/rc1.0_tokens.l
+++ b/tools/fp20compiler/rc1.0_tokens.l
@@ -58,227 +58,280 @@ alphanum [0-9a-zA-Z_]
 !!RC1\.0	{ /* eat header */ }
 
 fog\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_FOG_RGB;
 			    return(regVariable);
 			}
 fog\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_FOG_ALPHA;
 			    return(regVariable);
 			}
 fog\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_FOG_BLUE;
 			    return(regVariable);
 			}
 fog			{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_FOG;
 			    return(regVariable);
 			}
 
 col0\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_PRIMARY_COLOR_RGB;
 			    return(regVariable);
 			}
 col0\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_PRIMARY_COLOR_ALPHA;
 			    return(regVariable);
 			}
 col0\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_PRIMARY_COLOR_BLUE;
 			    return(regVariable);
 			}
 col0		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_PRIMARY_COLOR;
 			    return(regVariable);
 			}
 
 col1\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SECONDARY_COLOR_RGB;
 			    return(regVariable);
 			}
 col1\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SECONDARY_COLOR_ALPHA;
 			    return(regVariable);
 			}
 col1\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SECONDARY_COLOR_BLUE;
 			    return(regVariable);
 			}
 col1		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SECONDARY_COLOR;
 			    return(regVariable);
 			}
 
 spare0\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SPARE0_RGB;
 			    return(regVariable);
 			}
 spare0\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SPARE0_ALPHA;
 			    return(regVariable);
 			}
 spare0\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SPARE0_BLUE;
 			    return(regVariable);
 			}
 spare0		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SPARE0;
 			    return(regVariable);
 			}
 
 spare1\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SPARE1_RGB;
 			    return(regVariable);
 			}
 spare1\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SPARE1_ALPHA;
 			    return(regVariable);
 			}
 spare1\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SPARE1_BLUE;
 			    return(regVariable);
 			}
 spare1		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_SPARE1;
 			    return(regVariable);
 			}
 
 tex0\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE0_RGB;
 			    return(regVariable);
 			}
 tex0\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE0_ALPHA;
 			    return(regVariable);
 			}
 tex0\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE0_BLUE;
 			    return(regVariable);
 			}
 tex0		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE0;
 			    return(regVariable);
 			}
 
 tex1\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE1_RGB;
 			    return(regVariable);
 			}
 tex1\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE1_ALPHA;
 			    return(regVariable);
 			}
 tex1\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE1_BLUE;
 			    return(regVariable);
 			}
 tex1		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE1;
 			    return(regVariable);
 			}
 
 tex2\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE2_RGB;
 			    return(regVariable);
 			}
 tex2\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE2_ALPHA;
 			    return(regVariable);
 			}
 tex2\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE2_BLUE;
 			    return(regVariable);
 			}
 tex2		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE2;
 			    return(regVariable);
 			}
 
 tex3\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE3_RGB;
 			    return(regVariable);
 			}
 tex3\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE3_ALPHA;
 			    return(regVariable);
 			}
 tex3\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE3_BLUE;
 			    return(regVariable);
 			}
 tex3		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_TEXTURE3;
 			    return(regVariable);
 			}
 
 const0\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_CONST_COLOR0_RGB;
 			    return(regVariable);
 			}
 const0\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_CONST_COLOR0_ALPHA;
 			    return(regVariable);
 			}
 const0\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_CONST_COLOR0_BLUE;
 			    return(regVariable);
 			}
 const0		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_CONST_COLOR0;
 			    return(constVariable);
 			}
 
 const1\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_CONST_COLOR1_RGB;
 			    return(regVariable);
 			}
 const1\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_CONST_COLOR1_ALPHA;
 			    return(regVariable);
 			}
 const1\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_CONST_COLOR1_BLUE;
 			    return(regVariable);
 			}
 const1		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_CONST_COLOR1;
 			    return(constVariable);
 			}
 
 zero\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_ZERO_RGB;
 			    return(regVariable);
 			}
 zero\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_ZERO_ALPHA;
 			    return(regVariable);
 			}
 zero\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_ZERO_BLUE;
 			    return(regVariable);
 			}
 zero		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_ZERO;
 			    return(regVariable);
 			}
 
 one\.rgb	{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_ONE_RGB;
 			    return(regVariable);
 			}
 one\.a		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_ONE_ALPHA;
 			    return(regVariable);
 			}
 one\.b		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_ONE_BLUE;
 			    return(regVariable);
 			}
 one			{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_ONE;
 			    return(regVariable);
 			}
 
 discard		{
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_DISCARD;
 			    return(regVariable);
 			}
@@ -287,11 +340,13 @@ out\.rgb		return(fragment_rgb);
 out\.a			return(fragment_alpha);
 
 final_product {
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_FINAL_PRODUCT;
 			    return(final_product);
 			}
 
 color_sum {
+			    rc10_lval.registerEnum.line_number = line_number;
 			    rc10_lval.registerEnum.word = RCP_COLOR_SUM;
 			    return(color_sum);
 			}

--- a/tools/fp20compiler/ts1.0_grammar.y
+++ b/tools/fp20compiler/ts1.0_grammar.y
@@ -299,5 +299,5 @@ CondDesc :	gequal
 %%
 void yyerror(const char* s)
 {
-     errors.set("unrecognized token");
+     errors.set("syntax error", line_number);
 }


### PR DESCRIPTION
There should be no changes in behaviour, but:

- Adds line numbers to error messages.
- Provides more explicit error messages.
- Refactors code so code duplication is minimized.

All of the refactoring is contained in the final-combiner commit. I hope I didn't break anything. The code should be reviewed to make sure.

*This is the PR that has been mentioned in #240:
If this PR would have come first, it somehow would have prevented the issue explained in #216 (no more assert or crash).
I'm not sure why that happened, but I assume the structs get packed differently, so that the colors actually overwrite the color count.*

---

You can find shaders for testing (and a tool to run them) in this branch: https://github.com/JayFoxRox/nxdk/pull/56
Some of those tests annotations might not mention some additional errors that are displayed by now. Just review the shaders yourself to check if the errors make sense.