### PR TITLE
libc++

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -15,3 +15,7 @@
 [submodule "lib/sdl/SDL_ttf"]
 	path = lib/sdl/SDL_ttf
 	url = https://github.com/SDL-mirror/SDL_ttf
+[submodule "lib/libcxx"]
+	path = lib/libcxx
+	url = https://github.com/XboxDev/nxdk-libcxx.git
+	branch = nxdk

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -Wno-ignored-attributes -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
-NXDK_CXXFLAGS = $(NXDK_CFLAGS) -fno-threadsafe-statics -fno-rtti
+NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-threadsafe-statics -fno-rtti
 NXDK_LDFLAGS = -subsystem:windows -dll -entry:XboxCRTEntry \
                -stack:$(NXDK_STACKSIZE) -safeseh:no
 
@@ -79,6 +79,10 @@ all: $(TARGET)
 
 include $(NXDK_DIR)/lib/Makefile
 OBJS = $(addsuffix .obj, $(basename $(SRCS)))
+
+ifneq ($(NXDK_CXX),)
+include $(NXDK_DIR)/lib/libcxx/Makefile.nxdk
+endif
 
 ifneq ($(NXDK_NET),)
 include $(NXDK_DIR)/lib/net/Makefile

--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -3,6 +3,7 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/strings.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/wchar.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/wchar_ext_.c \
+	$(NXDK_DIR)/lib/xboxrt/libc_extensions/wctype_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/stdlib_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/string_ext_.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/_alldiv.s \

--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -19,4 +19,5 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/chkstk.s \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/purecall.c \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_exception.cpp \
-	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp
+	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp \
+	$(NXDK_DIR)/lib/xboxrt/vcruntime/eh.cpp

--- a/lib/xboxrt/libc_extensions/stdlib_ext_.c
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.c
@@ -85,3 +85,9 @@ long double strtold( const char * _PDCLIB_restrict nptr, char * * _PDCLIB_restri
     return 0.0;
 }
 
+int mbtowc (wchar_t *pwc, const char *string, size_t n)
+{
+    assert(0);
+    return 0;
+}
+

--- a/lib/xboxrt/libc_extensions/stdlib_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.h
@@ -21,6 +21,13 @@ _purecall_handler __cdecl _set_purecall_handler (_purecall_handler function);
 // https://docs.microsoft.com/en-us/cpp/c-runtime-library/errno-doserrno-sys-errlist-and-sys-nerr?view=vs-2019
 #define _sys_nerr _PDCLIB_ERRNO_MAX
 
+// Necessary stub for libc++
+#include <wchar.h>
+int mbtowc (wchar_t *pwc, const char *string, size_t n);
+
+// Defined as on ReactOS - may need further adjustment if we decide to do locales properly
+#define MB_CUR_MAX 2
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/xboxrt/libc_extensions/wctype_ext_.c
+++ b/lib/xboxrt/libc_extensions/wctype_ext_.c
@@ -1,0 +1,75 @@
+#include <assert.h>
+#include <wctype.h>
+
+_PDCLIB_PUBLIC int iswalpha( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswblank( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswcntrl( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswdigit( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswlower( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswprint( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswpunct( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswspace( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswupper( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC int iswxdigit( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+
+_PDCLIB_PUBLIC wint_t towlower( wint_t wc )
+{
+    assert(0);
+    return 0;
+}
+
+_PDCLIB_PUBLIC wint_t towupper( wint_t wc )
+{
+    assert(0);
+    return 0;
+}

--- a/lib/xboxrt/vcruntime/eh.cpp
+++ b/lib/xboxrt/vcruntime/eh.cpp
@@ -1,0 +1,87 @@
+#include <assert.h>
+#include <eh.h>
+
+void __cdecl __ExceptionPtrCreate (void*)
+{
+    assert(0);
+}
+
+void __cdecl __ExceptionPtrDestroy (void*)
+{
+    assert(0);
+}
+
+void __cdecl __ExceptionPtrCopy (void*, const void*)
+{
+    assert(0);
+}
+
+void __cdecl __ExceptionPtrAssign (void*, const void*)
+{
+    assert(0);
+}
+
+bool __cdecl __ExceptionPtrCompare (const void*, const void*)
+{
+    assert(0);
+    return false;
+}
+
+bool __cdecl __ExceptionPtrToBool (const void*)
+{
+    assert(0);
+    return false;
+}
+
+void __cdecl __ExceptionPtrSwap (void*, void*)
+{
+    assert(0);
+}
+
+void __cdecl __ExceptionPtrCurrentException (void*)
+{
+    assert(0);
+}
+
+[[noreturn]] void __cdecl __ExceptionPtrRethrow (const void*)
+{
+    assert(0);
+}
+
+void __cdecl __ExceptionPtrCopyException (void*, const void*, const void*)
+{
+    assert(0);
+}
+
+extern "C"
+{
+    terminate_handler __cdecl set_terminate (terminate_handler _NewTerminateHandler) throw()
+    {
+        assert(0);
+        return 0;
+    }
+
+    terminate_handler __cdecl _get_terminate ()
+    {
+        assert(0);
+        return 0;
+    }
+
+    unexpected_handler __cdecl set_unexpected (unexpected_handler _NewUnexpectedHandler) throw()
+    {
+        assert(0);
+        return 0;
+    }
+
+    unexpected_handler __cdecl _get_unexpected ()
+    {
+        assert(0);
+        return 0;
+    }
+
+    int __cdecl __uncaught_exceptions ()
+    {
+        assert(0);
+        return 0;
+    }
+}

--- a/lib/xboxrt/vcruntime/eh.h
+++ b/lib/xboxrt/vcruntime/eh.h
@@ -1,0 +1,15 @@
+#ifndef __VCRUNTIME_EH_H__
+#define __VCRUNTIME_EH_H__
+
+extern "C"
+{
+    typedef void (__cdecl *terminate_handler)();
+    terminate_handler __cdecl set_terminate (terminate_handler _NewTerminateHandler) throw();
+    terminate_handler __cdecl _get_terminate ();
+
+    typedef void (__cdecl *unexpected_handler)();
+    unexpected_handler __cdecl set_unexpected (unexpected_handler _NewUnexpectedHandler) throw();
+    unexpected_handler __cdecl _get_unexpected ();
+}
+
+#endif


### PR DESCRIPTION
This adds libc++ (along with a few more required stubs). The libc++ branch for nxdk currently lives under https://github.com/thrimbor/libcxx.git, and should obviously get moved before merge.

libc++ brings quite a lot of functionality, I don't expect everything to be bug-free and functional already. Simple stuff (`std::string`, `std::vector`) should work already though, and make it much easier to port or write new stuff in a safer way. I do plan to add C++11 thread support soon, I already have a branch where I implemented it.

For now, libc++ has to be enabled via `NXDK_CXX` (similar to how we handle SDL atm). libc++ supports a special pragma that causes the linker to automatically link it, but I disabled it for now because our build system can't track that dependency (the ELF-variant of lld supports emitting a Make-style dependency file, but the PE-variant doesn't).