### PR TITLE
ci: Utilize all cores for building

### DIFF
--- a/.ci_build_samples.sh
+++ b/.ci_build_samples.sh
@@ -1,9 +1,16 @@
 #!/bin/sh
 set -e
+
+if [ $(uname) = 'Darwin' ]; then
+    NUMCORES=$(sysctl -n hw.logicalcpu)
+else
+    NUMCORES=$(nproc)
+fi
+
 cd samples
 for dir in */
 do
     cd "$dir"
-    make
+    make -j${NUMCORES}
     cd ..
 done


### PR DESCRIPTION
Simple addition to our CI build script to let `make` use parallel jobs (where the number of jobs equals the number of cores). Roughly halves the build time (not the total job time, though).