### PR TITLE
hal: Respect XeImageFileName->Length in getCurrentDirString()

### DIFF
--- a/lib/hal/fileio.c
+++ b/lib/hal/fileio.c
@@ -61,7 +61,8 @@ static char *getCurrentDirString()
 		return currentDirString;
 	}
 	currentDirString = malloc(XeImageFileName->Length + 1);
-	strcpy(currentDirString, XeImageFileName->Buffer);
+	memcpy(currentDirString, XeImageFileName->Buffer, XeImageFileName->Length);
+	currentDirString[XeImageFileName->Length] = '\0';
 	// Remove XBE name, leaving the path
 	tmp = strrchr(currentDirString, '\\');
 	if (tmp) {


### PR DESCRIPTION
This fixes a bug that was [reported by KingLuxor on Discord](https://discordapp.com/channels/428359196719972353/428360618102226946/652594555832631308).

> Seeing an issue with fopen() when using Evox M8/IND-Bios, say the filename is flash.bin the file that gets created is xenium-tools.xbesk[flash.bin
> it works just fine using X2 BIOS, just wanted to pass the info along

This affects https://github.com/Ryzee119/OpenXenium/tree/master/Xenium-Tools; a code review revealed no issues in Xenium-Tools. However, I did spot a bug in nxdk where we don't zero-terminate the `XeImageFileName` using it's length (instead, we treat it as zero-terminated string - which it isn't).
This leads to garbage being added to the string (might overflow `currentDirString`), and `\` might be found outside the string, so the filename isn't trimmed correctly.

This PR aims to fix this, by manually zero-terminating.

I have also switched the code to a `memcpy` - I don't think it will ever be prematurely zero-terminated (and if it is, then `memcpy` might still be faster). I believe this can't cause any new issues either.

I did grep for `XeImageFileName` and couldn't find other uses. However, similar issues could exist for other variables.