### PR TITLE
cxbe: Remove obsolete Makefile.am

### DIFF
--- a/tools/cxbe/Makefile.am
+++ b/tools/cxbe/Makefile.am
@@ -1,8 +1,0 @@
-CXX=g++
-EXEEXT=$(XDKEXEEXT)
-
-bin_PROGRAMS = cxbe
-cxbe_SOURCES = $(SRCS)
-
-SRCS = Error.cpp Exe.cpp Main.cpp OpenXDK.cpp Xbe.cpp
-


### PR DESCRIPTION
Hi 👋 
This PR has no dedicated issue.
It removes the file `Makefile.am` from `tools/cxbe/` as it is needless. 
I build a few samples without issue.
