### PR TITLE
audio: Fix MmGetPhysicalAddress() assertion on debug BIOS

### DIFF
--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -103,6 +103,11 @@ void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, 
 	KIRQL irql;
 	ULONG vector;
 
+	// Hack to prevent an assertion in MmGetPhysicalAddress by locking the memory.
+	// A future API redesign should use proper allocation
+	// (MmAllocateContiguousMemory) instead.
+	MmLockUnlockBufferPages((PVOID)pac97device, sizeof(AC97_DEVICE), FALSE);
+
 	pac97device->mmio = (unsigned int *)0xfec00000;
 	pac97device->nextDescriptorMod31 = 0;
 	pac97device->callback = callback;


### PR DESCRIPTION
OpenXDK XAudio code currently doesn't work on debug BIOSes, due to triggering an assertion in `MmGetPhysicalAddress()` when calling `XAudioInit`. Without attaching a debugger, this looks like a hang, but it actually is a check whether the pages are locked in memory (which they should be for MMIO/DMA). This commit fixes it by manually locking the pages before calling that function.

There are other, less obvious, issues with that code though. The memory for the descriptors is part of `ac97Device`, which resides in `.data`. One day someone may get unlucky and have a descriptor entry cross a page-boundary with those two pages not being contiguous, and crazy things will happen.