### PR TITLE
lwip: Enable AUTOIP module

### DIFF
--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -211,7 +211,7 @@
 /**
  * LWIP_AUTOIP==1: Enable AUTOIP module.
  */
-#define LWIP_AUTOIP                     0
+#define LWIP_AUTOIP                     1
 
 /*
    ----------------------------------


### PR DESCRIPTION
AUTOIP has different names, but it is:

- [IETF: RFC 3927](https://tools.ietf.org/html/rfc3927)
- [Microsoft: APIPA](https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-2000-server/cc958957(v=technet.10)?redirectedfrom=MSDN)
- [Wikipedia: Link-local address](https://en.wikipedia.org/wiki/Link-local_address)

I'd like to have it, because it allows zero-config system-link-like architecture without a central DHCP server and without static IP configurations.

---

Applications should be able to use it similar to DHCP, like this (untested code):

```c
#ifdef DHCP
#include <lwip/dhcp.h>
#else
#include <lwip/autoip.h>
#endif
```
```c
#ifdef DHCP
    dhcp_start(g_pnetif);
#else
    autoip_start(g_pnetif);
#endif
```
```c
#ifdef DHCP
    debugPrint("Waiting for IP (DHCP)...\n");
    while (dhcp_supplied_address(g_pnetif) == 0)
        NtYieldExecution();
#else
    debugPrint("Waiting for IP (AUTOIP)...\n");
    while (autoip_supplied_address(g_pnetif) == 0)
        NtYieldExecution();
#endif
```