### PR TITLE
ci: Fix path conflict with preinstalled msys2

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -18,14 +18,14 @@ jobs:
           echo "Downloading MSYS2 environment..."
           Invoke-WebRequest -Uri "https://github.com/XboxDev/nxdk-ci-environment-msys2/releases/latest/download/msys64.7z" -OutFile "msys64.7z"
           echo "Extracting MSYS2 environment..."
-          7z x -y msys64.7z "-oC:\"
+          7z x -y msys64.7z "-oC:\tools\"
           echo "Updating MSYS2 environment..."
-          C:\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm"
+          C:\tools\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm"
       - name: Build
         env:
           MSYS2_ARCH: x86_64
           MSYSTEM: MINGW64
-        run: C:\msys64\usr\bin\bash.exe -lc "cd $(cygpath $env:GITHUB_WORKSPACE) && ./.ci_build_samples.sh"
+        run: C:\tools\msys64\usr\bin\bash.exe -lc "cd $(cygpath $env:GITHUB_WORKSPACE) && ./.ci_build_samples.sh"
   macos:
     name: macOS
     runs-on: macOS-latest


### PR DESCRIPTION
Our Windows CI recently started failing. The issue came down to a path conflict - the newer images contain an msys2 installation in `C:\msys2`, which is also where our own msys2 installation got extracted to. Partially overwriting the pre-existing installation then caused weird issues when trying to update or install packages.

This fixes it by changing the path where we extract msys2 to `C:\tools\msys2`, which is the path where chocolatey normally puts it (this path is also used in xqemu). Since we don't use chocolatey here to install msys2, there should be no path conflicts.