### PR TITLE
build: Add DWARF debug info to the assembler flags, too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ NXDK_LDFLAGS += -threads:no
 endif
 
 ifeq ($(DEBUG),y)
+NXDK_ASFLAGS += -g -gdwarf-4
 NXDK_CFLAGS += -g -gdwarf-4
 NXDK_CXXFLAGS += -g -gdwarf-4
 NXDK_LDFLAGS += -debug


### PR DESCRIPTION
While experimenting with intercepting the debug output, I noticed that no debug info was generated for assembly files. This fixes it by adding the flag to generate DWARF debug info to the assembler flags when debug info is requested.