### PR TITLE
build: Fix typo breaking make clean

### DIFF
--- a/lib/nxdk/Makefile
+++ b/lib/nxdk/Makefile
@@ -26,7 +26,7 @@ main.exe: $(NXDK_DIR)/lib/libnxdk_automount_d.lib
 NXDK_LDFLAGS += -include:_automount_d_drive
 endif
 
-CLEANRULES += clean-nxdk-autmount-d
+CLEANRULES += clean-nxdk-automount-d
 
 .PHONY: clean-nxdk-automount-d
 clean-nxdk-automount-d:


### PR DESCRIPTION
During the refactoring of #230 I accidentally introduced a typo in one of the cleaning rules, which broke `make clean`. This fixes the typo in the rule name.