### PR TITLE
winapi: Stub parts of Winmm.lib

### DIFF
--- a/lib/winapi/Makefile
+++ b/lib/winapi/Makefile
@@ -1,3 +1,5 @@
+include $(NXDK_DIR)/lib/winapi/winmm/Makefile
+
 WINAPI_SRCS := \
 	$(NXDK_DIR)/lib/winapi/debug.c \
 	$(NXDK_DIR)/lib/winapi/errhandlingapi.c \

--- a/lib/winapi/winmm/Makefile
+++ b/lib/winapi/winmm/Makefile
@@ -1,0 +1,17 @@
+WINMM_SRCS := \
+	$(NXDK_DIR)/lib/winapi/winmm/timeapi.c
+
+WINMM_OBJS = $(addsuffix .obj, $(basename $(WINMM_SRCS)))
+
+NXDK_CFLAGS += -I$(NXDK_DIR)/lib/winapi/winmm
+NXDK_CXXFLAGS += -I$(NXDK_DIR)/lib/winapi/winmm
+
+$(NXDK_DIR)/lib/winmm.lib: $(WINMM_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/winmm.lib
+
+CLEANRULES += clean-winmm
+
+.PHONY: clean-winmm
+clean-winmm:
+	$(VE)rm -f $(WINMM_OBJS) $(NXDK_DIR)/lib/winmm.lib

--- a/lib/winapi/winmm/mmsystem.h
+++ b/lib/winapi/winmm/mmsystem.h
@@ -1,0 +1,21 @@
+#ifndef __WINMM_MMSYSTEM_H__
+#define __WINMM_MMSYSTEM_H__
+
+#include <windef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define MMSYSERR_NOERROR 0
+
+typedef UINT MMRESULT;
+
+#include <timeapi.h>
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/winapi/winmm/timeapi.c
+++ b/lib/winapi/winmm/timeapi.c
@@ -1,0 +1,18 @@
+#include <timeapi.h>
+#include <winerror.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+MMRESULT timeBeginPeriod (UINT uPeriod)
+{
+    return TIMERR_NOERROR;
+}
+
+MMRESULT timeEndPeriod (UINT uPeriod)
+{
+    return TIMERR_NOERROR;
+}
+
+DWORD timeGetTime ()
+{
+    return KeTickCount;
+}

--- a/lib/winapi/winmm/timeapi.h
+++ b/lib/winapi/winmm/timeapi.h
@@ -1,0 +1,24 @@
+#ifndef __WINMM_TIMEAPI_H__
+#define __WINMM_TIMEAPI_H__
+
+#include <windef.h>
+#include <mmsystem.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define TIMERR_NOERROR 0
+#define TIMERR_NOCANDO 97
+
+MMRESULT timeBeginPeriod (UINT uPeriod);
+MMRESULT timeEndPeriod (UINT uPeriod);
+DWORD timeGetTime ();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+


### PR DESCRIPTION
This adds a stub for the most critical functions of Winmm.lib: `timeGetTime` and the period functions. This is built a separate library as this is likely where winapi will be heading.

~~I used "Winmm" instead of "winmm" because that's what MSDN often did. However, I'm already aware of projects linking against lowercase "winmm.lib". I'm not sure how to deal with this on case sensitive filesystems.~~ I'm now following MinGW style of all-lowercase.

I'm not sure how exactly the period functions should interact with the rest (if setting a high value as period will also reduce granularity of `timeGetTime`?). I'm also not sure if `timeBeginPeriod` and `timeEndPeriod` work like a stack.
For now, the `timeGetTime` will always run in milliseconds, and the period functions will always claim success. I still consider this a stub, not an implementation.

Our timer is the number of ticks and should always provide millisecond accuracy (which is the lowest / most accurate period you can get with these functions).

I decided to use the kernel export (`KeTickCount`) to avoid potential dependencies on other winapi libs in the future (for `GetTickCount()` for example).