### PR TITLE
hal: Remove deprecated functionality from xbox.c

### DIFF
--- a/lib/hal/xbox.c
+++ b/lib/hal/xbox.c
@@ -14,18 +14,6 @@ void XReboot()
 	HalReturnToFirmware(HalRebootRoutine);
 }
 
-int XGetTickCount()
-{
-	return KeTickCount;
-}
-
-void XSleep(int milliseconds)
-{
-	LARGE_INTEGER interval;
-        interval.QuadPart = (long long) milliseconds * -10000;
-        KeDelayExecutionThread(KernelMode, FALSE, &interval);
-}
-
 /**
  * Launches an XBE.  Examples of xbePath might be:
  *   c:\\blah.xbe
@@ -68,28 +56,4 @@ void XLaunchXBE(char *xbePath)
 
 	// if we couldn't find a trailing slash, the conversion to
 	// the xbox path mustn't have worked, so we will return
-}
-
-int XCreateThread(XThreadCallback callback, void *args1, void *args2)
-{
-	HANDLE id;
-	HANDLE handle;
-
-	NTSTATUS status = PsCreateSystemThreadEx(
-		(HANDLE)&handle,
-		0,
-		65536,
-		0,
-		&id,
-		args1,
-		args2,
-		FALSE,
-		FALSE,
-		(PKSYSTEM_ROUTINE)callback);
-
-	if (handle == 0) {
-		return -1;
-	}
-
-	return (unsigned int)handle;
 }

--- a/lib/hal/xbox.h
+++ b/lib/hal/xbox.h
@@ -9,19 +9,7 @@ extern "C"
 
 void XReboot();
 
-__attribute__((deprecated))
-int  XGetTickCount();
-
-__attribute__((deprecated))
-void XSleep(int milliseconds);
-
 void XLaunchXBE(char *xbePath);
-
-// the thread callback function
-typedef void (*XThreadCallback)(void *args1, void *args2);
-__attribute__((deprecated))
-int XCreateThread(XThreadCallback callback, void *args1, void *args2);
-
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This removes `XGetTickCount`, `XSleep` and `XCreateThread`, all of which have been marked as deprecated before and been replaced by their winapi counterpart.


Suggested migration path for third parties:
`XGetTickCount` -> `GetTickCount`
`XSleep` -> `Sleep`
`XCreateThread` -> `CreateThread`, or, in special cases and when you know exactly what you are doing, `PsCreateSystemThreadEx`
