### PR TITLE
winapi: Stub IsBadWritePtr

### DIFF
--- a/lib/winapi/Makefile
+++ b/lib/winapi/Makefile
@@ -1,4 +1,5 @@
 WINAPI_SRCS := \
+	$(NXDK_DIR)/lib/winapi/badptr.c \
 	$(NXDK_DIR)/lib/winapi/debug.c \
 	$(NXDK_DIR)/lib/winapi/errhandlingapi.c \
 	$(NXDK_DIR)/lib/winapi/error.c \

--- a/lib/winapi/badptr.c
+++ b/lib/winapi/badptr.c
@@ -1,0 +1,13 @@
+#include <windows.h>
+
+BOOL IsBadWritePtr (LPVOID lp, UINT_PTR ucb)
+{
+    // Windows appears to implement this by registering an SEH handler.
+    // The Microsoft implementation then probes each page.
+    // For Xbox, this is not suitable because `lp` potentially points at MMIO.
+
+    //FIXME: Walk allocations in region with NtQueryVirtualMemory and check write permission?
+
+    // We disallow all access for now, because memory is potentially unsafe
+    return TRUE;
+}

--- a/lib/winapi/basetsd.h
+++ b/lib/winapi/basetsd.h
@@ -1,0 +1,6 @@
+#ifndef __BASETSD_H__
+#define __BASETSD_H__
+
+typedef unsigned int UINT_PTR;
+
+#endif

--- a/lib/winapi/winbase.h
+++ b/lib/winapi/winbase.h
@@ -4,6 +4,7 @@
 #include <windef.h>
 #include <minwinbase.h>
 #include <winnt.h>
+#include <basetsd.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -92,6 +93,8 @@ DWORD GetLastError (void);
 void SetLastError (DWORD error);
 
 void WINAPI OutputDebugStringA (LPCTSTR lpOutputString);
+
+BOOL IsBadWritePtr (LPVOID lp, UINT_PTR ucb);
 
 #ifndef UNICODE
 #define OutputDebugString OutputDebugStringA


### PR DESCRIPTION
Pulled from my OpenAL-soft port; but maybe also required elsewhere.

This is a very weird function, which seems to probe page access rights (similar to `VirtualQuery` or `VirtualProtect`?). I'm not sure how this is implemented on Windows or how we should implement this on Xbox (also think of physical vs. virtual memory APIs on Xbox).

OpenAL seems to use it to check if enough elements in an array exist before trying to resize it.
I decided to stub it for now (and start upstreaming my changes as soon as possible, so they don't pile up). I might have to revisit / implement it in the near future, as I begin testing the port.

I wasn't sure about calling the file BaseTsd.h or basetsd.h - MSDN usually calls it BaseTsd.h, and due to case sensitivity, I decided to go with that.

The implementation is in badptr.c, because more similarly named functions like this exist, to check different permissions. [See "See also" in MSDN](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-isbadwriteptr).