### PR TITLE
Build winapi and xboxrt as libraries

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,8 +1,8 @@
 SRCS += \
-	$(wildcard $(NXDK_DIR)/lib/winapi/*.c) \
 	$(wildcard $(NXDK_DIR)/lib/pbkit/*.c)
 
 include $(NXDK_DIR)/lib/Makefile-pdclib
+include $(NXDK_DIR)/lib/winapi/Makefile
 include $(NXDK_DIR)/lib/hal/Makefile
 include $(NXDK_DIR)/lib/nxdk/Makefile
 include $(NXDK_DIR)/lib/usb/Makefile

--- a/lib/winapi/Makefile
+++ b/lib/winapi/Makefile
@@ -1,0 +1,27 @@
+WINAPI_SRCS := \
+	$(NXDK_DIR)/lib/winapi/debug.c \
+	$(NXDK_DIR)/lib/winapi/errhandlingapi.c \
+	$(NXDK_DIR)/lib/winapi/error.c \
+	$(NXDK_DIR)/lib/winapi/fiber.c \
+	$(NXDK_DIR)/lib/winapi/fileio.c \
+	$(NXDK_DIR)/lib/winapi/filemanip.c \
+	$(NXDK_DIR)/lib/winapi/findfile.c \
+	$(NXDK_DIR)/lib/winapi/handleapi.c \
+	$(NXDK_DIR)/lib/winapi/memory.c \
+	$(NXDK_DIR)/lib/winapi/profiling.c \
+	$(NXDK_DIR)/lib/winapi/sync.c \
+	$(NXDK_DIR)/lib/winapi/sysinfo.c \
+	$(NXDK_DIR)/lib/winapi/thread.c \
+	$(NXDK_DIR)/lib/winapi/tls.c
+
+WINAPI_OBJS = $(addsuffix .obj, $(basename $(WINAPI_SRCS)))
+
+$(NXDK_DIR)/lib/libwinapi.lib: $(WINAPI_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libwinapi.lib
+
+CLEANRULES += clean-winapi
+
+.PHONY: clean-winapi
+clean-winapi:
+	$(VE)rm -f $(WINAPI_OBJS) $(NXDK_DIR)/lib/libwinapi.lib

--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -1,4 +1,4 @@
-SRCS += \
+XBOXRT_SRCS := \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/stat.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/strings.c \
 	$(NXDK_DIR)/lib/xboxrt/libc_extensions/wchar.c \
@@ -22,3 +22,15 @@ SRCS += \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_exception.cpp \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/eh.cpp
+
+XBOXRT_OBJS = $(addsuffix .obj, $(basename $(XBOXRT_SRCS)))
+
+$(NXDK_DIR)/lib/libxboxrt.lib: $(XBOXRT_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libxboxrt.lib
+
+CLEANRULES += clean-xboxrt
+
+.PHONY: clean-xboxrt
+clean-xboxrt:
+	$(VE)rm -f $(XBOXRT_OBJS) $(NXDK_DIR)/lib/libxboxrt.lib


### PR DESCRIPTION
For using CMake or other build systems, it is more suitable to have these "modules" as actual libraries.