### PR TITLE
libc: Stub Microsoft _ASSERT macros in crtdbg.h

### DIFF
--- a/lib/xboxrt/libc_extensions/crtdbg.h
+++ b/lib/xboxrt/libc_extensions/crtdbg.h
@@ -1,0 +1,11 @@
+#ifndef XBOXRT_CRTDBG
+#define XBOXRT_CRTDBG
+
+#include <assert.h>
+
+// Part of Microsoft CRT
+#define _ASSERT_EXPR(booleanExpression, message) assert(booleanExpression)
+#define _ASSERT(booleanExpression) assert(booleanExpression)
+#define _ASSERTE(booleanExpression) assert(booleanExpression)
+
+#endif


### PR DESCRIPTION
This stubs the _ASSERT macros. See MSDN: https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/assert-asserte-assert-expr-macros?view=vs-2019

This file is included by newton-dynamics. It uses at least one of these macros (I forgot which one, and added all 3 for completeness).

The implementation is very naive and does not follow the description in the MSDN. I consider this a stub for now.