### PR TITLE
libc: Provide math.h / string.h overloads expected by libc++

### DIFF
--- a/lib/xboxrt/libc_extensions/stdlib_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.h
@@ -35,3 +35,37 @@ int mbtowc (wchar_t *pwc, const char *string, size_t n);
 #ifdef __cplusplus
 }
 #endif
+
+
+#ifdef __cplusplus
+#if (__cplusplus < 201103L)
+#define _NXDK_NOEXCEPT throw()
+#else
+#define _NXDK_NOEXCEPT noexcept
+#endif
+
+// libc++ expects MSVCRT to provide these overloads
+
+inline static long abs (long __x) _NXDK_NOEXCEPT
+{
+    return labs(__x);
+}
+
+inline static long long abs (long long __x) _NXDK_NOEXCEPT
+{
+    return llabs(__x);
+}
+
+inline static ldiv_t div (long __x, long __y) _NXDK_NOEXCEPT
+{
+    return ldiv(__x, __y);
+}
+
+inline static lldiv_t div (long long __x, long long __y) _NXDK_NOEXCEPT
+{
+    return lldiv(__x, __y);
+}
+
+#undef _NXDK_NOEXCEPT
+
+#endif

--- a/lib/xboxrt/libc_extensions/string_ext_.h
+++ b/lib/xboxrt/libc_extensions/string_ext_.h
@@ -33,3 +33,88 @@ __attribute__((deprecated)) static int stricmp (const char *s1, const char *s2)
 #ifdef __cplusplus
 }
 #endif
+
+
+#ifdef __cplusplus
+// libc++ expects MSVCRT to provide these overloads
+
+#ifndef _NXDK_PREFERRED_OVERLOAD
+#define _NXDK_PREFERRED_OVERLOAD __attribute__ ((__enable_if__(true, "")))
+#endif
+
+inline static char *__nxdk_strchr (const char *__s, int __c)
+{
+    return static_cast<char *>(strchr(__s, __c));
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD const char *strchr (const char *__s, int __c)
+{
+    return __nxdk_strchr(__s, __c);
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD char *strchr (char *__s, int __c)
+{
+    return __nxdk_strchr(__s, __c);
+}
+
+inline static char *__nxdk_strpbrk (const char *__s1, const char *__s2)
+{
+    return static_cast<char *>(strpbrk(__s1, __s2));
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD const char *strpbrk (const char *__s1, const char *__s2)
+{
+    return __nxdk_strpbrk(__s1, __s2);
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD char *strpbrk (char *__s1, char *__s2)
+{
+    return __nxdk_strpbrk(__s1, __s2);
+}
+
+inline static char *__nxdk_strrchr (const char *__s, int __c)
+{
+    return static_cast<char *>(strrchr(__s, __c));
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD const char *strrchr (const char *__s, int __c)
+{
+    return __nxdk_strrchr(__s, __c);
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD char *strrchr (char *__s, int __c)
+{
+    return __nxdk_strrchr(__s, __c);
+}
+
+inline static void *__nxdk_memchr (const void *__s, int __c, size_t __n)
+{
+    return static_cast<void *>(memchr(__s, __c, __n));
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD const void *memchr (const void *__s, int __c, size_t __n)
+{
+    return __nxdk_memchr(__s, __c, __n);
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD void *memchr (void *__s, int __c, size_t __n)
+{
+    return __nxdk_memchr(__s, __c, __n);
+}
+
+inline static char *__nxdk_strstr (const char *__s1, const char *__s2)
+{
+    return static_cast<char *>(strstr(__s1, __s2));
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD const char *strstr (const char *__s1, const char *__s2)
+{
+    return __nxdk_strstr(__s1, __s2);
+}
+
+inline static _NXDK_PREFERRED_OVERLOAD char *strstr (char *__s1, const char *__s2)
+{
+    return __nxdk_strstr(__s1, __s2);
+}
+
+#endif


### PR DESCRIPTION
About two hours ago lorecast162 mentioned issues in Discord with using `std::abs` with a parameter of type `std::intmax_t`. We tracked it down to libc++ expecting the C standard library to provide the `abs` overloads for `long` and `long long` when building C++ code.
I went through libc++'s `math.h` and added all expected overloaded functions to our PDCLib extension header for `stdlib.h` (which is the header libc++ expects to find these functions in). The overloarded functions added are basically identical to the ones libc++ provides for other platforms.

I then searched for other occurrences of this, and found similar issues in `string.h`. `_NXDK_PREFERRED_OVERLOAD` is necessary because otherwise the compiler doesn't allow overloading these functions as only the return type differs for some of them.