### PR TITLE
samples: Fix extern screen variables

### DIFF
--- a/samples/sdl/main.c
+++ b/samples/sdl/main.c
@@ -174,8 +174,8 @@ static const struct {
 };
 
 //Screen dimension constants
-const extern int SCREEN_WIDTH;
-const extern int SCREEN_HEIGHT;
+static const int SCREEN_WIDTH = 640;
+static const int SCREEN_HEIGHT = 480;
 #define NUM_SPRITES 10
 #define MAX_SPEED   5
 

--- a/samples/sdl_image/main.c
+++ b/samples/sdl_image/main.c
@@ -24,8 +24,8 @@ static void printIMGErrorAndReboot(void)
 }
 
 // Screen dimension constants
-const extern int SCREEN_WIDTH;
-const extern int SCREEN_HEIGHT;
+static const int SCREEN_WIDTH = 640;
+static const int SCREEN_HEIGHT = 480;
 
 void demo(void)
 {

--- a/samples/sdl_ttf/main.c
+++ b/samples/sdl_ttf/main.c
@@ -5,8 +5,8 @@
 #include <windows.h>
 #include <stdbool.h>
 
-const extern int SCREEN_WIDTH;
-const extern int SCREEN_HEIGHT;
+static const int SCREEN_WIDTH = 640;
+static const int SCREEN_HEIGHT = 480;
 
 int main(void) {
   int initialized_SDL   = -1;


### PR DESCRIPTION
b8d162b0aa9f5da5ed7a2af0cd7fb084a394ad89 changed the default values of SCREEN_WIDTH	and SCREEN_HEIGHT to zero. 

Now these are only synchronised to the actual framebuffer size when using the debug API.
Unfortunately this broke the sdl, sdl_tff and sdl_image samples as they relied on using these variables by `extern int`. 

This fix declares them locally in each sample.

Not sure if this is the best solution going forward, but it gets the samples working again.

Issue reported on xboxdev discord by a user.