### PR TITLE
libc: Stub Microsoft direct.h

### DIFF
--- a/lib/xboxrt/libc_extensions/direct.h
+++ b/lib/xboxrt/libc_extensions/direct.h
@@ -1,0 +1,1 @@
+// Part of Microsoft CRT


### PR DESCRIPTION
This can probably reuse code we'll eventually implement for unistd.h: https://en.wikipedia.org/wiki/Direct.h

newton-dynamic includes this file, but doesn't actually use it. Hence an empty file.

Because the name is vague I decided to leave a comment (this is different from the unistd.h which is completely empty, with no hint about it implementing UNIX / POSIX).