### PR TITLE
pbkit: Fix compiler optimizations breaking GPU initialization

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -199,7 +199,7 @@ static  DWORD           pb_DmaChID9Inst;
 static  DWORD           pb_DmaChID10Inst;
 static  DWORD           pb_DmaChID11Inst;
 
-static  DWORD           *pb_DmaUserAddr;
+static volatile DWORD  *pb_DmaUserAddr;
 
 static  DWORD           pb_PushIndex;
 static  DWORD           *pb_PushStart;
@@ -1105,9 +1105,9 @@ DWORD pb_wait_until_tiles_not_busy(void)
 
 static void pb_release_tile(int index,int clear_offset)
 {
-    DWORD       *pTile;
-    DWORD       *pZcomp;
-    DWORD       *p;
+    volatile DWORD *pTile;
+    volatile DWORD *pZcomp;
+    volatile DWORD *p;
 
     DWORD       addr;
     DWORD       data;


### PR DESCRIPTION
This fixes the GPU initialization issue encountered when enabling compiler optimizations, as described in #291, by applying the `volatile` keyword at the places described in the issue. I'm aware that there are potentially a lot more of these problems in the code, however, fixing all instances will take a more in-depth revision of the entire code. This is only meant to ensure that the recent interest in utilizing the GPU doesn't hit this problem.

Fixes #291.