### PR TITLE
pdclib: Update submodule to 31473f1

### DIFF
--- a/samples/sdl_ttf/main.c
+++ b/samples/sdl_ttf/main.c
@@ -52,7 +52,7 @@ int main(void) {
     goto cleanup;
   }
 
-  const char* font_path = "vegur-regular.ttf";
+  const char* font_path = "D:\\vegur-regular.ttf";
   const int font_size = 96;
   font = TTF_OpenFont(font_path, font_size);
   if (font == NULL) {


### PR DESCRIPTION
Changes in pdclib:

- xbox: Switch to using winapi for file I/O
- Implement gmtime()

The second change (gmtime) is just a minor one. I assume there won't be any issues.

The first change (winapi file I/O) is more critical and it's a breaking change. Existing apps will have to be reworked to use absolute paths and backslash instead forward-slash. The same path limitation exists with XDK, but it did not previously exist in nxdk / OpenXDK. Such limitations also do not exist on Windows.

You must also manually mount partitions that you plan to use. "D:" is typically auto-mounted as the current XBE path or DVD drive (depending on who mounts it). No other partitions are mounted by default.

We are considering to bring this closer to Windows, but it will take a lot more time. So please update your applications.

Due to the breaking nature of this change, I'd recommend to keep this open until at least after this weekend (this is the final warning, in addition to the many warnings present in https://github.com/XboxDev/nxdk-pdclib/pull/15).

Our SDL_ttf sample was fixed to reflect these path conventions. I did not spot the use of relative paths in the other samples. More testing would be appreciated.
