### PR TITLE
winapi: Add INT / PINT / LPINT / UINT / PUINT / LPUINT types

### DIFF
--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -11,6 +11,7 @@ typedef signed char SCHAR, *PSCHAR;
 
 typedef char CHAR, *PCHAR, CCHAR, *LPCH, *PCH, OCHAR, *POCHAR;
 typedef short SHORT, *PSHORT;
+typedef int INT, *PINT, *LPINT;
 typedef long LONG, *PLONG, *LPLONG;
 typedef long long LONGLONG, *PLONGLONG;
 

--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -18,6 +18,7 @@ typedef long long LONGLONG, *PLONGLONG;
 typedef unsigned char UCHAR, *PUCHAR;
 typedef unsigned short USHORT, *PUSHORT, CSHORT;
 typedef unsigned short WORD, WCHAR, *PWSTR;
+typedef unsigned int UINT, *PUINT, *LPUINT;
 typedef unsigned long DWORD, *PDWORD, *LPDWORD;
 typedef unsigned long ULONG, *PULONG;
 typedef unsigned long long ULONGLONG;


### PR DESCRIPTION
This exposes these types through windef.h (which primarily includes xboxdef.h).
This is necessary for https://github.com/XboxDev/nxdk-sdl/pull/24#discussion_r366668605.

I wasn't sure wether I should add these types to windef.h directly as they aren't used in the kernel (yet?).
I decided for xboxdef.h because our windef.h is really slim right now. Also our xboxdef.h already has `DWORD_PTR` which isn't used in the kernel either (also, that one should actually be in BaseTsd.h instead, so we have to refactor in the future anyway). 

You can find the documentation for these types here: https://docs.microsoft.com/en-us/windows/win32/winprog/windows-data-types

*(Random note: Our windef.h should probably also be renamed to WinDef.h in the future, to deal with case-sensitivity)*