### PR TITLE
vcruntime: Implement thread-safe statics initialization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -Wno-ignored-attributes -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
-NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-threadsafe-statics -fno-rtti
+NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-rtti
 NXDK_LDFLAGS = -subsystem:windows -fixed:no -entry:XboxCRTEntry \
                -stack:$(NXDK_STACKSIZE) -safeseh:no -include:__fltused -include:__xlibc_check_stack
 

--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -19,6 +19,7 @@ XBOXRT_SRCS := \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/check_stack.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/chkstk.s \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/purecall.c \
+	$(NXDK_DIR)/lib/xboxrt/vcruntime/threadsafe_statics.c \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_exception.cpp \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/eh.cpp

--- a/lib/xboxrt/vcruntime/threadsafe_statics.c
+++ b/lib/xboxrt/vcruntime/threadsafe_statics.c
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: CC0-1.0
+
+// SPDX-FileCopyrightText: 2019 Timo Kreuzer
+// SPDX-FileCopyrightText: 2020 Stefan Schmidt
+
+// Derived from ReactOS CRT code to provide thread safe statics initialization
+// in nxdk, as required by C++11.
+
+#include <stdint.h>
+#include <limits.h>
+#include <windows.h>
+
+
+long _Init_global_epoch = LONG_MIN;
+__declspec(thread) long _Init_thread_epoch = LONG_MIN;
+
+/*
+    This function tries to acquire a lock on the initialization for the static
+    variable by changing the value saved in *ptss to -1. If *ptss is 0, the
+    variable was not initialized yet and the function tries to set it to -1.
+    If that succeeds, the function will return. If the value is already -1,
+    another thread is in the process of doing the initialization and we
+    wait for it. If it is any other value the initialization is complete.
+    After returning the compiler generated code will check the value:
+    if it is -1 it will continue with the initialization, otherwise the
+    initialization must be complete and will be skipped.
+*/
+void _Init_thread_header (volatile int *ptss)
+{
+    while (1) {
+        /* Try to acquire the first initialization lock */
+        int oldTss = _InterlockedCompareExchange((long *)ptss, -1, 0);
+        if (oldTss == -1) {
+            /* Busy, wait for the other thread to do the initialization */
+            SwitchToThread();
+            continue;
+        } else if (oldTss == 0) {
+            /* We acquired the lock and the caller will do the initialization */
+            return;
+        }
+
+        /* The initialization is complete and the caller will skip it.
+           Update the epoch so this call can be skipped in the future, it
+           only needs to run once per thread. */
+        _Init_thread_epoch = _Init_global_epoch;
+        return;
+    }
+}
+
+void _Init_thread_footer (volatile int *ptss)
+{
+    /* Initialization is complete */
+    _Init_thread_epoch = *ptss = _InterlockedIncrement(&_Init_global_epoch);
+}
+
+void _Init_thread_abort (volatile int *ptss)
+{
+    /* Abort the initialization */
+    _InterlockedAnd((volatile long *)ptss, 0);
+}


### PR DESCRIPTION
The C++11 standard requires statics-initialization to be thread-safe. We had this behavior disabled till now, since we lacked the code to support the way MSVC (and clang when building for Windows) implemented it.

This code adds support for this and removes the compiler parameter that disabled it. The code is derived from and mostly identical to the one in the ReactOS CRT, but it contains two notable fixes, which I figured out by doing a bit of RE:
* `_Init_global_epoch` and `_Init_thread_epoch` get their correct starting values
* `_Init_thread_epoch` gets properly updated, so `_Init_thread_header` only gets called once per thread after initialization is done (clang automatically generates code that checks the epoch values)

I have some terrible code [here](https://gist.github.com/thrimbor/c32d373df6ebd250076a312534907015) that demonstrates that the linker errors are gone and initialization still works.

Closes #238.