### PR TITLE
ci: Set a 20 minute job timeout

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -6,6 +6,7 @@ jobs:
   windows:
     name: Windows
     runs-on: windows-latest
+    timeout-minutes: 20
     steps:
       - name: Clone Tree
         uses: actions/checkout@v1
@@ -27,6 +28,7 @@ jobs:
   macos:
     name: macOS
     runs-on: macOS-latest
+    timeout-minutes: 20
     steps:
       - name: Clone Tree
         uses: actions/checkout@v1
@@ -41,6 +43,7 @@ jobs:
   ubuntu:
     name: Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Clone Tree
         uses: actions/checkout@v1


### PR DESCRIPTION
The recent linker hangs on Windows made me realize that GH Actions have a default timeout of six hours, which is unnecessarily large for our purposes. This sets a custom timeout of 20 minutes, which is far less wasteful, but still is 4-5x the time required by our slowest build job, so we don't risk running into that limit soon.