### PR TITLE
Clean up stray whitespaces in Makefile, add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[Makefile*]
+indent_style = tab

--- a/Makefile
+++ b/Makefile
@@ -191,14 +191,14 @@ $(EXTRACT_XISO):
 	cmake -G "Unix Makefiles" .. $(QUIET) && \
 	$(MAKE) $(QUIET))
 
-.PHONY: clean 
+.PHONY: clean
 clean: $(CLEANRULES)
 	$(VE)rm -f $(TARGET) \
 	           main.exe main.exe.manifest main.lib \
 	           $(OBJS) $(SHADER_OBJS) $(DEPS) \
 	           $(GEN_XISO)
 
-.PHONY: distclean 
+.PHONY: distclean
 distclean: clean
 	$(VE)rm -rf $(NXDK_DIR)/tools/extract-xiso/build
 	$(VE)$(MAKE) -C $(NXDK_DIR)/tools/fp20compiler distclean $(QUIET)


### PR DESCRIPTION
This removes stray whitespaces, and introduces a .editorconfig file to avoid re-introducing them.