### PR TITLE
vp20compiler: Various improvements and better support for NV2A

### DIFF
--- a/samples/mesh/main.c
+++ b/samples/mesh/main.c
@@ -227,7 +227,7 @@ int main(void)
                            3, sizeof(Vertex), &alloc_vertices[3]);
         
         /* Set texture coordinate attribute */
-        set_attrib_pointer(8, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
+        set_attrib_pointer(9, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
                            2, sizeof(Vertex), &alloc_vertices[6]);
 
         /* Begin drawing triangles */

--- a/tools/vp20compiler/config.h
+++ b/tools/vp20compiler/config.h
@@ -11,17 +11,7 @@
 #define MAX_NV_VERTEX_PROGRAM_PARAMS       192
 #define MAX_NV_VERTEX_PROGRAM_INPUTS        16
 #define MAX_HARDWARE_INPUTS                 16
-/*
- Actually Xbox has 11 outputs, however, the parser is using the GL spec and
- expects 8 units. From the GL spec (NV_vertex_program, section 2.14.1.5):
-
-   "If the number of texture units supported is less than eight, the values of
-    vertex result registers that do not correspond to existent texture units
-    are ignored."
-
- So despite only having 4 texture units, we provide 8 texture units here.
- = 11 actual outputs (including 4 texture units) + 4 fake texture-units.
-*/
-#define MAX_NV_VERTEX_PROGRAM_OUTPUTS       (11+4)
+#define MAX_NV_VERTEX_PROGRAM_OUTPUTS       15
+#define MAX_HARDWARE_OUTPUTS                15
 
 #endif

--- a/tools/vp20compiler/config.h
+++ b/tools/vp20compiler/config.h
@@ -10,6 +10,7 @@
 #define MAX_NV_VERTEX_PROGRAM_TEMPS         13
 #define MAX_NV_VERTEX_PROGRAM_PARAMS       192
 #define MAX_NV_VERTEX_PROGRAM_INPUTS        16
+#define MAX_HARDWARE_INPUTS                 16
 /*
  Actually Xbox has 11 outputs, however, the parser is using the GL spec and
  expects 8 units. From the GL spec (NV_vertex_program, section 2.14.1.5):

--- a/tools/vp20compiler/main.c
+++ b/tools/vp20compiler/main.c
@@ -540,9 +540,18 @@ void translate(const char* str)
                     // TODO: the index needs ajustment?
                     vsh_set_field(vsh_ins, FLD_CONST, reg.Index+96);
                 } else if (reg.File == PROGRAM_INPUT) {
+                    int in_reg;
+                    const char* name = _mesa_nv_vertex_input_register_name(reg.Index);
+                    for (in_reg = 0; _mesa_nv_vertex_hw_input_register_name(in_reg); in_reg++) {
+                        if (strcmp(name, _mesa_nv_vertex_hw_input_register_name(in_reg)) == 0) {
+                            break;
+                        }
+                    }
+                    if (!_mesa_nv_vertex_hw_input_register_name(in_reg)) {
+                        assert(false);
+                    }
                     vsh_set_field(vsh_ins, mux_field[j], PARAM_V);
-                    //TODO: also needs ajustment?
-                    vsh_set_field(vsh_ins, FLD_V, reg.Index);
+                    vsh_set_field(vsh_ins, FLD_V, in_reg);
                 } else {
                     assert(false);
                 }

--- a/tools/vp20compiler/main.c
+++ b/tools/vp20compiler/main.c
@@ -164,21 +164,6 @@ static const VshFieldMapping field_mapping[] = {
     {  FLD_FINAL,            3,    0,     1 }
 };
 
-
-typedef enum {
-    OUTREG_oPos = 0,
-    OUTREG_oD0 = 3,
-    OUTREG_oD1,
-    OUTREG_oFog,
-    OUTREG_oPts,
-    OUTREG_oB0,
-    OUTREG_oB1,
-    OUTREG_oT0,
-    OUTREG_oT1,
-    OUTREG_oT2,
-    OUTREG_oT3
-} VshOutReg;
-
 typedef enum {
     MASK_W = 1,   
     MASK_Z,   
@@ -456,34 +441,17 @@ void translate(const char* str)
                 } else if (ilu) {
                     vsh_set_field(vsh_ins, FLD_OUT_MUX, OMUX_ILU);
                 }
-                vsh_set_field(vsh_ins, FLD_OUT_ORB, OUTPUT_O);
-                const char* dst_name = _mesa_nv_vertex_output_register_name(ins.DstReg.Index);
-                uint8_t out_reg = 0;
-                if (strcmp(dst_name, "HPOS") == 0) {
-                    out_reg = OUTREG_oPos;
-                } else if (strcmp(dst_name, "COL0") == 0) {
-                    out_reg = OUTREG_oD0;
-                } else if (strcmp(dst_name, "COL1") == 0) {
-                    out_reg = OUTREG_oD1;
-                } else if (strcmp(dst_name, "FOGC") == 0) {
-                    out_reg = OUTREG_oFog;
-                } else if (strcmp(dst_name, "TEX0") == 0) {
-                    out_reg = OUTREG_oT0;
-                } else if (strcmp(dst_name, "TEX1") == 0) {
-                    out_reg = OUTREG_oT1;
-                } else if (strcmp(dst_name, "TEX2") == 0) {
-                    out_reg = OUTREG_oT2;
-                } else if (strcmp(dst_name, "TEX3") == 0) {
-                    out_reg = OUTREG_oT3;
-                } else if (strcmp(dst_name, "PSIZ") == 0) {
-                    out_reg = OUTREG_oPts;
-                } else if (strcmp(dst_name, "BFC0") == 0) {
-                    out_reg = OUTREG_oB0;
-                } else if (strcmp(dst_name, "BFC1") == 0) {
-                    out_reg = OUTREG_oB1;
-                } else {
+                int out_reg;
+                const char* name = _mesa_nv_vertex_output_register_name(ins.DstReg.Index);
+                for (out_reg = 0; _mesa_nv_vertex_hw_output_register_name(out_reg); out_reg++) {
+                    if (strcmp(name, _mesa_nv_vertex_hw_output_register_name(out_reg)) == 0) {
+                        break;
+                    }
+                }
+                if (!_mesa_nv_vertex_hw_output_register_name(out_reg)) {
                     assert(false);
                 }
+                vsh_set_field(vsh_ins, FLD_OUT_ORB, OUTPUT_O);
                 vsh_set_field(vsh_ins, FLD_OUT_ADDRESS, out_reg);
             } else if (ins.DstReg.File == PROGRAM_ENV_PARAM) {
                 vsh_set_field(vsh_ins, FLD_OUT_O_MASK, vsh_mask(ins.DstReg.WriteMask));

--- a/tools/vp20compiler/nvvertparse.c
+++ b/tools/vp20compiler/nvvertparse.c
@@ -892,7 +892,7 @@ Parse_UnaryOpInstruction(struct parse_state *parseState,
                          enum prog_opcode opcode)
 {
    if (opcode == OPCODE_ABS && !parseState->isVersion1_1)
-      RETURN_ERROR1("ABS illegal for vertex program 1.0");
+      RETURN_ERROR1("ABS requires vertex program 1.1");
 
    inst->Opcode = opcode;
 
@@ -920,9 +920,9 @@ Parse_BiOpInstruction(struct parse_state *parseState,
                       enum prog_opcode opcode)
 {
    if (opcode == OPCODE_DPH && !parseState->isVersion1_1)
-      RETURN_ERROR1("DPH illegal for vertex program 1.0");
+      RETURN_ERROR1("DPH requires vertex program 1.1");
    if (opcode == OPCODE_SUB && !parseState->isVersion1_1)
-      RETURN_ERROR1("SUB illegal for vertex program 1.0");
+      RETURN_ERROR1("SUB requires vertex program 1.1");
 
    inst->Opcode = opcode;
 
@@ -1032,7 +1032,7 @@ Parse_ScalarInstruction(struct parse_state *parseState,
                         enum prog_opcode opcode)
 {
    if (opcode == OPCODE_RCC && !parseState->isVersion1_1)
-      RETURN_ERROR1("RCC illegal for vertex program 1.0");
+      RETURN_ERROR1("RCC requires vertex program 1.1");
 
    inst->Opcode = opcode;
 

--- a/tools/vp20compiler/nvvertparse.c
+++ b/tools/vp20compiler/nvvertparse.c
@@ -547,16 +547,21 @@ Parse_AttribReg(struct parse_state *parseState, int *tempRegNum)
    if (!Parse_Token(parseState, token))
       RETURN_ERROR;
 
-   if (parseState->isStateProgram && token[0] != '0')
-      RETURN_ERROR1("Only v[0] accessible in vertex state programs");
-
    if (IsDigit(token[0])) {
       int reg = atoi((char *) token);
       if (reg >= MAX_NV_VERTEX_PROGRAM_INPUTS)
          RETURN_ERROR1("Bad vertex attribute register name");
+
+      if (parseState->isStateProgram && reg != 0)
+         RETURN_ERROR1("Vertex state programs can only access vertex attribute register v[0]");
+
       *tempRegNum = reg;
    }
    else {
+
+      if (parseState->isStateProgram)
+         RETURN_ERROR1("Vertex state programs can only access vertex attribute registers by index");
+
       for (j = 0; InputRegisters[j]; j++) {
          if (strcmp((const char *) token, InputRegisters[j]) == 0) {
             *tempRegNum = j;

--- a/tools/vp20compiler/nvvertparse.c
+++ b/tools/vp20compiler/nvvertparse.c
@@ -127,9 +127,9 @@ record_error(struct parse_state *parseState, const char *msg, const char* file,
                                     parseState->pos, &line, &column);
    // _mesa_debug(parseState->ctx,
    fprintf(stderr,
-               "%s: %s(%d): line %d, column %d: %s (%s)\n",
+               "%s: line %d, column %d: %s (%s)\n",
                onlyWarn ? "warning" : "error",
-               file, lineNo, line, column, (char *) lineStr, msg);
+               line, column, (char *) lineStr, msg);
    free((void *) lineStr);
 
    /* Check that no error was already recorded.  Only record the first one. */

--- a/tools/vp20compiler/nvvertparse.c
+++ b/tools/vp20compiler/nvvertparse.c
@@ -347,10 +347,19 @@ static const char *HardwareInputRegisters[MAX_HARDWARE_INPUTS + 1] = {
    "TEX0", "TEX1", "TEX2", "TEX3", "13", "14", "15", NULL
 };
 
+/* as defined in NV_vertex_program */
 static const char *OutputRegisters[MAX_NV_VERTEX_PROGRAM_OUTPUTS + 1] = {
    "HPOS", "COL0", "COL1", "FOGC", 
    "TEX0", "TEX1", "TEX2", "TEX3", "TEX4", "TEX5", "TEX6", "TEX7", 
    "PSIZ", "BFC0", "BFC1", NULL
+};
+
+/* as implemented in NV2A */
+static const char *HardwareOutputRegisters[MAX_HARDWARE_OUTPUTS + 1] = {
+   "HPOS", "1", "2", "COL0", "COL1", "FOGC",
+   "PSIZ", "BFC0", "BFC1",
+   "TEX0", "TEX1", "TEX2", "TEX3",
+   "13", "14", NULL
 };
 
 
@@ -623,6 +632,18 @@ Parse_OutputReg(struct parse_state *parseState, int *outputRegNum)
    /* Match ']' */
    if (!Parse_String(parseState, "]"))
       RETURN_ERROR1("Expected ]");
+
+   /* make sure this register is available on hardware */
+   for (j = 0; HardwareOutputRegisters[j]; j++) {
+      if (strcmp((const char *) token, HardwareOutputRegisters[j]) == 0) {
+         break;
+      }
+   }
+   if (!HardwareOutputRegisters[j]) {
+      char msg[1000];
+      sprintf(msg, "Output register o[%s] not available in hardware", token);
+      WARNING1(msg);
+   }
 
    return TRUE;
 }
@@ -1627,3 +1648,9 @@ _mesa_nv_vertex_output_register_name(unsigned int i)
    return OutputRegisters[i];
 }
 
+const char *
+_mesa_nv_vertex_hw_output_register_name(unsigned int i)
+{
+   assert(i < MAX_HARDWARE_OUTPUTS);
+   return HardwareOutputRegisters[i];
+}

--- a/tools/vp20compiler/nvvertparse.h
+++ b/tools/vp20compiler/nvvertparse.h
@@ -40,6 +40,9 @@ extern const char *
 _mesa_nv_vertex_input_register_name(unsigned int i);
 
 extern const char *
+_mesa_nv_vertex_hw_input_register_name(unsigned int i);
+
+extern const char *
 _mesa_nv_vertex_output_register_name(unsigned int i);
 
 #endif

--- a/tools/vp20compiler/nvvertparse.h
+++ b/tools/vp20compiler/nvvertparse.h
@@ -45,4 +45,7 @@ _mesa_nv_vertex_hw_input_register_name(unsigned int i);
 extern const char *
 _mesa_nv_vertex_output_register_name(unsigned int i);
 
+extern const char *
+_mesa_nv_vertex_hw_output_register_name(unsigned int i);
+
 #endif


### PR DESCRIPTION
This PR is best reviewed one commit at a time:

See https://www.khronos.org/registry/OpenGL/extensions/NV/NV_vertex_program.txt for more background information.

### vp20compiler: Remap input registers for NV2A

The register indices for registers of the same semantics of NV2A and NV_vertex_program differ.
When we support the fixed-function-pipeline or certain immediate-mode setters in the GPU, where we can't just remap the vertex attributes, this will be a problem.

To solve this, this commit creates an array with the hardware registers. These must match the names of the NV_vertex_program registers, but be in hardware order.

The parser will check if the used NV_vertex_program registers exist in hardware. If the index is different, it warns (to avoid people assuming a 1:1 mapping and using indices from the NV_vertex_program spec on the CPU side).

The emitter will try to find the correct hardware register and `assert(false)` if nothing was found.

This also requires a change in the mesh sample, which actually uses `v[8]` (TEX0 in NV_vertex_program) when it should be using `v[9]` (TEX0 in NV2A).

The hardware mappings for this commit have been taken from XQEMU: <https://github.com/xqemu/xqemu/blob/42579ba366b69b04a79f41fe9b5744ea6c2e7193/hw/xbox/nv2a/nv2a_shaders.c#L296>.
The NV_vertex_program mappings existed in the code already and should match the spec linked above (Table X.3).
I did not check the correctness of these arrays.

### vp20compiler: Remap output registers for NV2A

Like the previous commit, but for output registers.

In this case, it's not allowed to access registers by index, so this could only cause errors, but no warnings.

This replaces some ugly table in main.c. However, this change does mix hardware and software related things in the parser. I think this is fine because I intend to create extension `OPTION`s for directly accessing NV2A registers soon.

The hardware mappings for this commit have been taken from XQEMU: <https://github.com/xqemu/xqemu/blob/master/hw/xbox/nv2a/nv2a_vsh.c#L243> (A0 is special, so we don't consider it as an output register).
The NV_vertex_program mappings existed in the code already and there are no explicit indices, so the order should be irrelevant; see spec linked above (Table X.1).

### vp20compiler: Improve vertex attribute register checks for VSPs

The old check allowed registers like `v[05]` which should not have been allowed. This fixes that.

Also it is a bit confusing that VSPs can only be accessed by index, so I made an explicit error for it.

### vp20compiler: Do not list compiler-code location in error-messages

The old error printer also printed the location in the vp20compiler-code which triggered the message. I feel this doesn't add anything. It only confuses users of the tool, so I removed it.

### vp20compiler: Improve error-messages for syntax-errors

This replaces a frequently appearing pattern using the `RETURN_ERROR;` macro by `EXPECT("symbol")`, to provide more explicit error messages.

### vp20compiler: Improve error-messages for version checks

The version checks incorrectly claimed that version 1.0 did not support something. However, this message can does not tell the user which version is actually required.

The new message informs the user that version 1.1 is required.