### PR TITLE
build: Replacing wildcards with paths

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,5 +1,5 @@
 SRCS += \
-	$(wildcard $(NXDK_DIR)/lib/pbkit/*.c)
+	$(NXDK_DIR)/lib/pbkit/pbkit.c
 
 include $(NXDK_DIR)/lib/Makefile-pdclib
 include $(NXDK_DIR)/lib/winapi/Makefile

--- a/lib/net/Makefile
+++ b/lib/net/Makefile
@@ -9,8 +9,9 @@ LWIPSRCS := $(COREFILES) \
             $(APIFILES)
 
 # Include driver sources
-DRIVERSRCS := $(wildcard $(NXDK_DIR)/lib/net/pktdrv/*.c) \
-              $(wildcard $(NXDK_DIR)/lib/net/nforceif/src/*.c)
+DRIVERSRCS := $(NXDK_DIR)/lib/net/pktdrv/pktdrv.c \
+              $(NXDK_DIR)/lib/net/nforceif/src/driver.c \
+              $(NXDK_DIR)/lib/net/nforceif/src/sys_arch.c
 
 SRCS += $(LWIPSRCS) $(DRIVERSRCS)
 

--- a/samples/gamma-fade/Makefile
+++ b/samples/gamma-fade/Makefile
@@ -1,5 +1,5 @@
 XBE_TITLE=gamma-fade
 GEN_XISO = $(XBE_TITLE).iso
-SRCS = $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..
 include $(NXDK_DIR)/Makefile

--- a/samples/gamma/Makefile
+++ b/samples/gamma/Makefile
@@ -1,5 +1,5 @@
 XBE_TITLE=gamma
 GEN_XISO = $(XBE_TITLE).iso
-SRCS = $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..
 include $(NXDK_DIR)/Makefile

--- a/samples/hello/Makefile
+++ b/samples/hello/Makefile
@@ -1,5 +1,5 @@
 XBE_TITLE=hello
 GEN_XISO = $(XBE_TITLE).iso
-SRCS = $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..
 include $(NXDK_DIR)/Makefile

--- a/samples/httpd/Makefile
+++ b/samples/httpd/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE=httpd
 GEN_XISO = $(XBE_TITLE).iso
-SRCS += $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/main.c $(CURDIR)/httpserver.c
 NXDK_DIR = $(CURDIR)/../..
 NXDK_NET=y
 include $(NXDK_DIR)/Makefile

--- a/samples/httpd_bsd/Makefile
+++ b/samples/httpd_bsd/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE=httpd_bsd
 GEN_XISO = $(XBE_TITLE).iso
-SRCS += $(CURDIR)/main.c $(CURDIR)/httpserver.c
+SRCS = $(CURDIR)/main.c $(CURDIR)/httpserver.c
 NXDK_DIR = $(CURDIR)/../..
 NXDK_NET=y
 include $(NXDK_DIR)/Makefile

--- a/samples/led/Makefile
+++ b/samples/led/Makefile
@@ -1,5 +1,5 @@
 XBE_TITLE=led
 GEN_XISO = $(XBE_TITLE).iso
-SRCS = $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..
 include $(NXDK_DIR)/Makefile

--- a/samples/mesh/Makefile
+++ b/samples/mesh/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE = mesh
 GEN_XISO = $(XBE_TITLE).iso
-SRCS = $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/math3d.c $(CURDIR)/main.c
 SHADER_OBJS = ps.inl vs.inl
 NXDK_DIR = $(CURDIR)/../..
 

--- a/samples/sdl/Makefile
+++ b/samples/sdl/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE = sdl
 GEN_XISO = $(XBE_TITLE).iso
-SRCS += $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..
 NXDK_SDL = y
 include $(NXDK_DIR)/Makefile

--- a/samples/sdl_image/Makefile
+++ b/samples/sdl_image/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE = sdl_image
 GEN_XISO = $(XBE_TITLE).iso
-SRCS += $(CURDIR)/main.c
+SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..
 NXDK_SDL = y
 include $(NXDK_DIR)/Makefile

--- a/samples/sdl_ttf/Makefile
+++ b/samples/sdl_ttf/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE = sdl_ttf
 GEN_XISO = $(XBE_TITLE).iso
-SRCS += $(CURDIR)/main.c
+SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..
 NXDK_SDL = y
 

--- a/samples/triangle/Makefile
+++ b/samples/triangle/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE = triangle
 GEN_XISO = $(XBE_TITLE).iso
-SRCS = $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/main.c
 SHADER_OBJS = ps.inl vs.inl
 NXDK_DIR = $(CURDIR)/../..
 include $(NXDK_DIR)/Makefile

--- a/samples/xaudio/Makefile
+++ b/samples/xaudio/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE = xaudio
 GEN_XISO = $(XBE_TITLE).iso
-SRCS = $(wildcard $(CURDIR)/*.c)
+SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..
 
 all: nxdk_wav.h

--- a/tools/cxbe/Makefile
+++ b/tools/cxbe/Makefile
@@ -1,5 +1,18 @@
-INCLUDES := $(wildcard *.h)
-SRCS := $(wildcard *.cpp)
+INCLUDES := \
+	AlignPosfix1.h \
+	AlignPrefix1.h \
+	Common.h \
+	Cxbx.h \
+	Error.h \
+	Exe.h \
+	Xbe.h
+SRCS := \
+	Main.cpp \
+	Common.cpp \
+	Error.cpp \
+	Exe.cpp \
+	OpenXDK.cpp \
+	Xbe.cpp
 
 cxbe: $(SRCS) $(INCLUDES)
 	$(CXX) -o '$@' $(SRCS)

--- a/tools/fp20compiler/Makefile
+++ b/tools/fp20compiler/Makefile
@@ -1,12 +1,22 @@
 MAIN = fp20compiler
 CXXFLAGS= -DYY_NO_UNPUT -Wall -g
 
-INCLUDES = $(wildcard *.h) \
+INCLUDES = \
+	nvparse_errors.h \
+	nvparse_externs.h \
+	ps1.0_program.h \
+	rc1.0_combiners.h \
+	rc1.0_final.h \
+	rc1.0_general.h \
+	rc1.0_register.h \
+	ts1.0_inst.h \
+	ts1.0_inst_list.h \
 	_ps1.0_parser.hpp \
 	_rc1.0_parser.hpp \
 	_ts1.0_parser.hpp
 
-SRCS = main.cpp \
+SRCS = \
+	main.cpp \
 	nvparse_errors.cpp \
 	rc1.0_combiners.cpp \
 	rc1.0_final.cpp \

--- a/tools/vp20compiler/Makefile
+++ b/tools/vp20compiler/Makefile
@@ -1,8 +1,13 @@
 MAIN = vp20compiler
 
-INCLUDES = $(wildcard *.h)
+INCLUDES = \
+	config.h \
+	mtypes.h \
+	nvvertparse.h \
+	prog_instruction.h
 
-SRCS = nvvertparse.c \
+SRCS = \
+	nvvertparse.c \
 	prog_instruction.c \
 	main.c
 


### PR DESCRIPTION
Hi,
closes #67

I replaced all wildcards in all Makefiles I could find. There are still wildcards in these sub-repositories:

- `lib/zlib`
- `lib/pdcib`
- `lib/sdl`
- `lib/net/lwip`