### PR TITLE
lwip: Update submodule to STABLE-2_1_2_RELEASE

### DIFF
--- a/lib/net/Makefile
+++ b/lib/net/Makefile
@@ -1,6 +1,7 @@
 # Include LWIP sources
 LWIPDIR = $(NXDK_DIR)/lib/net/lwip/src
 include $(LWIPDIR)/Filelists.mk
+NETIFFILES := $(filter-out $(LWIPDIR)/netif/slipif.c,$(NETIFFILES))
 LWIPSRCS := $(COREFILES) \
             $(CORE4FILES) \
             $(CORE6FILES) \

--- a/lib/net/nforceif/include/arch/sys_arch.h
+++ b/lib/net/nforceif/include/arch/sys_arch.h
@@ -34,8 +34,6 @@
 #ifndef LWIP_ARCH_SYS_ARCH_H
 #define LWIP_ARCH_SYS_ARCH_H
 
-#include <usb/include/asm/errno.h>
-
 #define SYS_MBOX_NULL NULL
 #define SYS_SEM_NULL  NULL
 

--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -43,7 +43,9 @@
 #define LWIP_IPV4 1
 #define LWIP_IPV6 1
 #define LWIP_DEBUG 1
-extern int errno;
+#define LWIP_ERRNO_INCLUDE <errno.h>
+#define LWIP_COMPAT_MUTEX_ALLOWED
+#define SYS_LIGHTWEIGHT_PROT 0
 
 /*
    -----------------------------------------------

--- a/lib/net/nforceif/src/driver.c
+++ b/lib/net/nforceif/src/driver.c
@@ -117,7 +117,7 @@ low_level_init(struct netif *netif)
   if (netif->mld_mac_filter != NULL) {
     ip6_addr_t ip6_allnodes_ll;
     ip6_addr_set_allnodes_linklocal(&ip6_allnodes_ll);
-    netif->mld_mac_filter(netif, &ip6_allnodes_ll, MLD6_ADD_MAC_FILTER);
+    netif->mld_mac_filter(netif, &ip6_allnodes_ll, NETIF_ADD_MAC_FILTER);
   }
 #endif /* LWIP_IPV6 && LWIP_IPV6_MLD */
 

--- a/lib/net/nforceif/src/sys_arch.c
+++ b/lib/net/nforceif/src/sys_arch.c
@@ -198,6 +198,12 @@ sys_mbox_trypost(struct sys_mbox **mb, void *msg)
   return ERR_OK;
 }
 
+err_t
+sys_mbox_trypost_fromisr(struct sys_mbox **mb, void *msg)
+{
+  return sys_mbox_trypost(mb, msg);
+}
+
 void
 sys_mbox_post(struct sys_mbox **mb, void *msg)
 {

--- a/samples/httpd/main.c
+++ b/samples/httpd/main.c
@@ -4,7 +4,7 @@
 #include "lwip/netif.h"
 #include "lwip/sys.h"
 #include "lwip/tcpip.h"
-#include "lwip/timers.h"
+#include "lwip/timeouts.h"
 #include "netif/etharp.h"
 #include "pktdrv.h"
 #include <hal/input.h>
@@ -87,7 +87,7 @@ int main(void)
 
 #if USE_DHCP
 	debugPrint("Waiting for DHCP...\n");
-	while (g_pnetif->dhcp->state != DHCP_STATE_BOUND)
+	while (dhcp_supplied_address(g_pnetif) == 0)
 		NtYieldExecution();
 	debugPrint("DHCP bound!\n");
 #endif

--- a/samples/httpd_bsd/main.c
+++ b/samples/httpd_bsd/main.c
@@ -4,7 +4,7 @@
 #include <lwip/netif.h>
 #include <lwip/sys.h>
 #include <lwip/tcpip.h>
-#include <lwip/timers.h>
+#include <lwip/timeouts.h>
 #include <netif/etharp.h>
 #include <pktdrv.h>
 #include <hal/video.h>
@@ -86,7 +86,7 @@ int main(void)
 
 #if USE_DHCP
     debugPrint("Waiting for DHCP...\n");
-    while (g_pnetif->dhcp->state != DHCP_STATE_BOUND)
+    while (dhcp_supplied_address(g_pnetif) == 0)
         NtYieldExecution();
     debugPrint("DHCP bound!\n");
 #endif


### PR DESCRIPTION
This pretty much does what the title says - instead of using some random commit before the 2.0.0 release, this updates our lwip submodule to the latest stable release. Some changes were necessary for this, and I'll leave review comments with the details.

This PR intentionally doesn't touch any areas where we could optimize or clean up things or utilize features of newer releases - I focused only on updating the submodule without introducing regressions.

I tested this with our two http server samples on my 1.0 Xbox.