### PR TITLE
nxdk: Add extern "C" identifier in path.h

### DIFF
--- a/lib/nxdk/path.h
+++ b/lib/nxdk/path.h
@@ -8,7 +8,7 @@
 #define __NXDK_PATH_H__
 
 #ifdef __cplusplus
-{
+extern "C" {
 #endif
 
 #ifndef __cplusplus


### PR DESCRIPTION
I stumbled upon this issue while trying to make NevolutionX expose the DVD drive as "D:".