### PR TITLE
Allocate framebuffer when XVideoSetMode is called

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -37,6 +37,11 @@ static void synchronizeVideoMode()
 	SCREEN_FB = XVideoGetFB();
 }
 
+static void writebackBuffers()
+{
+	asm __volatile__("sfence");
+}
+
 static void drawChar(unsigned char c, int x, int y, int fgColour, int bgColour)
 {
 	unsigned char *videoBuffer = SCREEN_FB;
@@ -202,6 +207,8 @@ void debugPrint(const char *format, ...)
 
 		s++;
 	}
+
+	writebackBuffers();
 }
 
 void advanceScreen( void )
@@ -219,6 +226,8 @@ void advanceScreen( void )
 
 	nextRow -= (FONT_HEIGHT+1);
 	nextCol  = MARGIN; 
+
+	writebackBuffers();
 }
 
 void debugClearScreen( void )
@@ -228,6 +237,8 @@ void debugClearScreen( void )
 	memset( SCREEN_FB, 0, ((SCREEN_BPP+7)/8) * (SCREEN_WIDTH * SCREEN_HEIGHT) );
 	nextRow = MARGIN;
 	nextCol = MARGIN; 
+
+	writebackBuffers();
 }
 
 void debugPrintHex(const char *buffer, int length)

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -35,15 +35,15 @@
 #define VIDEO_R5G6B5				0x00000011
 #define VIDEO_A8R8G8B8				0x00000012
 
-unsigned char*	framebufferMemory = NULL;
-unsigned char*	_fb = NULL;
-DWORD			dwEncoderSettings 	= 0;
-VIDEO_MODE		vmCurrent = { 0, 0, 0, 0 };
-int			flickerLevel		= 5;
-BOOL			flickerSet		= FALSE;
-BOOL			softenFilter		= TRUE;
-BOOL			softenSet		= FALSE;
-GAMMA_RAMP_ENTRY	gammaRampEntries[256];
+static unsigned char*	framebufferMemory = NULL;
+static unsigned char*	_fb = NULL;
+static DWORD			dwEncoderSettings 	= 0;
+static VIDEO_MODE		vmCurrent = { 0, 0, 0, 0 };
+static int			flickerLevel		= 5;
+static BOOL			flickerSet		= FALSE;
+static BOOL			softenFilter		= TRUE;
+static BOOL			softenSet		= FALSE;
+static GAMMA_RAMP_ENTRY	gammaRampEntries[256];
 
 static KINTERRUPT InterruptObject;
 static KDPC DPCObject;
@@ -62,7 +62,7 @@ typedef struct _VIDEO_MODE_SETTING
 	DWORD dwFlags;
 } VIDEO_MODE_SETTING;
 
-VIDEO_MODE_SETTING vidModes[] =
+static VIDEO_MODE_SETTING vidModes[] =
 {
  {0x44030307,640,480,50,VIDEO_REGION_PAL,AV_PACK_STANDARD}, //640x480 PAL 50Hz
  {0x44040408,720,480,50,VIDEO_REGION_PAL,AV_PACK_STANDARD}, //720x480 PAL 50Hz
@@ -122,7 +122,7 @@ VIDEO_MODE_SETTING vidModes[] =
  {0x04020204,720,480,60,VIDEO_REGION_NTSCJ,AV_PACK_SVIDEO}, //720x480 NTSCJ 60Hz
 };
 
-int iVidModes = sizeof(vidModes) / sizeof(VIDEO_MODE_SETTING);
+static int iVidModes = sizeof(vidModes) / sizeof(VIDEO_MODE_SETTING);
 
 static void __stdcall DPC(PKDPC Dpc,
 PVOID DeferredContext,

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -38,7 +38,7 @@
 unsigned char*	framebufferMemory = NULL;
 unsigned char*	_fb = NULL;
 DWORD			dwEncoderSettings 	= 0;
-VIDEO_MODE		vmCurrent;
+VIDEO_MODE		vmCurrent = { 0, 0, 0, 0 };
 int			flickerLevel		= 5;
 BOOL			flickerSet		= FALSE;
 BOOL			softenFilter		= TRUE;

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -292,6 +292,13 @@ unsigned char* XVideoGetFB(void)
 	return _fb;
 }
 
+void XVideoSetFB(unsigned char *fb)
+{
+	assert(((unsigned int)fb & ~0x7FFFFFFF) == 0);
+	_fb = fb;
+	VIDEOREG(PCRTC_START) = (unsigned int)_fb & 0x7FFFFFFF;
+}
+
 VIDEO_MODE XVideoGetMode(void)
 {
 	return vmCurrent;
@@ -440,11 +447,6 @@ void XVideoWaitForVBlank()
 	/* Disable vblank interrupt */
 	VIDEOREG(PCRTC_INTR_EN)=PCRTC_INTR_EN_VBLANK_DISABLED;
 	VIDEOREG(PCRTC_INTR)=PCRTC_INTR_VBLANK_RESET;
-}
-
-void XVideoSetDisplayStart(unsigned int offset)
-{
-	VIDEOREG(PCRTC_START) = (unsigned int) (_fb - 0xF0000000 + offset);
 }
 
 unsigned char* XVideoGetVideoBase()

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -52,6 +52,7 @@ typedef struct _GAMMA_RAMP_ENTRY
 
 DWORD XVideoGetEncoderSettings(void);
 unsigned char* XVideoGetFB(void);
+void XVideoSetFB(unsigned char *fb);
 VIDEO_MODE XVideoGetMode(void);
 
 void XVideoSetFlickerFilter(int level);
@@ -74,7 +75,6 @@ If a value of 0 is provided for the bpp a default value of 32bpp is used.
 BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p);
 
 void XVideoWaitForVBlank();
-void XVideoSetDisplayStart(unsigned int offset);
 unsigned char* XVideoGetVideoBase();
 int XVideoVideoMemorySize();
 

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -10,7 +10,6 @@ extern "C"
 
 // Defines for frame buffer
 #define VIDEO_BASE				0xFD000000
-#define VIDEO_FRAMEBUFFER			0x03c00000
 
 // Hardware access macros
 #define VIDEOREG(x) (*(volatile unsigned int*)(VIDEO_BASE + (x)))


### PR DESCRIPTION
This PR adds a framebuffer that is owned by XVideo.

This change decouples XVideo from the actual GPU framebuffer. We only expect XVideo to reflect some virtual single-buffered display now, and all changes to that will be copied to the GPU, but not the other way around.
In other words: if the user circumvents XVideo to switch to another buffer / mode, then XVideo will stick to the configured mode / resolution for its own framebuffer.

This closes #170 because XVideo will no longer be expected to synchronized with the GPU (XVideo sets the GPU, but never reads it).

Some notes:

- Unconditionally (re-)allocate our own framebuffer in `XVideoSetMode` (write-combined); this closes #169. There is currently no way to free or avoid this buffer.
- Assert that we got a framebuffer in `XVideoInit`; ideally this would just make `XVideoSetMode` fail, but this can be done later. An issue will have to be created after merge.
- Zero-out the mode returned from `XVideoGetMode` until it was set; this closes #149 because we no longer have a random state, but a well-defined state. I decided against querying the GPU for information, because it would complicate the code and complicate APIs like debug.c which would no longer know when the framebuffer is actually owned. Another API can be added to retrieve the state in the future.
- More carefully synchronize with `XVideoGetMode` in debug.c; this prevents drawing until video mode was set (previously, bugs allowed it to `memset` some memory). So debug.c should no longer be dangerous.
- `sfence` after drawing in debug.c [to avoid data being stuck in write-combining buffers]; also see https://github.com/XboxDev/nxdk-sdl/pull/32 for the explanation / comments.
- Hide some variables in video.c; this should avoid API misuse, hopefully leading to cleaner API design in the future; this closes #269.

Another API for freeing the buffer might be added in the future.

For now, if you want to avoid the buffer, write your own API and avoid XVideo and any API that depends on initialized XVideo. Even without XVideo, you can still safely use debug.c, but it will be a no-op (except for flushing write-combine buffers and some useless math).

*This was not tested yet.*