### PR TITLE
winapi: Stub parts of dynamic-linker API

### DIFF
--- a/lib/winapi/Makefile
+++ b/lib/winapi/Makefile
@@ -9,6 +9,7 @@ WINAPI_SRCS := \
 	$(NXDK_DIR)/lib/winapi/findfile.c \
 	$(NXDK_DIR)/lib/winapi/handleapi.c \
 	$(NXDK_DIR)/lib/winapi/memory.c \
+	$(NXDK_DIR)/lib/winapi/libloaderapi.c \
 	$(NXDK_DIR)/lib/winapi/profiling.c \
 	$(NXDK_DIR)/lib/winapi/shlobj_core.c \
 	$(NXDK_DIR)/lib/winapi/sync.c \

--- a/lib/winapi/libloaderapi.c
+++ b/lib/winapi/libloaderapi.c
@@ -1,0 +1,42 @@
+#include <libloaderapi.h>
+#include <winbase.h>
+#include <windef.h>
+#include <winerror.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+#include <assert.h>
+#include <stdlib.h>
+
+HMODULE LoadLibraryExA (LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+    assert(hFile == NULL);
+    assert(dwFlags == 0);
+
+    // Always fail with not having found the library
+    SetLastError(ERROR_MOD_NOT_FOUND);
+    return NULL;
+}
+
+HMODULE LoadLibraryA (LPCSTR lpLibFileName)
+{
+    return LoadLibraryExA(lpLibFileName, NULL, 0);
+}
+
+BOOL FreeLibrary (HMODULE hLibModule)
+{
+    assert(hLibModule != NULL);
+
+    // Always claim success when free'ing a library
+    return TRUE;
+}
+
+FARPROC GetProcAddress (HMODULE hModule, LPCSTR lpProcName)
+{
+    // FIXME: If hModule is NULL, the symbol is looked up in the current module
+
+    // FIXME: If the module handle is invalid, fail with ERROR_MOD_NOT_FOUND
+
+    // Always fail with not having found the export
+    SetLastError(ERROR_PROC_NOT_FOUND);
+    return NULL;
+}

--- a/lib/winapi/libloaderapi.h
+++ b/lib/winapi/libloaderapi.h
@@ -1,0 +1,26 @@
+#ifndef __LIBLOADERAPI_H__
+#define __LIBLOADERAPI_H__
+
+#include <windef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+HMODULE LoadLibraryExA (LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
+HMODULE LoadLibraryA (LPCSTR lpLibFileName);
+BOOL FreeLibrary (HMODULE hLibModule);
+FARPROC GetProcAddress (HMODULE hModule, LPCSTR lpProcName);
+
+#ifndef UNICODE
+#define LoadLibraryEx LoadLibraryExA
+#define LoadLibrary LoadLibraryA
+#else
+#error nxdk does not support the Unicode API
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/winapi/windef.h
+++ b/lib/winapi/windef.h
@@ -3,10 +3,17 @@
 
 #include <xboxkrnl/xboxdef.h>
 
+#define far
+#define FAR far
+
 #define WINAPI __stdcall
 
 #define MAX_PATH 260
 
 typedef HANDLE HWND;
+typedef HANDLE HINSTANCE;
+typedef HINSTANCE HMODULE;
+
+typedef int (FAR WINAPI *FARPROC)();
 
 #endif

--- a/lib/winapi/windows.h
+++ b/lib/winapi/windows.h
@@ -6,6 +6,7 @@
 #include <fibersapi.h>
 #include <fileapi.h>
 #include <handleapi.h>
+#include <libloaderapi.h>
 #include <memoryapi.h>
 #include <processthreadsapi.h>
 #include <profileapi.h>


### PR DESCRIPTION
Pulled from my newton-dynamics port.

For now, it's just to make it easier to compile libraries or applications. Most applications will handle failure of `LoadLibrary` very gracefully (typically it's used for optional plugins).

Entirely untested at runtime, but tested compilation with:

```c
HMODULE* dll = LoadLibrary("sample.dll");
if (dll != NULL) {
  void* f = GetProcAddress(dll, "sample_function");
  FreeLibrary(dll);
}
```

I might implement a linker in the future (if nobody beats me to it).