### PR TITLE
Allocate framebuffer when XVideoSetMode is called

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -202,6 +202,8 @@ void debugPrint(const char *format, ...)
 
 		s++;
 	}
+
+	XVideoFlushFB();
 }
 
 void debugAdvanceScreen( void )
@@ -219,6 +221,8 @@ void debugAdvanceScreen( void )
 
 	nextRow -= (FONT_HEIGHT+1);
 	nextCol  = MARGIN; 
+
+	XVideoFlushFB();
 }
 
 void debugClearScreen( void )
@@ -228,6 +232,8 @@ void debugClearScreen( void )
 	memset( SCREEN_FB, 0, ((SCREEN_BPP+7)/8) * (SCREEN_WIDTH * SCREEN_HEIGHT) );
 	nextRow = MARGIN;
 	nextCol = MARGIN; 
+
+	XVideoFlushFB();
 }
 
 void debugPrintHex(const char *buffer, int length)

--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -15,9 +15,10 @@
 #define MARGIN         25
 #define MARGINS        50 // MARGIN*2
 
-int SCREEN_WIDTH	= 640;
-int SCREEN_HEIGHT	= 480;
-int SCREEN_BPP = 32;
+unsigned char *SCREEN_FB = NULL;
+int SCREEN_WIDTH	= 0;
+int SCREEN_HEIGHT	= 0;
+int SCREEN_BPP = 0;
 
 int nextRow = MARGIN;
 int nextCol = MARGIN; 
@@ -27,9 +28,18 @@ static const unsigned char systemFont[] =
 #include "font_unscii_16.h"
 };
 
+static void synchronizeFramebuffer(void)
+{
+	VIDEO_MODE vm = XVideoGetMode();
+	SCREEN_WIDTH = vm.width;
+	SCREEN_HEIGHT = vm.height;
+	SCREEN_BPP = vm.bpp;
+	SCREEN_FB = XVideoGetFB();
+}
+
 static void drawChar(unsigned char c, int x, int y, int fgColour, int bgColour)
 {
-	unsigned char *videoBuffer = XVideoGetFB();
+	unsigned char *videoBuffer = SCREEN_FB;
 	videoBuffer += (y * SCREEN_WIDTH + x) * ((SCREEN_BPP+7)/8);
 
 	unsigned char mask;
@@ -146,11 +156,9 @@ void debugPrint(const char *format, ...)
 	va_start(argList, format);
 	vsprintf(buffer, format, argList);
 	va_end(argList);
-	
-	VIDEO_MODE vm = XVideoGetMode();
-	SCREEN_WIDTH = vm.width;
-	SCREEN_HEIGHT = vm.height;
-	SCREEN_BPP = vm.bpp;
+
+	synchronizeFramebuffer();
+
 	int fgColour;
 	int bgColour;
 	switch (SCREEN_BPP) {
@@ -198,11 +206,13 @@ void debugPrint(const char *format, ...)
 
 void debugAdvanceScreen( void )
 {
+	synchronizeFramebuffer();
+
 	int pixelSize = (SCREEN_BPP+7)/8;
 	int screenSize  = SCREEN_WIDTH * (SCREEN_HEIGHT - MARGINS)  * pixelSize;
 	int lineSize    = SCREEN_WIDTH * (FONT_HEIGHT + 1) * pixelSize;
 	
-	unsigned char* thisScreen = XVideoGetFB() + (SCREEN_WIDTH * MARGIN)  * pixelSize;
+	unsigned char* thisScreen = SCREEN_FB + (SCREEN_WIDTH * MARGIN)  * pixelSize;
 	unsigned char* prevScreen = thisScreen+lineSize;
 		
 	memmove(thisScreen, prevScreen, screenSize);
@@ -213,9 +223,9 @@ void debugAdvanceScreen( void )
 
 void debugClearScreen( void )
 {
-	unsigned char* videoBuffer = XVideoGetFB();
+	synchronizeFramebuffer();
 
-	memset( videoBuffer, 0, ((SCREEN_BPP+7)/8) * (SCREEN_WIDTH * SCREEN_HEIGHT) );
+	memset( SCREEN_FB, 0, ((SCREEN_BPP+7)/8) * (SCREEN_WIDTH * SCREEN_HEIGHT) );
 	nextRow = MARGIN;
 	nextCol = MARGIN; 
 }

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -35,15 +35,15 @@
 #define VIDEO_R5G6B5				0x00000011
 #define VIDEO_A8R8G8B8				0x00000012
 
-unsigned char*	framebufferMemory = NULL;
-unsigned char*	_fb = NULL;
-DWORD			dwEncoderSettings 	= 0;
-VIDEO_MODE		vmCurrent = { 0, 0, 0, 0 };
-int			flickerLevel		= 5;
-BOOL			flickerSet		= FALSE;
-BOOL			softenFilter		= TRUE;
-BOOL			softenSet		= FALSE;
-GAMMA_RAMP_ENTRY	gammaRampEntries[256];
+static unsigned char*	framebufferMemory = NULL;
+static unsigned char*	_fb = NULL;
+static DWORD			dwEncoderSettings 	= 0;
+static VIDEO_MODE		vmCurrent = { 0, 0, 0, 0 };
+static int			flickerLevel		= 5;
+static BOOL			flickerSet		= FALSE;
+static BOOL			softenFilter		= TRUE;
+static BOOL			softenSet		= FALSE;
+static GAMMA_RAMP_ENTRY	gammaRampEntries[256];
 
 static KINTERRUPT InterruptObject;
 static KDPC DPCObject;
@@ -62,7 +62,7 @@ typedef struct _VIDEO_MODE_SETTING
 	DWORD dwFlags;
 } VIDEO_MODE_SETTING;
 
-VIDEO_MODE_SETTING vidModes[] =
+static VIDEO_MODE_SETTING vidModes[] =
 {
  {0x44030307,640,480,50,VIDEO_REGION_PAL,AV_PACK_STANDARD}, //640x480 PAL 50Hz
  {0x44040408,720,480,50,VIDEO_REGION_PAL,AV_PACK_STANDARD}, //720x480 PAL 50Hz
@@ -122,7 +122,7 @@ VIDEO_MODE_SETTING vidModes[] =
  {0x04020204,720,480,60,VIDEO_REGION_NTSCJ,AV_PACK_SVIDEO}, //720x480 NTSCJ 60Hz
 };
 
-int iVidModes = sizeof(vidModes) / sizeof(VIDEO_MODE_SETTING);
+static int iVidModes = sizeof(vidModes) / sizeof(VIDEO_MODE_SETTING);
 
 static void __stdcall DPC(PKDPC Dpc,
 PVOID DeferredContext,

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -304,6 +304,11 @@ VIDEO_MODE XVideoGetMode(void)
 	return vmCurrent;
 }
 
+void XVideoFlushFB(void)
+{
+	asm __volatile__("sfence");
+}
+
 void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 {
 	int i;

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -38,7 +38,7 @@
 unsigned char*	framebufferMemory = NULL;
 unsigned char*	_fb = NULL;
 DWORD			dwEncoderSettings 	= 0;
-VIDEO_MODE		vmCurrent;
+VIDEO_MODE		vmCurrent = { 0, 0, 0, 0 };
 int			flickerLevel		= 5;
 BOOL			flickerSet		= FALSE;
 BOOL			softenFilter		= TRUE;

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -35,8 +35,8 @@
 #define VIDEO_R5G6B5				0x00000011
 #define VIDEO_A8R8G8B8				0x00000012
 
-
-unsigned char*	_fb;
+unsigned char*	framebufferMemory = NULL;
+unsigned char*	_fb = NULL;
 DWORD			dwEncoderSettings 	= 0;
 VIDEO_MODE		vmCurrent;
 int			flickerLevel		= 5;
@@ -331,11 +331,28 @@ void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 
 	XVideoSetVideoEnable(FALSE);
 
+	if (framebufferMemory != NULL) {
+		MmFreeContiguousMemory(framebufferMemory);
+	}
+	framebufferMemory = MmAllocateContiguousMemoryEx(screenSize,
+	                                                 0x00000000, 0x7FFFFFFF,
+	                                                 0x1000,
+	                                                 PAGE_READWRITE |
+	                                                 PAGE_WRITECOMBINE);
+	assert(framebufferMemory != NULL);
+	memset(framebufferMemory, 0x00, screenSize);
+	asm __volatile__("sfence");
+
 	do
 	{
 		Step = AvSetDisplayMode((PVOID)VIDEO_BASE, Step, 
-			dwMode, dwFormat, pitch, VIDEO_FRAMEBUFFER);
+			dwMode, dwFormat, pitch, (unsigned int)framebufferMemory & 0x7FFFFFFF);
 	} while(Step);
+
+	/* Store the framebuffer that we set; normally this is done in XVideoSetFB.
+	   However, we're using the kernel's AvSetDisplayMode here instead, so we
+	   set it here, too. */
+	_fb = framebufferMemory;
 
 	XVideoSetFlickerFilter(5);
 	XVideoSetSoftenFilter(TRUE);
@@ -348,9 +365,6 @@ void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 	XVideoSetGammaRamp(0, defaultGammaRampEntries, 256);
 
 	XVideoSetVideoEnable(TRUE);
-
-	_fb = (unsigned char*)(0xF0000000+VIDEOREG(PCRTC_START));
-	memset(_fb, 0x00, screenSize);
 }
 
 

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -292,6 +292,13 @@ unsigned char* XVideoGetFB(void)
 	return _fb;
 }
 
+void XVideoSetFB(unsigned char *fb)
+{
+	assert(((unsigned int)fb & ~0x7FFFFFFF) == 0);
+	_fb = fb;
+	VIDEOREG(PCRTC_START) = (unsigned int)_fb & 0x7FFFFFFF;
+}
+
 VIDEO_MODE XVideoGetMode(void)
 {
 	return vmCurrent;
@@ -440,11 +447,6 @@ void XVideoWaitForVBlank()
 	/* Disable vblank interrupt */
 	VIDEOREG(PCRTC_INTR_EN)=PCRTC_INTR_EN_VBLANK_DISABLED;
 	VIDEOREG(PCRTC_INTR)=PCRTC_INTR_VBLANK_RESET;
-}
-
-void XVideoSetDisplayStart(unsigned int offset)
-{
-	VIDEOREG(PCRTC_START) = (unsigned int) (_fb - 0xF0000000 + offset);
 }
 
 unsigned char* XVideoGetVideoBase()

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -52,6 +52,7 @@ typedef struct _GAMMA_RAMP_ENTRY
 
 DWORD XVideoGetEncoderSettings(void);
 unsigned char* XVideoGetFB(void);
+void XVideoSetFB(unsigned char *fb);
 VIDEO_MODE XVideoGetMode(void);
 
 void XVideoSetFlickerFilter(int level);
@@ -74,7 +75,6 @@ If a value of 0 is provided for the bpp a default value of 32bpp is used.
 BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p);
 
 void XVideoWaitForVBlank();
-void XVideoSetDisplayStart(unsigned int offset);
 unsigned char* XVideoGetVideoBase();
 int XVideoVideoMemorySize();
 

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -53,6 +53,7 @@ DWORD XVideoGetEncoderSettings(void);
 unsigned char* XVideoGetFB(void);
 void XVideoSetFB(unsigned char *fb);
 VIDEO_MODE XVideoGetMode(void);
+void XVideoFlushFB(void);
 
 void XVideoSetFlickerFilter(int level);
 BOOL XVideoSetMode(int width, int height, int bpp, int refresh);

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -10,7 +10,6 @@ extern "C"
 
 // Defines for frame buffer
 #define VIDEO_BASE				0xFD000000
-#define VIDEO_FRAMEBUFFER			0x03c00000
 
 // Hardware access macros
 #define VIDEOREG(x) (*(volatile unsigned int*)(VIDEO_BASE + (x)))


### PR DESCRIPTION
This supersedes #355.

The commits are mostly the same - I only addressed the review comments from #355 and modified the newly introduced functions to use `(void)` instead of an empty parameter list.

I tested the changes by running the samples as well as a slightly modified (to remove the `_fb` reference in it) SDLPoPX.

Closes #170.
Closes #169.
Closes #149.
Closes #269.