### PR TITLE
Gamma sample

### DIFF
--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -42,6 +42,13 @@ typedef struct _VIDEO_MODE
 	int		refresh;
 } VIDEO_MODE;
 
+typedef struct _GAMMA_RAMP_ENTRY
+{
+	unsigned char red;
+	unsigned char green;
+	unsigned char blue;
+} GAMMA_RAMP_ENTRY;
+
 
 DWORD XVideoGetEncoderSettings(void);
 unsigned char* XVideoGetFB(void);
@@ -51,6 +58,7 @@ void XVideoSetFlickerFilter(int level);
 BOOL XVideoSetMode(int width, int height, int bpp, int refresh);
 void XVideoSetSoftenFilter(BOOL enable);
 void XVideoSetVideoEnable(BOOL enable);
+void XVideoSetGammaRamp(unsigned int offset, const GAMMA_RAMP_ENTRY *entries, unsigned int count);
 
 /*
 Lists the video modes available at the given colour depth and refresh rate.

--- a/samples/gamma/Makefile
+++ b/samples/gamma/Makefile
@@ -1,0 +1,5 @@
+XBE_TITLE=gamma
+GEN_XISO = $(XBE_TITLE).iso
+SRCS = $(wildcard $(CURDIR)/*.c)
+NXDK_DIR = $(CURDIR)/../..
+include $(NXDK_DIR)/Makefile

--- a/samples/gamma/README.md
+++ b/samples/gamma/README.md
@@ -1,0 +1,11 @@
+gamma
+=====
+
+Example of using GPU gamma ramps for tonemapping and effects.
+
+By not setting a linear ramp, you are typically reducing the amount of colors that you can output to the display.
+It might still be beneficial in some situations (correcting for bad display).
+
+In practice, tonemapping is not useful on original Xbox.
+The GPU does not support higher framebuffer precision than 8-bit integers per channel.
+So when working in linear space, it will quickly lead to quantization artifacts.

--- a/samples/gamma/main.c
+++ b/samples/gamma/main.c
@@ -1,0 +1,158 @@
+#include <stdint.h>
+#include <string.h>
+#include <math.h>
+#include <hal/video.h>
+#include <hal/debug.h>
+#include <windows.h>
+
+static void draw_title(const char* title)
+{
+    extern int nextCol;
+    extern int nextRow;
+    nextCol = 25;
+    nextRow = 25;
+    debugPrint("%s", title);
+    for(int i = strlen(title); i < 60; i++) {
+        debugPrint(" ");
+    }
+}
+
+int main(void)
+{
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
+    /* Create test image in framebuffer */
+    uint32_t *rgbx = (uint32_t*)XVideoGetFB();
+    for(unsigned int y = 0; y < 480; y++) {
+        unsigned int stripe = y / (480/3);
+
+        /* Border left */
+        for(unsigned int x = 0; x < (640-512)/2; x++) {
+            *rgbx++ = 0x808080;
+        }
+        /* 512 pixels gradient */
+        for(unsigned int x = 0; x < 256; x++) {
+            *rgbx++ = x << (16 - stripe * 8);
+            *rgbx++ = x << (16 - stripe * 8);
+        }
+        /* Border right */
+        for(unsigned int x = 0; x < (640-512)/2; x++) {
+            *rgbx++ = 0x808080;
+        }
+    }
+
+
+    while(1) {
+        GAMMA_RAMP_ENTRY entries[256];
+
+        draw_title("Linear");
+        for(int i = 0; i < 256; i++) {
+            entries[i].red   = i;
+            entries[i].green = i;
+            entries[i].blue  = i;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+        draw_title("Gamma correction (Simplified 2.2)");
+        for(int i = 0; i < 256; i++) {
+            float f = i / (float)0xFF;
+
+            f = powf(f, 1.0f/2.2f);
+
+            entries[i].red   = 0xFF * f;
+            entries[i].green = 0xFF * f;
+            entries[i].blue  = 0xFF * f;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+        draw_title("Gamma correction (Accurate sRGB)");
+        for(int i = 0; i < 256; i++) {
+            float f = i / (float)0xFF;
+
+            /* https://seblagarde.files.wordpress.com/2015/07/course_notes_moving_frostbite_to_pbr_v32.pdf (Listing 30) */
+            float flo = f * 12.92f;
+            float fhi = powf(f, 1.0f/2.4f) * 1.055f - 0.055f;
+            f = (f <= 0.0031308f) ? flo : fhi;
+
+            entries[i].red   = 0xFF * f;
+            entries[i].green = 0xFF * f;
+            entries[i].blue  = 0xFF * f;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+        draw_title("Tonemap (Reinhard) + Gamma correction (Simplified 2.2)");
+        for(int i = 0; i < 256; i++) {
+            float f = i / (float)0xFF;
+
+            /* http://filmicworlds.com/blog/why-reinhard-desaturates-your-blacks/ */
+            f = f / (f + 1.0f);
+            f = powf(f, 1.0f/2.2f);
+
+            entries[i].red   = 0xFF * f;
+            entries[i].green = 0xFF * f;
+            entries[i].blue  = 0xFF * f;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+        draw_title("Tonemap (Filmic) + Gamma correction (Simplified 2.2)");
+        for(int i = 0; i < 256; i++) {
+            float f = i / (float)0xFF;
+
+            /* http://filmicworlds.com/blog/why-a-filmic-curve-saturates-your-blacks/ */
+            f = f - 0.004;
+            if (f < 0.0f) { f = 0.0f; }
+            f = (f * (6.2f * f + 0.5f)) / (f * (6.2f * f + 1.7f) + 0.06f);
+
+            entries[i].red   = 0xFF * f;
+            entries[i].green = 0xFF * f;
+            entries[i].blue  = 0xFF * f;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+        draw_title("Inverse");
+        for(int i = 0; i < 256; i++) {
+            entries[i].red   = 0xFF - i;
+            entries[i].green = 0xFF - i;
+            entries[i].blue  = 0xFF - i;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+        draw_title("Red only");
+        for(int i = 0; i < 256; i++) {
+            entries[i].red   = i;
+            entries[i].green = 0;
+            entries[i].blue  = 0;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+        draw_title("Green only");
+        for(int i = 0; i < 256; i++) {
+            entries[i].red   = 0;
+            entries[i].green = i;
+            entries[i].blue  = 0;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+        draw_title("Blue only");
+        for(int i = 0; i < 256; i++) {
+            entries[i].red   = 0;
+            entries[i].green = 0;
+            entries[i].blue  = i;
+        }
+        XVideoSetGammaRamp(0, entries, 256);
+        Sleep(1000);
+
+    }
+
+    /* Unreachable */
+
+    return 0;
+}


### PR DESCRIPTION
This is something I've played around with recently; as also described in the README, this isn't exactly useful on Xbox, but might still be useful in niche situations or for "free" effects (fades, color filters, flashes, ..).

As this is adding to the hal/video API I wasn't too focused on making this clean.
I chose a `memcpy` style API for now.

The sample has some ugly bits which will need to be improved in the future (the sample image is poorly chosen for a gamma test *and* tone-mapping). Ideally we'll be loading a couple of different images from memory.

In the XDK, this is exposed by D3D (presumably). However, it makes sense to expose this together with video-encoder features as it's not part of the rendering, but display routines.

---

I have not tested this with 16bpp modes yet. I'm not sure if the ramp is after conversion to 8-bit.
This should be checked before merge.

*(This feature is not emulated in XQEMU yet, so this must be tested on physical hardware)*