### PR TITLE
Spell "nxdk" in lowercase

### DIFF
--- a/samples/hello/main.c
+++ b/samples/hello/main.c
@@ -7,7 +7,7 @@ int main(void)
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
     while(1) {
-        debugPrint("Hello NXDK!\n");
+        debugPrint("Hello nxdk!\n");
         Sleep(2000);
     }
 

--- a/samples/httpd_bsd/httpserver.c
+++ b/samples/httpd_bsd/httpserver.c
@@ -21,7 +21,7 @@
 #define PORT "80"   // port we're listening on
 
 static const char http_html_hdr[] = "HTTP/1.1 200 OK\r\nContent-type: text/html\r\nContent-Length: 77\r\n\r\n";
-static const char http_body_template[] = "<html><head><title>NXDK</title></head><body>%04d-%02d-%02dT%02d:%02d:%02d</body></html>";
+static const char http_body_template[] = "<html><head><title>nxdk</title></head><body>%04d-%02d-%02dT%02d:%02d:%02d</body></html>";
 static char http_body[78];
 
 // get sockaddr, IPv4 or IPv6:

--- a/samples/sdl_ttf/main.c
+++ b/samples/sdl_ttf/main.c
@@ -34,7 +34,7 @@ int main(void) {
   SDL_Surface  *surface;
   TTF_Font     *font;
 
-  window = SDL_CreateWindow("NXDK SDL_ttf sample",
+  window = SDL_CreateWindow("nxdk SDL_ttf sample",
                             SDL_WINDOWPOS_UNDEFINED,
                             SDL_WINDOWPOS_UNDEFINED,
                             SCREEN_WIDTH, SCREEN_HEIGHT,
@@ -62,7 +62,7 @@ int main(void) {
   }
 
   SDL_Color font_color = {0x7F, 0xFF, 0x7F, 0xFF};
-  surface = TTF_RenderText_Blended(font, "NXDK", font_color);
+  surface = TTF_RenderText_Blended(font, "nxdk", font_color);
   TTF_CloseFont(font);
   if (surface == NULL) {
     debugPrint("TTF_RenderText failed: %s", TTF_GetError());


### PR DESCRIPTION
This makes the spelling of "nxdk" a bit more consistent.

We have been going back and forth with "NXDK" and "nxdk", but most instances are "nxdk" (in lowercase) now.

Some instances of uppercase spellings might still exist in code comments / submodules. We can fix those later / when we touch such code.

`NXDK` remains a preprocessor macro for finding out if compilation is happening with nxdk.