### PR TITLE
build: Work around LLVM LTO symbol issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-threadsafe-statics -fno-rtti
 NXDK_LDFLAGS = -subsystem:windows -fixed:no -entry:XboxCRTEntry \
-               -stack:$(NXDK_STACKSIZE) -safeseh:no
+               -stack:$(NXDK_STACKSIZE) -safeseh:no -include:__fltused -include:__xlibc_check_stack
 
 # Multithreaded LLD on Windows hang workaround
 ifneq (,$(findstring MINGW,$(UNAME_S)))

--- a/lib/xboxrt/c_runtime/_fltused.c
+++ b/lib/xboxrt/c_runtime/_fltused.c
@@ -1,2 +1,1 @@
-#pragma comment(linker, "/include:__fltused")
 int _fltused = 1;


### PR DESCRIPTION
This fixes lld crashes with LLVM 10 (and maybe more versions) when using LTO. The crash is caused by issues in lld with regards to handling of symbols that get emitted during code generation, in this case, `__fltused` and `__chkstk`/`__xlibc_check_stack`. I've opened a bug report upstream for this: https://bugs.llvm.org/show_bug.cgi?id=45985

The solution in this PR is to add linker parameters that make lld add the symbols properly. I would prefer a cleaner solution, but this will probably require waiting for a future LLVM release. In the meantime, this makes it possible to build SDLPoPX with LTO turned on.