### PR TITLE
samples: Harmonise flag assignment style in Makefiles

### DIFF
--- a/samples/gamma-fade/Makefile
+++ b/samples/gamma-fade/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE=gamma-fade
+XBE_TITLE = gamma-fade
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/gamma/Makefile
+++ b/samples/gamma/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE=gamma
+XBE_TITLE = gamma
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/hello++/Makefile
+++ b/samples/hello++/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE=hello++
+XBE_TITLE = hello++
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.cpp
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/hello/Makefile
+++ b/samples/hello/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE=hello
+XBE_TITLE = hello
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/httpd/Makefile
+++ b/samples/httpd/Makefile
@@ -1,6 +1,6 @@
-XBE_TITLE=httpd
+XBE_TITLE = httpd
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c $(CURDIR)/httpserver.c
 NXDK_DIR = $(CURDIR)/../..
-NXDK_NET=y
+NXDK_NET = y
 include $(NXDK_DIR)/Makefile

--- a/samples/httpd_bsd/Makefile
+++ b/samples/httpd_bsd/Makefile
@@ -1,6 +1,6 @@
-XBE_TITLE=httpd_bsd
+XBE_TITLE = httpd_bsd
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c $(CURDIR)/httpserver.c
 NXDK_DIR = $(CURDIR)/../..
-NXDK_NET=y
+NXDK_NET = y
 include $(NXDK_DIR)/Makefile

--- a/samples/led/Makefile
+++ b/samples/led/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE=led
+XBE_TITLE = led
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/winapi_drivelist/Makefile
+++ b/samples/winapi_drivelist/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE=winapi_drivelist
+XBE_TITLE = winapi_drivelist
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..


### PR DESCRIPTION
Hi! 👋 
I spotted that the assignment style for various flags(mainly `XBE_TITLE`) in the Makefiles is irregular. This PR harmonise it by making sure there is always exactly one whitespace before and exactly one whitespace after a given `=`. 
I rebuild all samples without an issue. I did not run them. 