### PR TITLE
Implement GetDiskFreeSpaceExA() / GetDiskFreeSpaceA()

### DIFF
--- a/lib/winapi/fileapi.h
+++ b/lib/winapi/fileapi.h
@@ -38,6 +38,8 @@ BOOL RemoveDirectoryA (LPCSTR lpPathName);
 BOOL CreateDirectoryA (LPCSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes);
 BOOL MoveFileA (LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName);
 
+BOOL GetDiskFreeSpaceExA (LPCSTR lpDirectoryName, PULARGE_INTEGER lpFreeBytesAvailableToCaller, PULARGE_INTEGER lpTotalNumberOfBytes, PULARGE_INTEGER lpTotalNumberOfFreeBytes);
+
 #ifndef UNICODE
 #define GetFileAttributes GetFileAttributesA
 #define GetFileAttributesEx GetFileAttributesExA
@@ -49,6 +51,7 @@ BOOL MoveFileA (LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName);
 #define RemoveDirectory(...) RemoveDirectoryA(__VA_ARGS__)
 #define CreateDirectory(...) CreateDirectoryA(__VA_ARGS__)
 #define MoveFile(...) MoveFileA(__VA_ARGS__)
+#define GetDiskFreeSpaceEx GetDiskFreeSpaceExA
 #else
 #error nxdk does not support the Unicode API
 #endif

--- a/lib/winapi/fileapi.h
+++ b/lib/winapi/fileapi.h
@@ -39,6 +39,7 @@ BOOL CreateDirectoryA (LPCSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttrib
 BOOL MoveFileA (LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName);
 
 BOOL GetDiskFreeSpaceExA (LPCSTR lpDirectoryName, PULARGE_INTEGER lpFreeBytesAvailableToCaller, PULARGE_INTEGER lpTotalNumberOfBytes, PULARGE_INTEGER lpTotalNumberOfFreeBytes);
+BOOL GetDiskFreeSpaceA (LPCSTR lpRootPathName, LPDWORD lpSectorsPerCluster, LPDWORD lpBytesPerSector, LPDWORD lpNumberOfFreeClusters, LPDWORD lpTotalNumberOfClusters);
 
 #ifndef UNICODE
 #define GetFileAttributes GetFileAttributesA
@@ -52,6 +53,7 @@ BOOL GetDiskFreeSpaceExA (LPCSTR lpDirectoryName, PULARGE_INTEGER lpFreeBytesAva
 #define CreateDirectory(...) CreateDirectoryA(__VA_ARGS__)
 #define MoveFile(...) MoveFileA(__VA_ARGS__)
 #define GetDiskFreeSpaceEx GetDiskFreeSpaceExA
+#define GetDiskFreeSpace GetDiskFreeSpaceA
 #else
 #error nxdk does not support the Unicode API
 #endif


### PR DESCRIPTION
This implements `GetDiskFreeSpaceExA()` and `GetDiskFreeSpaceA()`.
I checked the results of both functions against the values reported by the dashboard on my Xbox, and they do match. The error reporting (both `SetLastError(ERROR_PATH_NOT_FOUND);` and returning `0xFFFFFFFF` in `GetDiskFreeSpaceA()`) were checked against the behavior of Windows 7.