### PR TITLE
libc: Fix alloca()

### DIFF
--- a/lib/xboxrt/libc_extensions/malloc.h
+++ b/lib/xboxrt/libc_extensions/malloc.h
@@ -5,6 +5,6 @@
 #include <stdlib.h>
 
 // Forward alloca to the builtin with the Windows-specific name
-static void *alloca (size_t size) { return _alloca(size); }
+#define alloca(size) _alloca(size)
 
 #endif


### PR DESCRIPTION
As @JayFoxRox pointed out `alloca()` isn't allowed to be a static function because the memory allocated is in the local stackframe and will be invalid after returning.