### PR TITLE
libc: Implement case-insensitive string comparison functions

### DIFF
--- a/lib/xboxrt/libc_extensions/string_ext_.c
+++ b/lib/xboxrt/libc_extensions/string_ext_.c
@@ -1,3 +1,6 @@
+#include <assert.h>
+#include <errno.h>
+#include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -14,3 +17,45 @@ char *strdup (const char *s)
 
     return new_s;
 }
+
+int _strnicmp (const char *s1, const char *s2, size_t n)
+{
+    assert(s1);
+    assert(s2);
+
+    if (!s1 || !s2) {
+        errno = EINVAL;
+        return _NLSCMPERROR;
+    }
+
+    while (n && *s1 && (tolower(*s1) == tolower(*s2))) {
+        ++s1;
+        ++s2;
+        --n;
+    }
+
+    if (n == 0) {
+        return 0;
+    } else {
+        return (tolower(*(unsigned char *)s1) - tolower(*(unsigned char *)s2));
+    }
+}
+
+int _stricmp (const char *s1, const char *s2)
+{
+    assert(s1);
+    assert(s2);
+
+    if (!s1 || !s2) {
+        errno = EINVAL;
+        return _NLSCMPERROR;
+    }
+
+    while (*s1 && (tolower(*s1) == tolower(*s2))) {
+        ++s1;
+        ++s2;
+    }
+
+    return (tolower(*(unsigned char *)s1) - tolower(*(unsigned char *)s2));
+}
+

--- a/lib/xboxrt/libc_extensions/string_ext_.h
+++ b/lib/xboxrt/libc_extensions/string_ext_.h
@@ -9,6 +9,27 @@ static char *_strdup (const char *s)
     return strdup(s);
 }
 
+// Compared to their Win32 counterparts, these functions currently don't invoke
+// an invalid parameter handler routine as described in the MSDN, and instead
+// behave as if the invalid parameter handler allowed to continue execution.
+int _strnicmp (const char *s1, const char *s2, size_t n);
+int _stricmp (const char *s1, const char *s2);
+
+__attribute__((deprecated)) static int strnicmp (const char *s1, const char *s2, size_t n)
+{
+    return _strnicmp(s1, s2, n);
+}
+
+__attribute__((deprecated)) static int stricmp (const char *s1, const char *s2)
+{
+    return _stricmp(s1, s2);
+}
+
+#ifndef NLSCMP_DEFINED
+#define _NLSCMPERROR 0x7FFFFFFF
+#define _NLSCMP_DEFINED
+#endif
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This adds `_stricmp`, `stricmp`, `_strnicmp` and `strnicmp` as libc extensions. This hopefully eliminates the need for some workarounds, such as in @Ryzee119's SDLPoP port.

The code is copied from PDCLib's normal comparison functions, but adjusted to behave like the MSDN describes. The only difference is that it doesn't invoke an invalid parameter handler routine when encountering a null pointer, instead it behaves as if the invalid parameter handler routine allowed to continue execution. I added asserts to still catch those errors in debug builds.

Interestingly, ReactOS's version of these functions does not do that at all, and also uses `toupper` instead of `tolower` (the latter being what the MSDN describes).