### PR TITLE
lwip C++ compat fixes

### DIFF
--- a/lib/net/Makefile
+++ b/lib/net/Makefile
@@ -18,3 +18,6 @@ SRCS += $(LWIPSRCS) $(DRIVERSRCS)
 CFLAGS += -I $(LWIPDIR)/include
 CFLAGS += -I $(NXDK_DIR)/lib/net/nforceif/include
 CFLAGS += -I $(NXDK_DIR)/lib/net/pktdrv
+CXXFLAGS += -I $(LWIPDIR)/include
+CXXFLAGS += -I $(NXDK_DIR)/lib/net/nforceif/include
+CXXFLAGS += -I $(NXDK_DIR)/lib/net/pktdrv

--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -43,7 +43,7 @@
 #define LWIP_IPV4 1
 #define LWIP_IPV6 1
 #define LWIP_DEBUG 1
-#define LWIP_ERRNO_INCLUDE <errno.h>
+#define LWIP_ERRNO_STDINCLUDE 1
 #define LWIP_COMPAT_MUTEX_ALLOWED
 #define SYS_LIGHTWEIGHT_PROT 0
 

--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -437,7 +437,13 @@
 #define TCP_QLEN_DEBUG   LWIP_DBG_ON
 #define TCP_RST_DEBUG    LWIP_DBG_ON
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 extern unsigned char debug_flags;
+#ifdef __cplusplus
+}
+#endif
 #define LWIP_DBG_TYPES_ON debug_flags
 
 

--- a/lib/net/pktdrv/pktdrv.h
+++ b/lib/net/pktdrv/pktdrv.h
@@ -1,6 +1,10 @@
 #ifndef _Pktdrv_
 #define _Pktdrv_
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern void* PktdrvMmioBase;
 extern unsigned int PktdrvInterrupt;
 
@@ -10,5 +14,9 @@ int Pktdrv_ReceivePackets(void);
 void Pktdrv_SendPacket(unsigned char *buffer,int length);
 void Pktdrv_GetEthernetAddr(unsigned char *address);
 int Pktdrv_GetQueuedTxPkts(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
This fixes some issues that occur when using lwip from C++, such as missing include paths, name mangling, and issues with including `errno.h.` (which was encountered by @dracc).

Mostly tested by building one of the http server samples as C++ code, and @dracc's ftpserver-branch of NevolutionX.

Closes #296.