### PR TITLE
hal: Remove dead constants and adjust function name prefix

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -172,7 +172,7 @@ void debugPrint(const char *format, ...)
 	{
 		if( nextRow >= (SCREEN_HEIGHT-MARGINS) ) {
 			debugClearScreen();
-			// advanceScreen();
+			// debugAdvanceScreen();
 		}
 		
 		if (*s == '\n')
@@ -196,7 +196,7 @@ void debugPrint(const char *format, ...)
 	}
 }
 
-void advanceScreen( void )
+void debugAdvanceScreen( void )
 {
 	int pixelSize = (SCREEN_BPP+7)/8;
 	int screenSize  = SCREEN_WIDTH * (SCREEN_HEIGHT - MARGINS)  * pixelSize;

--- a/lib/hal/debug.h
+++ b/lib/hal/debug.h
@@ -12,9 +12,6 @@ extern "C"
 
 #define WHITE   0x00FFFFFF
 #define BLACK   0x00000000
-#define RED     0x00FF0000
-#define GREEN   0x0000FF00
-#define BLUE    0x000000FF
 
 #define WHITE_16BPP   0xFFFF
 #define BLACK_16BPP  0x0000

--- a/lib/hal/debug.h
+++ b/lib/hal/debug.h
@@ -31,7 +31,7 @@ void debugPrintNum(int i);
 void debugPrintBinary( int num );
 void debugPrintHex(const char *buffer, int length);
 void debugClearScreen( void );
-void advanceScreen( void );
+void debugAdvanceScreen( void );
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
Hi 👋 
This PR
- removes unused color constants from `debug.h`
- renames `advanceScreen()` to `debugAdvanceScreen()` to mind the namespace

Aims to close #171 

Samples still compile and a quick search revealed that `advanceScreen()` is no where in use inside nxdk. 
