### PR TITLE
Fix many issues in OpenXDK XAudio

### DIFF
--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -153,7 +153,11 @@ void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, 
 	memset((void *)&pac97device->pcmSpdifDescriptor[0], 0, sizeof(pac97device->pcmSpdifDescriptor));
 	memset((void *)&pac97device->pcmOutDescriptor[0], 0, sizeof(pac97device->pcmOutDescriptor));
 
-	// perform a cold reset
+	// perform cold reset
+	pac97device->mmio[0x12C>>2] &= ~2;
+	LARGE_INTEGER Interval;
+	Interval.QuadPart = -10;
+	KeDelayExecutionThread(KernelMode, FALSE, &Interval);
 	pac97device->mmio[0x12C>>2] |= 2;
 	
 	// wait until the chip is finished resetting...

--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -25,8 +25,10 @@
 
 #define AUDIO_IRQ 6
 
-static volatile int analogBufferCount;
-static volatile int digitalBufferCount;
+static volatile unsigned int analogBufferCount;
+static volatile unsigned int digitalBufferCount;
+static bool analogDrained;
+static bool digitalDrained;
 
 static KINTERRUPT InterruptObject;
 static KDPC DPCObject;
@@ -68,10 +70,14 @@ static BOOLEAN __stdcall ISR(PKINTERRUPT Interrupt, PVOID ServiceContext)
 		bool waitingForAnalog = (analogBufferCount > digitalBufferCount);
 
 		// Was the interrupt triggered because we were out of data?
-		if (analogInterrupt & 8) {
-			waitCompleted |= waitingForAnalog;
-			analogBufferCount--;
+		if ((analogInterrupt & 8) && !analogDrained) {
+			if (analogBufferCount > 0) {
+				waitCompleted |= waitingForAnalog;
+				analogBufferCount--;
+			}
 		}
+
+		analogDrained = analogInterrupt & 4;
 
 		*(volatile unsigned char *)0xFEC00116=0xFF; // clear all int sources
 	}
@@ -80,10 +86,14 @@ static BOOLEAN __stdcall ISR(PKINTERRUPT Interrupt, PVOID ServiceContext)
 		bool waitingForDigital = (digitalBufferCount > analogBufferCount);
 
 		// Was the interrupt triggered because we were out of data?
-		if (digitalInterrupt & 8) {
-			waitCompleted |= waitingForDigital;
-			digitalBufferCount--;
+		if ((digitalInterrupt & 8) && !digitalDrained) {
+			if (digitalBufferCount > 0) {
+				waitCompleted |= waitingForDigital;
+				digitalBufferCount--;
+			}
 		}
+
+		digitalDrained = digitalInterrupt & 4;
 
 		*(volatile unsigned char *)0xFEC00176=0xFF; // clear all int sources
 	}
@@ -167,6 +177,8 @@ void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, 
 	// reset buffer status
 	analogBufferCount = 0;
 	digitalBufferCount = 0;
+	analogDrained = false;
+	digitalDrained = false;
 	
 	// Register our ISR
 	vector = HalGetInterruptVector(AUDIO_IRQ, &irql);

--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -143,7 +143,7 @@ void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, 
 	MmLockUnlockBufferPages((PVOID)pac97device, sizeof(AC97_DEVICE), FALSE);
 
 	pac97device->mmio = (unsigned int *)0xfec00000;
-	pac97device->nextDescriptorMod31 = 0;
+	pac97device->nextDescriptor = 0;
 	pac97device->callback = callback;
 	pac97device->callbackData = data;
 	pac97device->sampleSizeInBits = sampleSizeInBits;
@@ -245,18 +245,18 @@ void XAudioProvideSamples(unsigned char *buffer, unsigned short bufferLength, in
 	unsigned int address = MmGetPhysicalAddress((PVOID)buffer);
 	unsigned int wordCount = bufferLength / 2;
 
-	pac97device->pcmOutDescriptor[pac97device->nextDescriptorMod31].bufferStartAddress    = address;
-	pac97device->pcmOutDescriptor[pac97device->nextDescriptorMod31].bufferLengthInSamples = wordCount;
-	pac97device->pcmOutDescriptor[pac97device->nextDescriptorMod31].bufferControl         = bufferControl;
-	pb[0x115] = (unsigned char)pac97device->nextDescriptorMod31; // set last active descriptor
+	pac97device->pcmOutDescriptor[pac97device->nextDescriptor].bufferStartAddress    = address;
+	pac97device->pcmOutDescriptor[pac97device->nextDescriptor].bufferLengthInSamples = wordCount;
+	pac97device->pcmOutDescriptor[pac97device->nextDescriptor].bufferControl         = bufferControl;
+	pb[0x115] = (unsigned char)pac97device->nextDescriptor; // set last active descriptor
 	analogBufferCount++;
 
-	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptorMod31].bufferStartAddress    = address;
-	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptorMod31].bufferLengthInSamples = wordCount;
-	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptorMod31].bufferControl         = bufferControl;
-	pb[0x175] = (unsigned char)pac97device->nextDescriptorMod31; // set last active descriptor
+	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptor].bufferStartAddress    = address;
+	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptor].bufferLengthInSamples = wordCount;
+	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptor].bufferControl         = bufferControl;
+	pb[0x175] = (unsigned char)pac97device->nextDescriptor; // set last active descriptor
 	digitalBufferCount++;
 
 	// increment to the next buffer descriptor (rolling around to 0 once you get to 31)
-	pac97device->nextDescriptorMod31 = (pac97device->nextDescriptorMod31 +1 ) & 0x1f;
+	pac97device->nextDescriptor = (pac97device->nextDescriptor + 1) % 32;
 }

--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -164,6 +164,16 @@ void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, 
 	while(!(pac97device->mmio[0x130>>2]&0x100))
 		;
 
+	// reset bus master registers for analog output
+	*(volatile unsigned char*)0xFEC0011B = (1 << 4) | (1 << 3) | (1 << 2) | (1 << 1);
+	while((*(volatile unsigned char*)0xFEC0011B) & (1 << 1))
+		;
+
+	// reset bus master registers for digital output
+	*(volatile unsigned char*)0xFEC0017B = (1 << 4) | (1 << 3) | (1 << 2) | (1 << 1);
+	while((*(volatile unsigned char*)0xFEC0017B) & (1 << 1))
+		;
+
 	// clear all interrupts
 	((unsigned char *)pac97device->mmio)[0x116] = 0xFF;
 	((unsigned char *)pac97device->mmio)[0x176] = 0xFF;

--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -242,16 +242,17 @@ void XAudioProvideSamples(unsigned char *buffer, unsigned short bufferLength, in
 	if (isFinal) 
 		bufferControl |= 0x4000;
 
-	unsigned int address = (unsigned int)buffer;
+	unsigned int address = MmGetPhysicalAddress((PVOID)buffer);
+	unsigned int wordCount = bufferLength / 2;
 
-	pac97device->pcmOutDescriptor[pac97device->nextDescriptorMod31].bufferStartAddress    = MmGetPhysicalAddress((PVOID)address);
-	pac97device->pcmOutDescriptor[pac97device->nextDescriptorMod31].bufferLengthInSamples = bufferLength / (pac97device->sampleSizeInBits / 8);
+	pac97device->pcmOutDescriptor[pac97device->nextDescriptorMod31].bufferStartAddress    = address;
+	pac97device->pcmOutDescriptor[pac97device->nextDescriptorMod31].bufferLengthInSamples = wordCount;
 	pac97device->pcmOutDescriptor[pac97device->nextDescriptorMod31].bufferControl         = bufferControl;
 	pb[0x115] = (unsigned char)pac97device->nextDescriptorMod31; // set last active descriptor
 	analogBufferCount++;
 
-	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptorMod31].bufferStartAddress    = MmGetPhysicalAddress((PVOID)address);
-	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptorMod31].bufferLengthInSamples = bufferLength / (pac97device->sampleSizeInBits / 8);
+	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptorMod31].bufferStartAddress    = address;
+	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptorMod31].bufferLengthInSamples = wordCount;
 	pac97device->pcmSpdifDescriptor[pac97device->nextDescriptorMod31].bufferControl         = bufferControl;
 	pb[0x175] = (unsigned char)pac97device->nextDescriptorMod31; // set last active descriptor
 	digitalBufferCount++;

--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -37,24 +37,23 @@ static KDPC DPCObject;
 AC97_DEVICE ac97Device;
 
 
+//DPCs avoid crashes inside non reentrant user callbacks called by nested ISRs.
+//CAUTION : if you use fpu in DPC you have to save & restore yourself fpu state!!!
+//(fpu=floating point unit, i.e the coprocessor executing floating point opcodes)
 static void __stdcall DPC(PKDPC Dpc, 
 					PVOID DeferredContext, 
 					PVOID SystemArgument1, 
 					PVOID SystemArgument2)
 {
-	//DPCs avoid crashes inside non reentrant user callbacks called by nested ISRs.
-	//CAUTION : if you use fpu in DPC you have to save & restore yourself fpu state!!!
-	//(fpu=floating point unit, i.e the coprocessor executing floating point opcodes)
-
 	AC97_DEVICE *pac97device;
 
 	pac97device = &ac97Device;
 	if (pac97device)
-			if (pac97device->callback)
-				(pac97device->callback)((void *)pac97device, pac97device->callbackData);
+		if (pac97device->callback)
+			(pac97device->callback)((void *)pac97device, pac97device->callbackData);
 
 	return;
-		}
+}
 	
 // Although we have to explicitly clear the S/PDIF interrupt sources, in fact
 // the way we are set up PCM and S/PDIF are in lockstep and we only listen for

--- a/lib/hal/audio.h
+++ b/lib/hal/audio.h
@@ -24,7 +24,7 @@ typedef struct
 	AC97_DESCRIPTOR        pcmSpdifDescriptor[32];
 	AC97_DESCRIPTOR        pcmOutDescriptor[32];
 	volatile unsigned int *mmio;
-	volatile unsigned int  nextDescriptorMod31;
+	volatile unsigned int  nextDescriptor;
 	XAudioCallback         callback;
 	void                  *callbackData;
 	int                    sampleSizeInBits;

--- a/lib/hal/audio.h
+++ b/lib/hal/audio.h
@@ -21,14 +21,14 @@ typedef struct
 // represents the current ac97 device
 typedef struct 
 {
-	AC97_DESCRIPTOR        pcmSpdifDescriptor[32];
-	AC97_DESCRIPTOR        pcmOutDescriptor[32];
-	volatile unsigned int *mmio;
-	volatile unsigned int  nextDescriptor;
-	XAudioCallback         callback;
-	void                  *callbackData;
-	int                    sampleSizeInBits;
-	int                    numChannels;
+	volatile AC97_DESCRIPTOR pcmSpdifDescriptor[32];
+	volatile AC97_DESCRIPTOR pcmOutDescriptor[32];
+	volatile unsigned int   *mmio;
+	unsigned char            nextDescriptor;
+	XAudioCallback           callback;
+	void                    *callbackData;
+	int                      sampleSizeInBits;
+	int                      numChannels;
 } AC97_DEVICE  __attribute__ ((aligned (8)));
 
 // note that I currently ignore sampleSizeInBits and numChannels.  They


### PR DESCRIPTION
**This code was tested very little; in particular, I did not test it with any existing OpenXDK XAudio applications. I also did not test the digital audio-out.**

Please test and review before merge. For testing, I've been using https://github.com/JayFoxRox/nxdk/pull/78 which can create some metadata for audacity.

---

## Synchronize analog and digital buffers

The interrupts for analog audio come about 16 samples before digital audio interrupts. This means we might mark a buffer as processed (by calling the user callback) before the AC97 has finished processing it.

We also cleared the interrupts for the digital audio in the interrupt handler of analog audio. This could lead to race conditions.

This commit keeps counters so we always know how many buffers there are per bus master.
Only once both bus masters have processed the buffer, we call the callback.

## Only cause 1 callback per XAudioProvideSamples

When AC97 runs out of data (because no new buffer has been provided) it will actually keep repeating the last buffer. Each buffer completion causes an interrupt.

This means that submitting a single buffer usually caused infinitely many callbacks.
If the application submitted 2 buffers, it would not know if one of the buffers played twice, or if both buffers have played.

This code changes the callback behaviour:
If the last buffer is played it will have 4 (last valid buffer completion) in addition to the usual 8 (end of buffer) set as interrupt reason (MMIO register 0x116 / 0x176).
If this condition has been found, a single callback is generated. Further buffer completions are ignored until new buffers have been submitted and started processing.

Unfortunately, there might be a risk of losing buffers now: If the buffer is too small, I could imagine that AC97 fires 2 interrupts but the CPU might only see one of them (as it's not fast enough to clear the interrupt flag between the two). As such, the CPU might skip one callback. This is only a theoretical problem though. I'll create an issue about this after merge, so it can be investigated.

## Respect timing requirement of AC97 cold-reset

AMD AC97 docs say that cold-reset must be pulled to 0 for at least 1 microsecond.
Our current code never pulled it to zero and also didn't respect any timing.

This commit respects this.

*(This was supposed to prevent #362, but it did not work. It doesn't seem to have any practical effect)*

## Reset bus master registers at startup

Saw this in the documentation and figured I should add it.
It might be unnecessary (is cold-reset enough?).

*(This was supposed to prevent #362, but it did not work. It doesn't seem to have any practical effect)*

## Avoid recalculation of descriptor parameters

General cleanup.

## Rename nextDescriptorMod31 to nextDescriptor

General cleanup. Intention was correctness and readability.

## Improve use of the volatile keyword 

General cleanup. Intention was better support for optimizations and more stability.