### PR TITLE
build: Fix LLD hang on Windows by disabling multi-threaded linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-threadsafe-
 NXDK_LDFLAGS = -subsystem:windows -dll -entry:XboxCRTEntry \
                -stack:$(NXDK_STACKSIZE) -safeseh:no
 
+# Multithreaded LLD on Windows hang workaround
+ifneq (,$(findstring MINGW,$(UNAME_S)))
+NXDK_LDFLAGS += -threads:no
+endif
 
 ifeq ($(DEBUG),y)
 NXDK_CFLAGS += -g -gdwarf-4


### PR DESCRIPTION
Since we seem to hit the LLD hang with every single CI run now, I did some investigating on a Windows 10 VM. I was able to reproduce the issue in 100% of all attempts and found out that it is related to LLD using multi-threaded linking by default, and that we can work around the issue by disabling that.

This is an issue that has been encountered by others [before](https://github.com/android/ndk/issues/855) and was [seemingly fixed](https://reviews.llvm.org/D53968) but seems to have returned in some other form.

Since, according to reports in Discord, this problem doesn't always happen, I tested this patch by building the recently merged gamma sample ten times with and ten times without the patch. Without it, it always hung, with it, it always worked.

Fixes #279.