### PR TITLE
libc: Add alloca() / _alloca()

### DIFF
--- a/lib/xboxrt/libc_extensions/malloc.h
+++ b/lib/xboxrt/libc_extensions/malloc.h
@@ -1,0 +1,10 @@
+#ifndef _XBOXRT_MALLOC_H_
+#define _XBOXRT_MALLOC_H_
+
+// Some code expects to find a declaration of malloc here, so we simply include the whole C header
+#include <stdlib.h>
+
+// Forward alloca to the builtin with the Windows-specific name
+static void *alloca (size_t size) { return _alloca(size); }
+
+#endif


### PR DESCRIPTION
I'm not a huge fan of `alloca`, but some code out there (like libraries used by SDLPoP) use it, and it's an easy thing to add. Some test code can be found [here](https://gist.github.com/thrimbor/2815f00a97966b97028ac0a23b94bde3), it mainly checks whether we corrupt the stack.