### PR TITLE
Add Zstandard

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "lib/sdl/SDL_image"]
 	path = lib/sdl/SDL2_image
 	url = https://github.com/SDL-mirror/SDL_image.git
+[submodule "lib/zstd/zstd"]
+	path = lib/zstd/zstd
+	url = https://github.com/facebook/zstd

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,10 @@ include $(NXDK_DIR)/lib/sdl/SDL2/Makefile.xbox
 include $(NXDK_DIR)/lib/sdl/Makefile
 endif
 
+ifneq ($(NXDK_ZSTD),)
+include $(NXDK_DIR)/lib/zstd/Makefile
+endif
+
 V = 0
 VE_0 := @
 VE_1 :=

--- a/lib/xboxrt/libc_extensions/stdlib_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.h
@@ -32,6 +32,10 @@ int mbtowc (wchar_t *pwc, const char *string, size_t n);
 #define __min(a,b) (((a) < (b)) ? (a) : (b))
 #define __max(a,b) (((a) > (b)) ? (a) : (b))
 
+#define _byteswap_ushort __builtin_bswap16
+#define _byteswap_ulong __builtin_bswap32
+#define _byteswap_uint64 __builtin_bswap64
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/zstd/Makefile
+++ b/lib/zstd/Makefile
@@ -1,12 +1,37 @@
 zstd_DIR	= $(NXDK_DIR)/lib/zstd/zstd
-zstd_SRCS	= $(sort $(wildcard $(zstd_DIR)/lib/common/*.c))
-zstd_SRCS	+= $(sort $(wildcard $(zstd_DIR)/lib/compress/*.c))
-zstd_SRCS	+= $(sort $(wildcard $(zstd_DIR)/lib/decompress/*.c))
-zstd_SRCS	+= $(sort $(wildcard $(zstd_DIR)/lib/dictBuilder/*.c))
+zstd_SRCS	=	$(zstd_DIR)/lib/common/debug.c \
+				$(zstd_DIR)/lib/common/entropy_common.c \
+				$(zstd_DIR)/lib/common/error_private.c \
+				$(zstd_DIR)/lib/common/fse_decompress.c \
+				$(zstd_DIR)/lib/common/pool.c \
+				$(zstd_DIR)/lib/common/threading.c \
+				$(zstd_DIR)/lib/common/xxhash.c \
+				$(zstd_DIR)/lib/common/zstd_common.c
+zstd_SRCS	+=	$(zstd_DIR)/lib/compress/fse_compress.c \
+				$(zstd_DIR)/lib/compress/hist.c \
+				$(zstd_DIR)/lib/compress/huf_compress.c \
+				$(zstd_DIR)/lib/compress/zstdmt_compress.c \
+				$(zstd_DIR)/lib/compress/zstd_compress.c \
+				$(zstd_DIR)/lib/compress/zstd_compress_literals.c \
+				$(zstd_DIR)/lib/compress/zstd_compress_sequences.c \
+				$(zstd_DIR)/lib/compress/zstd_compress_superblock.c \
+				$(zstd_DIR)/lib/compress/zstd_double_fast.c \
+				$(zstd_DIR)/lib/compress/zstd_fast.c \
+				$(zstd_DIR)/lib/compress/zstd_lazy.c \
+				$(zstd_DIR)/lib/compress/zstd_ldm.c \
+				$(zstd_DIR)/lib/compress/zstd_opt.c
+zstd_SRCS	+=	$(zstd_DIR)/lib/decompress/huf_decompress.c \
+				$(zstd_DIR)/lib/decompress/zstd_ddict.c \
+				$(zstd_DIR)/lib/decompress/zstd_decompress.c \
+				$(zstd_DIR)/lib/decompress/zstd_decompress_block.c
+zstd_SRCS	+=	$(zstd_DIR)/lib/dictBuilder/cover.c \
+				$(zstd_DIR)/lib/dictBuilder/divsufsort.c \
+				$(zstd_DIR)/lib/dictBuilder/fastcover.c \
+				$(zstd_DIR)/lib/dictBuilder/zdict.c
 
 zstd_OBJS = $(addsuffix .obj, $(basename $(zstd_SRCS)))
 
-NXDK_CFLAGS += -I $(zstd_DIR)/lib -D_byteswap_ulong=__builtin_bswap32 -D_byteswap_uint64=__builtin_bswap64
+NXDK_CFLAGS += -I $(zstd_DIR)/lib
 
 $(NXDK_DIR)/lib/libzstd.lib: $(zstd_OBJS)
 

--- a/lib/zstd/Makefile
+++ b/lib/zstd/Makefile
@@ -1,0 +1,19 @@
+zstd_DIR	= $(NXDK_DIR)/lib/zstd/zstd
+zstd_SRCS	= $(sort $(wildcard $(zstd_DIR)/lib/common/*.c))
+zstd_SRCS	+= $(sort $(wildcard $(zstd_DIR)/lib/compress/*.c))
+zstd_SRCS	+= $(sort $(wildcard $(zstd_DIR)/lib/decompress/*.c))
+zstd_SRCS	+= $(sort $(wildcard $(zstd_DIR)/lib/dictBuilder/*.c))
+
+zstd_OBJS = $(addsuffix .obj, $(basename $(zstd_SRCS)))
+
+NXDK_CFLAGS += -I $(zstd_DIR)/lib -D_byteswap_ulong=__builtin_bswap32 -D_byteswap_uint64=__builtin_bswap64
+
+$(NXDK_DIR)/lib/libzstd.lib: $(zstd_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libzstd.lib
+
+CLEANRULES += clean-zstd
+
+.PHONY: clean-zstd
+clean-zstd:
+	$(VE)rm -f $(zstd_OBJS) $(NXDK_DIR)/lib/libzstd.lib

--- a/samples/compression-zstd/Makefile
+++ b/samples/compression-zstd/Makefile
@@ -1,0 +1,7 @@
+XBE_TITLE	= $(shell basename $(CURDIR))
+GEN_XISO	= $(XBE_TITLE).iso
+SRCS		= $(shell find . -name '*.c')
+NXDK_ZSTD	= y
+NXDK_DIR	= $(CURDIR)/../..
+
+include $(NXDK_DIR)/Makefile

--- a/samples/compression-zstd/Makefile
+++ b/samples/compression-zstd/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE	= $(shell basename $(CURDIR))
+XBE_TITLE	= compression-zstd
 GEN_XISO	= $(XBE_TITLE).iso
 SRCS		= $(shell find . -name '*.c')
 NXDK_ZSTD	= y

--- a/samples/compression-zstd/Makefile
+++ b/samples/compression-zstd/Makefile
@@ -1,6 +1,6 @@
 XBE_TITLE	= compression-zstd
 GEN_XISO	= $(XBE_TITLE).iso
-SRCS		= $(shell find . -name '*.c')
+SRCS		= $(CURDIR)/main.c
 NXDK_ZSTD	= y
 NXDK_DIR	= $(CURDIR)/../..
 

--- a/samples/compression-zstd/main.c
+++ b/samples/compression-zstd/main.c
@@ -1,10 +1,8 @@
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
 #include <hal/debug.h>
 #include <hal/video.h>
-#include <hal/input.h>
 #include <hal/xbox.h>
 
 #include <xboxkrnl/xboxkrnl.h>
@@ -16,28 +14,32 @@ const char* example = "This text has been compressed on the Microsoft Xbox using
 int main(void)
 {
     XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+    debugPrint("Compressing now:\n\"%s\"\n", example);
 
     size_t size = strlen(example), compressed_size = ZSTD_compressBound(strlen(example));
+    debugPrint("Original size: %lu.\n", size);
 
     char* compressed_buffer = calloc(compressed_size + 1, sizeof(char));
-    memset(compressed_buffer, 0, (compressed_size + 1) * sizeof(char));
+    size_t end_size = ZSTD_compress(compressed_buffer, compressed_size, example, size, 16);
+    debugPrint("New size: %lu.\n", end_size);
 
-    int code = ZSTD_compress(compressed_buffer, compressed_size, example, size, 16);
-    debugPrint("Compression result code: %d\n", code);
-    debugPrint("Original size: %lu\n", size);
-    debugPrint("Compressed size: %lu\n", compressed_size);
+    char* minified_compressed_buffer = calloc(end_size + 1, sizeof(char));
+    memcpy(minified_compressed_buffer, compressed_buffer, sizeof(char) * end_size);
+    free(compressed_buffer);
 
     debugPrint("Compressed data:\n");
-    debugPrintHex(compressed_buffer, compressed_size);
+    debugPrintHex(minified_compressed_buffer, end_size);
     debugPrint("\n");
 
-    char* decompressed_buffer = calloc(size + 1, sizeof(char));
-    code = ZSTD_decompress(decompressed_buffer, size, compressed_buffer, compressed_size);
-    debugPrint("Decompression result code: %d\n", code);
+    char* decompressed_buffer = calloc(1, sizeof(char));
+    size_t new_size = ZSTD_decompress(decompressed_buffer, size, minified_compressed_buffer, end_size);
+    debugPrint("Decompressed size: %d.\n", new_size);
     debugPrint("Decompressed data:\n\"%s\"\n", decompressed_buffer);
 
+    free(minified_compressed_buffer);
     free(decompressed_buffer);
-    free(compressed_buffer);
+
+    debugPrint("Done.");
 
     while (TRUE) NtYieldExecution();
 

--- a/samples/compression-zstd/main.c
+++ b/samples/compression-zstd/main.c
@@ -1,0 +1,45 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <hal/debug.h>
+#include <hal/video.h>
+#include <hal/input.h>
+#include <hal/xbox.h>
+
+#include <xboxkrnl/xboxkrnl.h>
+
+#include <zstd.h>
+
+const char* example = "This text has been compressed on the Microsoft Xbox using Zstandard. The application was built with the nxdk.";
+
+int main(void)
+{
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+
+    size_t size = strlen(example), compressed_size = ZSTD_compressBound(strlen(example));
+
+    char* compressed_buffer = calloc(compressed_size + 1, sizeof(char));
+    memset(compressed_buffer, 0, (compressed_size + 1) * sizeof(char));
+
+    int code = ZSTD_compress(compressed_buffer, compressed_size, example, size, 16);
+    debugPrint("Compression result code: %d\n", code);
+    debugPrint("Original size: %lu\n", size);
+    debugPrint("Compressed size: %lu\n", compressed_size);
+
+    debugPrint("Compressed data:\n");
+    debugPrintHex(compressed_buffer, compressed_size);
+    debugPrint("\n");
+
+    char* decompressed_buffer = calloc(size + 1, sizeof(char));
+    code = ZSTD_decompress(decompressed_buffer, size, compressed_buffer, compressed_size);
+    debugPrint("Decompression result code: %d\n", code);
+    debugPrint("Decompressed data:\n\"%s\"\n", decompressed_buffer);
+
+    free(decompressed_buffer);
+    free(compressed_buffer);
+
+    while (TRUE) NtYieldExecution();
+
+    return 0;
+}

--- a/samples/compression-zstd/main.c
+++ b/samples/compression-zstd/main.c
@@ -5,7 +5,7 @@
 #include <hal/video.h>
 #include <hal/xbox.h>
 
-#include <xboxkrnl/xboxkrnl.h>
+#include <windows.h>
 
 #include <zstd.h>
 
@@ -41,7 +41,7 @@ int main(void)
 
     debugPrint("Done.");
 
-    while (TRUE) NtYieldExecution();
+    while (TRUE) SwitchToThread();
 
     return 0;
 }


### PR DESCRIPTION
Added Zstandard, it should be a good alternative to zlib.
I've added a sample and tested it on my Xbox and didn't encounter any issues.

Edit: maybe a sample showcasing how to add a library in a subdirectory within a project would be useful in case someone makes an application that requires another not-yet-ported library.