### PR TITLE
lwip: Change submodule URL to GitHub mirror

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/XboxDev/extract-xiso.git
 [submodule "lib/net/lwip"]
 	path = lib/net/lwip
-	url = git://git.savannah.nongnu.org/lwip.git
+	url = https://github.com/lwip-tcpip/lwip.git
 [submodule "lib/sdl/SDL2"]
 	path = lib/sdl/SDL2
 	url = https://github.com/XboxDev/nxdk-sdl.git


### PR DESCRIPTION
This changes the submodule URL for lwIP from `git://git.savannah.nongnu.org/lwip.git`, their normal repo, to `https://github.com/lwip-tcpip/lwip.git`, their GitHub mirror, which they also use for CI.

The main reason for this is to allow shallow cloning, which doesn't work with their regular repo. It also has the benefit of GitHub allowing you to browse the submodule repo at the version used in nxdk by simply clicking on the submodule folder in the nxdk repo.

To update the local submodule remote URL one needs to run `git submodule sync`.