### PR TITLE
winapi: Implement GetExitCodeThread()

### DIFF
--- a/lib/winapi/minwinbase.h
+++ b/lib/winapi/minwinbase.h
@@ -29,4 +29,6 @@ typedef struct _SYSTEMTIME
     WORD wMilliseconds;
 } SYSTEMTIME, *PSYSTEMTIME, *LPSYSTEMTIME;
 
+#define STILL_ACTIVE 259
+
 #endif

--- a/lib/winapi/processthreadsapi.h
+++ b/lib/winapi/processthreadsapi.h
@@ -12,6 +12,7 @@ extern "C"
 typedef DWORD (__stdcall *LPTHREAD_START_ROUTINE) (LPVOID lpThreadParameter);
 HANDLE CreateThread (LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSize, LPTHREAD_START_ROUTINE lpStartAddress, LPVOID lpParameter, DWORD dwCreationFlags, LPDWORD lpThreadId);
 VOID ExitThread (DWORD dwExitCode);
+BOOL GetExitCodeThread (HANDLE hThread, LPDWORD lpExitCode);
 
 HANDLE GetCurrentThread (VOID);
 DWORD GetCurrentThreadId (VOID);

--- a/lib/winapi/thread.c
+++ b/lib/winapi/thread.c
@@ -89,6 +89,26 @@ VOID ExitThread (DWORD dwExitCode)
     PsTerminateSystemThread(dwExitCode);
 }
 
+BOOL GetExitCodeThread (HANDLE hThread, LPDWORD lpExitCode)
+{
+    PETHREAD thread;
+    NTSTATUS status;
+
+    status = ObReferenceObjectByHandle(hThread, NULL, (PVOID *)&thread);
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return FALSE;
+    }
+
+    if (thread->Tcb.HasTerminated) {
+        *lpExitCode = thread->ExitStatus;
+    } else {
+        *lpExitCode = STILL_ACTIVE;
+    }
+    ObfDereferenceObject(thread);
+    return TRUE;
+}
+
 HANDLE GetCurrentThread (VOID)
 {
     return (HANDLE)-2;


### PR DESCRIPTION
This implements `GetExitCodeThread()`, which is required by my upcoming PDCLib PR that will simplify the C11 threading code by implementing it on top of the Win32 thread API. The implementation is roughly based on the code in `thrd_join()`.

Quick testcase:
```c
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>

DWORD WINAPI threadFunc (LPVOID lpParam) {
    return 0xDEADBEEF;
}

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    HANDLE t = CreateThread(NULL, 0, threadFunc, NULL, 0, NULL);
    Sleep(2000);
    DWORD exitcode;
    GetExitCodeThread(t, &exitcode);
    debugPrint("ec: %x\n", exitcode);

    while(1) {
        Sleep(2000);
    }

    return 0;
}
```