### PR TITLE
ci: Use cached msys2 environment

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -13,13 +13,17 @@ jobs:
           submodules: recursive
       - name: Install MSYS2 & Dependencies
         run: |
-          choco install msys2 --no-progress
-          C:\tools\msys64\usr\bin\bash.exe -lc "pacman --needed --noconfirm -S make bison flex mingw-w64-x86_64-llvm mingw-w64-x86_64-clang mingw-w64-x86_64-lld cmake"
+          echo "Downloading MSYS2 environment..."
+          Invoke-WebRequest -Uri "https://github.com/XboxDev/nxdk-ci-environment-msys2/releases/latest/download/msys64.7z" -OutFile "msys64.7z"
+          echo "Extracting MSYS2 environment..."
+          7z x -y msys64.7z "-oC:\"
+          echo "Updating MSYS2 environment..."
+          C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm"
       - name: Build
         env:
           MSYS2_ARCH: x86_64
           MSYSTEM: MINGW64
-        run: C:\tools\msys64\usr\bin\bash.exe -lc "cd $(cygpath $env:GITHUB_WORKSPACE) && ./.ci_build_samples.sh"
+        run: C:\msys64\usr\bin\bash.exe -lc "cd $(cygpath $env:GITHUB_WORKSPACE) && ./.ci_build_samples.sh"
   macos:
     name: macOS
     runs-on: macOS-latest


### PR DESCRIPTION
Pretty much the same thing @mborgerson set up for xqemu, I copied the config changes from him. The msys2 environment was adjusted to contain the packages nxdk needs, and while it's much larger than the xqemu version, it still reduces the time required a lot while also working around chocolatey reliability issues.