### PR TITLE
video: Respect video-region when querying dashboard settings

### DIFF
--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -214,6 +214,8 @@ BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p)
 	DWORD dwAdapter = dwEnc & 0x000000FF;
 	DWORD dwStandard = dwEnc & 0x0000FF00;
 
+	bool is_pal = (dwStandard == VIDEO_REGION_PAL);
+
 	bool allow_480p = dwEnc & VIDEO_MODE_480P;
 	bool allow_720p = dwEnc & VIDEO_MODE_720P;
 	bool allow_1080i = dwEnc & VIDEO_MODE_1080I;
@@ -225,12 +227,11 @@ BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p)
 	}
 	if (refresh == 0)
 	{
-		if(dwEnc & 0x00400000)
+		if(is_pal)
 		{
+			refresh = (dwEnc & 0x00400000) ? 60 : 50;
+		} else {
 			refresh = 60;
-		} else
-		{
-			refresh = 50;
 		}
 	}
 	for(; position < iVidModes; position++)
@@ -246,7 +247,7 @@ BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p)
 		if(pVidMode->refresh != refresh)
 			continue;
 
-		if(dwAdapter == AV_PACK_HDTV)
+		if(!is_pal && (dwAdapter == AV_PACK_HDTV))
 		{
 			bool is_hd = pVidMode->dwMode & 0x80000000;
 


### PR DESCRIPTION
This hopefully closes #343. However, this code is untested and I have not tried to reproduce the problem.

- On PAL Xboxes, the users get to enable/disable PAL-60.
- On NTSC Xboxes, the users get to enable/disable 480p, 720p and 1080i.

However, nxdk code in master *always* looks at the PAL-60 setting, regardless of the video standard. It also always looks at the HD modes, regardless of video standard.

I'm not sure if the MS dashboards defaults to a safe value for PAL-60 (for NTSC), or safe values for 480p, 720p and 1080p (for PAL) if the video-standard does not have those settings.

This, potentially, causes trouble:

- On a PAL Xbox, we might accidentally reject all 480 line modes. PAL only has 480i (and no 480p), but if the NTSC 480p setting is turned on, we try to force 480p by rejecting all 480i modes.
- On a NTSC Xbox, we might accidentally reject all modes (all of them). NTSC only has 60Hz modes (and no 50Hz modes), but if the PAL-60 setting is disabled, we might reject all modes.

The code in this PR tries to avoid this problem, by:

**New handling of refresh rates**

- For PAL:
    - `REFRESH_DEFAULT`: Respecting the dashboard settings, by choosing 60 Hz if enabled, 50 Hz otherwise.
    - `REFRESH_50HZ`: Forcing 50 Hz mode.
    - `REFRESH_60HZ`: Forcing 60 Hz mode, even if disabled by dashboard. Applications should avoid doing this as the users TV might not support it.
- For NTSC:
    - `REFRESH_DEFAULT`: Forcing 60Hz mode.
    - `REFRESH_50HZ`: Forcing 50 Hz mode, but will fail because no such mode exists (yet?). Applications should avoid doing this as no such modes exist.
    - `REFRESH_60HZ`: Forcing 60 Hz mode.

In practice, this means that applications should always use `REFRESH_DEFAULT` and they'll have to deal with whatever refresh-rate they get.

**New handling of video-modes**

- For PAL: Simply tries to find an acceptable mode.
- For NTSC: Tries to find an acceptable mode, but also respects dashboard settings by rejecting disabled modes. If 480p is enabled, all 480i modes will be rejected. There is currently no way to force 480i mode if the user has 480p enabled.