### PR TITLE
build: Link to fixed base instead of relocating in cxbe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions
-NXDK_LDFLAGS = -subsystem:windows -fixed:no -entry:XboxCRTEntry \
+NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 -entry:XboxCRTEntry \
                -stack:$(NXDK_STACKSIZE) -safeseh:no -include:__fltused -include:__xlibc_check_stack
 
 # Multithreaded LLD on Windows hang workaround


### PR DESCRIPTION
This changes the linker parameters to directly link to the fixed base `0x00010000` instead of producing a relocatable binary that is then relocated by cxbe. I did this mainly to make debugging a bit more comfortable - with the exe already having the correct base, we can just let gdb read it directly without having to extract section addresses from the xbe.
Another benefit is that it reduces binary size by not emitting a `.reloc` section.