### PR TITLE
fp20compiler:  Replace bad emitter string for REG_ONE with assert(false)

### DIFF
--- a/tools/fp20compiler/rc1.0_register.h
+++ b/tools/fp20compiler/rc1.0_register.h
@@ -75,7 +75,11 @@ static const char* GetRegisterNameString(unsigned int reg_name) {
     case REG_DISCARD:
         return "0x0";
     case REG_ONE:
-        return "0x12";
+        // REG_ONE is a pseudo-register that should have been 
+        // mapped to REG_ZERO (with modifier) in MappedRegisterStruct::Init; 
+        // therefore, this should not be reachable. 
+        assert(false);
+        break;
     default:
         fprintf(stderr, "unknown register name index %d\n", reg_name);
         assert(false);


### PR DESCRIPTION
Hello 👋 
This PR closes #236 
It does so, as suggested, by replacing the return value with an `assert(false);`. 
I wasn't sure if I should also add a warning `fprintf` or not. Feel free to request it 🙂
