### PR TITLE
xboxrt: Fix lld dropping the _fltused symbol when using LTO

### DIFF
--- a/lib/xboxrt/c_runtime/_fltused.c
+++ b/lib/xboxrt/c_runtime/_fltused.c
@@ -1,1 +1,2 @@
+#pragma comment(linker, "/include:__fltused")
 int _fltused = 1;


### PR DESCRIPTION
For some reason `_fltused` seems to get dropped somewhere when using LTO, even though it's implicitly referenced. I'm not sure what exactly causes this, and whether this is expected with this special symbol, or a bug in clang, or lld...

Adding a linker pragma fixes this, though. It should only be added when the obj file is pulled in, so it should be fine to have it there.