### PR TITLE
build: Use /fixed:no instead of /dll

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-threadsafe-statics -fno-rtti
-NXDK_LDFLAGS = -subsystem:windows -dll -entry:XboxCRTEntry \
+NXDK_LDFLAGS = -subsystem:windows -fixed:no -entry:XboxCRTEntry \
                -stack:$(NXDK_STACKSIZE) -safeseh:no
 
 # Multithreaded LLD on Windows hang workaround


### PR DESCRIPTION
Just a little thing I noticed when I was investigating optimization options - we're currently using `/dll` in order to get a PE file with a `.reloc` section, but we can have that by just using `/fixed:no`, which has the benefit of not generating an unnecessary import lib (which may confuse people).

I tested the change, and everything still seems to work fine.