### PR TITLE
Fix some xboxkrnl prototypes

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -4095,7 +4095,7 @@ XBAPI VOID NTAPI HalDisableSystemInterrupt
     IN ULONG BusInterruptLevel
 );
 
-XBAPI DWORD HalBootSMCVideoMode(void);
+XBAPI DWORD HalBootSMCVideoMode;
 
 
 XBAPI NTSTATUS NTAPI FscSetCacheSize

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -3502,7 +3502,7 @@ XBAPI ULONG NTAPI KeResumeThread
     IN PKTHREAD Thread
 );
 
-XBAPI NTSTATUS KeRestoreFloatingPointState
+XBAPI NTSTATUS NTAPI KeRestoreFloatingPointState
 (
     IN PKFLOATING_SAVE FloatSave
 );


### PR DESCRIPTION
* `KeRestoreFloatingPointState` was not marked as `NTAPI` and wasn't linkable (as name decoration in import lib is different). I ran into this, because a future submodule PR of mine will use a DPC which might require the FPU.
* `HalBootSMCVideoMode` is a variable, not a function. I found this using: `grep XBAPI -R ./ | grep -v FASTCALL | grep -v NTAPI | grep -v CDECL | grep \(`.