### PR TITLE
xboxkrnl: Make Handles parameter of NtWaitForMultipleObjectsEx const

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -2626,7 +2626,7 @@ XBAPI NTSTATUS NTAPI NtWaitForSingleObject
 XBAPI NTSTATUS NTAPI NtWaitForMultipleObjectsEx
 (
     IN ULONG Count,
-    IN HANDLE Handles[],
+    IN CONST HANDLE Handles[],
     IN WAIT_TYPE WaitType,
     IN KPROCESSOR_MODE WaitMode,
     IN BOOLEAN Alertable,


### PR DESCRIPTION
This fixes a warning about implicitly casting away `const` in `WaitForMultipleObjectsEx`.

From what I could see, `NtWaitForMultipleObjectsEx` doesn't try to modify the handles array (it also wouldn't make any sense), so we should be fine.