### PR TITLE
ci: Build, test and push Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**/.git
+tools/cg/mac
+tools/cg/win
+lib/sdl/SDL2/test
+lib/libcxx/test

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,0 +1,47 @@
+name: Build Docker image
+
+on:
+  push:
+    branches: master
+
+jobs:
+  main:
+    name: Docker
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Clone Tree
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          submodules: recursive
+      - name: Generate tags
+        id: tags
+        run: |
+          DOCKER_IMAGE=xboxdev/nxdk
+          TAGS="${DOCKER_IMAGE}:latest"
+          TAGS="$TAGS,${DOCKER_IMAGE}:git-${GITHUB_SHA::8}"
+          TAGS="$TAGS,ghcr.io/${DOCKER_IMAGE}:latest"
+          TAGS="$TAGS,ghcr.io/${DOCKER_IMAGE}:git-${GITHUB_SHA::8}"
+          echo ::set-output name=tags::${TAGS}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/386
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -3,6 +3,22 @@ name: Build Samples
 on: [push, pull_request]
 
 jobs:
+  docker:
+    name: Docker
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Clone Tree
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+          submodules: recursive
+      - name: Build Docker image
+        run: |
+          docker build -t nxdk ./
+      - name: Test Docker image
+        run: |
+          docker run nxdk sh -c "cd /usr/src/nxdk && sh ./.ci_build_samples.sh"
   windows:
     name: Windows
     runs-on: windows-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ghcr.io/xboxdev/nxdk-buildbase:git-39eb90d1
+
+COPY ./ /usr/src/nxdk/
+
+ENV NXDK_DIR=/usr/src/nxdk
+
+WORKDIR /usr/src/app


### PR DESCRIPTION
This adds a Dockerfile plus two actions to build and test a Docker image containing Alpine Linux 3.12, the requirements of nxdk (llvm etc.) and the nxdk source code. Pushes to master will trigger the second action, which builds the image and pushes it to DockerHub: https://hub.docker.com/repository/docker/xboxdev/nxdk. The images are tagged with their git short hash, so we we can correlate commits and images.
I also added a `.dockerignore` to exclude the git directories and some other large unnecessary directories and files from the image to reduce the size.

For the push to DockerHub to work, we'll have to configure the username and token secrets on the nxdk repo before merging.

To test, you can pull the image from https://hub.docker.com/repository/docker/thrimbor/nxdk and run this from a directory containing an nxdk Makefile:
``docker run --rm -v `pwd`:/usr/src/app -it nxdk make``
It'll automatically set `NXDK_DIR` correctly, too.

/edit:
Fixes #37.