### PR TITLE
winapi: Implement ZeroMemory()

### DIFF
--- a/lib/winapi/memory.c
+++ b/lib/winapi/memory.c
@@ -47,3 +47,8 @@ SIZE_T VirtualQuery (LPCVOID lpAddress, PMEMORY_BASIC_INFORMATION lpBuffer, SIZE
 
     return sizeof(MEMORY_BASIC_INFORMATION);
 }
+
+VOID WINAPI ZeroMemory (PVOID Destination, SIZE_T length)
+{
+    RtlZeroMemory(Destination, length);
+}

--- a/lib/winapi/winbase.h
+++ b/lib/winapi/winbase.h
@@ -120,6 +120,8 @@ typedef struct _WIN32_FIND_DATAA {
 #define LPWIN32_FIND_DATA LPWIN32_FIND_DATAA
 #endif
 
+VOID WINAPI ZeroMemory (PVOID Destination, SIZE_T length);
+
 DWORD GetLastError (void);
 void SetLastError (DWORD error);
 


### PR DESCRIPTION
This adds `ZeroMemory`, which is just a wrapper for `RtlZeroMemory`. I initially used this in a feature branch I'm working on, and even though that branch now doesn't require it anymore, I still think it's worthy of getting added just for completeness.