### PR TITLE
winapi: Stub SHGetSpecialFolderPathA

### DIFF
--- a/lib/winapi/Makefile
+++ b/lib/winapi/Makefile
@@ -9,6 +9,7 @@ WINAPI_SRCS := \
 	$(NXDK_DIR)/lib/winapi/handleapi.c \
 	$(NXDK_DIR)/lib/winapi/memory.c \
 	$(NXDK_DIR)/lib/winapi/profiling.c \
+	$(NXDK_DIR)/lib/winapi/shlobj_core.c \
 	$(NXDK_DIR)/lib/winapi/sync.c \
 	$(NXDK_DIR)/lib/winapi/sysinfo.c \
 	$(NXDK_DIR)/lib/winapi/thread.c \

--- a/lib/winapi/shlobj.h
+++ b/lib/winapi/shlobj.h
@@ -1,0 +1,1 @@
+#include <shlobj_core.h>

--- a/lib/winapi/shlobj_core.c
+++ b/lib/winapi/shlobj_core.c
@@ -1,0 +1,7 @@
+#include <windows.h>
+#include <shlobj_core.h>
+
+BOOL SHGetSpecialFolderPathA (HWND hwnd, LPSTR pszPath, int csidl, BOOL fCreate)
+{
+    return FALSE;
+}

--- a/lib/winapi/shlobj_core.h
+++ b/lib/winapi/shlobj_core.h
@@ -1,0 +1,23 @@
+#ifndef __SHLOBJ_CORE_H__
+#define __SHLOBJ_CORE_H__
+
+#include <windef.h>
+#include <minwinbase.h>
+#include <winnt.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#ifndef CSIDL_APPDATA
+#define CSIDL_APPDATA 0x001A
+#endif
+
+BOOL SHGetSpecialFolderPathA (HWND hwnd, LPSTR pszPath, int csidl, BOOL fCreate);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/winapi/windef.h
+++ b/lib/winapi/windef.h
@@ -7,4 +7,6 @@
 
 #define MAX_PATH 260
 
+typedef HANDLE HWND;
+
 #endif


### PR DESCRIPTION
Pulled from my OpenAL-soft port; but maybe also required elsewhere.

This adds a stub for `SHGetSpecialFolderPathA` which will always fail on Xbox (at least for now).
I also added CSIDL_APPDATA as I found it in mingw source-code (they keep it in shfolder.h), because that's required for OpenAL-soft.

Normally this function is supposed to return a common path (like the users document folder), so a potential implementation would return UDATA / TDATA in the future (it's still a bad fit).

I tried to keep the filenames as named in MSDN - I don't have a Windows SDK to check if this is right.