### PR TITLE
debug: Support setting and resetting cursor position

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -236,6 +236,25 @@ void debugClearScreen( void )
 	XVideoFlushFB();
 }
 
+void debugResetCursor ( void )
+{
+	nextRow = MARGIN;
+	nextCol = MARGIN;
+}
+
+void debugMoveCursor (int x, int y)
+{
+	if ( x < MARGIN || x > SCREEN_WIDTH-MARGIN-FONT_WIDTH ) {
+		return;
+	}
+	if ( y < MARGIN || y > SCREEN_HEIGHT-MARGIN-FONT_HEIGHT ) {
+		return;
+	}
+	
+	nextRow = y;
+	nextCol = x;
+}
+
 void debugPrintHex(const char *buffer, int length)
 {
 	char tmp[10];

--- a/lib/hal/debug.h
+++ b/lib/hal/debug.h
@@ -29,7 +29,8 @@ void debugPrintBinary( int num );
 void debugPrintHex(const char *buffer, int length);
 void debugClearScreen( void );
 void debugAdvanceScreen( void );
-
+void debugMoveCursor(int x, int y);
+void debugResetCursor( void );
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This makes it easy to use debugPrint() to make a simple persistent readout. Call debugPrint() with your readout text after you have drawn your screen, then debugResetCursor() to prevent the next frames prints from running down the screen on the next frames.

It's not perfect because the readout will flicker a bit depending on how fast the screen is being updated, but it's very easy to use this way and perfectly readable for quick debug output.