### PR TITLE
ci: Use shallow cloning

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Clone Tree
         uses: actions/checkout@v1
         with:
+          fetch-depth: 1
           submodules: recursive
       - name: Install MSYS2 & Dependencies
         run: |
@@ -33,6 +34,7 @@ jobs:
       - name: Clone Tree
         uses: actions/checkout@v1
         with:
+          fetch-depth: 1
           submodules: recursive
       - name: Install Dependencies
         run: |
@@ -48,6 +50,7 @@ jobs:
       - name: Clone Tree
         uses: actions/checkout@v1
         with:
+          fetch-depth: 1
           submodules: recursive
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
This changes the GH workflow to do shallow clones of git repos, which reduces the amount of traffic we cause on the build VM and the cloning time a bit.