### PR TITLE
Implement more WaitFor* functions for winapi

### DIFF
--- a/lib/winapi/sync.c
+++ b/lib/winapi/sync.c
@@ -79,6 +79,30 @@ DWORD WaitForSingleObject (HANDLE hHandle, DWORD dwMilliseconds)
     return WaitForSingleObjectEx(hHandle, dwMilliseconds, FALSE);
 }
 
+DWORD WaitForMultipleObjectsEx (DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAll, DWORD dwMilliseconds, BOOL bAlertable)
+{
+    LARGE_INTEGER duration;
+    duration.QuadPart = ((LONGLONG)dwMilliseconds) * -10000;
+
+    while (true) {
+        NTSTATUS status = NtWaitForMultipleObjectsEx(nCount, lpHandles, bWaitAll ? WaitAll : WaitAny, UserMode, bAlertable, &duration);
+
+        if (status == STATUS_ALERTED) continue;
+
+        if (!NT_SUCCESS(status)) {
+            SetLastError(RtlNtStatusToDosError(status));
+            return WAIT_FAILED;
+        }
+
+        return status;
+    }
+}
+
+DWORD WaitForMultipleObjects (DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAll, DWORD dwMilliseconds)
+{
+    return WaitForMultipleObjectsEx(nCount, lpHandles, bWaitAll, dwMilliseconds, FALSE);
+}
+
 HANDLE CreateSemaphore (LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCSTR lpName)
 {
     NTSTATUS status;

--- a/lib/winapi/sync.c
+++ b/lib/winapi/sync.c
@@ -74,6 +74,11 @@ DWORD WaitForSingleObjectEx (HANDLE hHandle, DWORD dwMilliseconds, BOOL bAlertab
     }
 }
 
+DWORD WaitForSingleObject (HANDLE hHandle, DWORD dwMilliseconds)
+{
+    return WaitForSingleObjectEx(hHandle, dwMilliseconds, FALSE);
+}
+
 HANDLE CreateSemaphore (LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCSTR lpName)
 {
     NTSTATUS status;

--- a/lib/winapi/synchapi.h
+++ b/lib/winapi/synchapi.h
@@ -29,6 +29,8 @@ DWORD SleepEx (DWORD dwMilliseconds, BOOL bAlertable);
 
 DWORD WaitForSingleObjectEx (HANDLE hHandle, DWORD dwMilliseconds, BOOL bAlertable);
 DWORD WaitForSingleObject (HANDLE hHandle, DWORD dwMilliseconds);
+DWORD WaitForMultipleObjectsEx (DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAll, DWORD dwMilliseconds, BOOL bAlertable);
+DWORD WaitForMultipleObjects (DWORD nCount, const HANDLE *lpHandles, BOOL bWaitAll, DWORD dwMilliseconds);
 
 HANDLE CreateSemaphore (LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCSTR lpName);
 BOOL ReleaseSemaphore (HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCount);

--- a/lib/winapi/synchapi.h
+++ b/lib/winapi/synchapi.h
@@ -28,6 +28,7 @@ VOID Sleep (DWORD dwMilliseconds);
 DWORD SleepEx (DWORD dwMilliseconds, BOOL bAlertable);
 
 DWORD WaitForSingleObjectEx (HANDLE hHandle, DWORD dwMilliseconds, BOOL bAlertable);
+DWORD WaitForSingleObject (HANDLE hHandle, DWORD dwMilliseconds);
 
 HANDLE CreateSemaphore (LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCSTR lpName);
 BOOL ReleaseSemaphore (HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCount);


### PR DESCRIPTION
Pulled from my OpenAL-soft port; but maybe also required elsewhere.

This adds the `WaitForSingleObject` function (simply forwarding to the existing `WaitForSingleObjectEx`).

I also decided to add `WaitForMultipleObjects` and `WaitForMultipleObjectsEx` (based on the existing `WaitForSingleObjectEx`).

None of this code was tested. I assume it works fine. If there are bugs, they likely already existed in the existing `WaitForMultipleObjects` functions or our xboxkrnl header.