### PR TITLE
Make non-public functions and variables static

### DIFF
--- a/lib/hal/fileio.c
+++ b/lib/hal/fileio.c
@@ -10,7 +10,7 @@
 
 static char *currentDirString = NULL;
 
-char *partitions[] =
+static char *partitions[] =
 {
 	"\\??\\D:\\",
 	"\\Device\\Harddisk0\\Partition1\\",
@@ -22,7 +22,7 @@ char *partitions[] =
 	"\\Device\\Harddisk0\\Partition7\\",
 };
 
-int getPartitionIndex(char c)
+static int getPartitionIndex(char c)
 {
 	switch(c)
 	{
@@ -38,7 +38,7 @@ int getPartitionIndex(char c)
 	}
 }
 
-char *getPartitionString(char c)
+static char *getPartitionString(char c)
 {
 	int i = getPartitionIndex(c);
 	if (i == -1)
@@ -47,7 +47,7 @@ char *getPartitionString(char c)
 		return partitions[i];
 }
 
-void setPartitionString(char c, char *string)
+static void setPartitionString(char c, char *string)
 {
 	int i = getPartitionIndex(c);
 	if (i != -1)

--- a/lib/winapi/fiber.c
+++ b/lib/winapi/fiber.c
@@ -12,11 +12,11 @@ typedef struct fls_node_t_
     PVOID slots[FLS_MAXIMUM_AVAILABLE];
 } fls_node_t;
 
-CRITICAL_SECTION fls_lock;
-thread_local fls_node_t fls_node;
-LIST_ENTRY fls_nodes_list;
-uint32_t fls_bitmap[FLS_MAXIMUM_AVAILABLE / 32];
-PFLS_CALLBACK_FUNCTION fls_dtors[FLS_MAXIMUM_AVAILABLE];
+static CRITICAL_SECTION fls_lock;
+static thread_local fls_node_t fls_node;
+static LIST_ENTRY fls_nodes_list;
+static uint32_t fls_bitmap[FLS_MAXIMUM_AVAILABLE / 32];
+static PFLS_CALLBACK_FUNCTION fls_dtors[FLS_MAXIMUM_AVAILABLE];
 
 // Gets run by the CRT on startup.
 __attribute__((constructor)) static VOID fls_init (VOID)

--- a/lib/xboxrt/libc_extensions/stdlib_ext_.c
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.c
@@ -9,7 +9,7 @@ once_flag init_flag = ONCE_FLAG_INIT;
 mtx_t rand_mutex;
 unsigned char rand_buffer[116];
 
-void update_rand_buffer (void)
+static void update_rand_buffer (void)
 {
     LARGE_INTEGER performanceCounter;
     QueryPerformanceCounter(&performanceCounter);


### PR DESCRIPTION
Based on the [Discord discussion](https://discordapp.com/channels/428359196719972353/428360618102226946/664534847082987563) I went through `hal`, `nxdk`, `xboxrt` and `winapi` to check for variables or functions that could be static but aren't, and fixed every occurrence I found. Depending on whether we build the code as a library I used `nm --defined only` on the library file or read through the sourcecode.