### PR TITLE
Makefile: Fix lld-link -threads argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,11 +70,6 @@ NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions
 NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 -entry:XboxCRTEntry \
                -stack:$(NXDK_STACKSIZE) -safeseh:no -include:__fltused -include:__xlibc_check_stack
 
-# Multithreaded LLD on Windows hang workaround
-ifneq (,$(findstring MINGW,$(UNAME_S)))
-NXDK_LDFLAGS += -threads:no
-endif
-
 ifeq ($(DEBUG),y)
 NXDK_ASFLAGS += -g -gdwarf-4
 NXDK_CFLAGS += -g -gdwarf-4


### PR DESCRIPTION
Argument expects an integer on the latest version of lld-link (11.0.0-1), rather than the string "no".
This fixes compilation of nxdk programs on windows msys2, which would otherwise have shown the following error at link time:
`lld-link: error: -threads:: expected a positive integer, but got 'no'`

Tested and working also with clang/llvm 9, for compatibility. It just shows up as an unknown argument warning anyway.