### PR TITLE
Implement lookup of functions export by the xbe, add PE and XBE header structs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions
 NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 -entry:XboxCRTEntry \
-               -stack:$(NXDK_STACKSIZE) -safeseh:no -include:__fltused -include:__xlibc_check_stack
+               -stack:$(NXDK_STACKSIZE) -safeseh:no -include:__fltused -include:__xlibc_check_stack -merge:.edata=.edataxb
 
 ifeq ($(DEBUG),y)
 NXDK_ASFLAGS += -g -gdwarf-4

--- a/lib/winapi/libloaderapi.c
+++ b/lib/winapi/libloaderapi.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <stdlib.h>
+#include <string.h>
 
 HMODULE LoadLibraryExA (LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
 {
@@ -30,9 +31,46 @@ BOOL FreeLibrary (HMODULE hLibModule)
     return TRUE;
 }
 
+static PIMAGE_EXPORT_DIRECTORY find_edataxb (void)
+{
+    DWORD num_sections = CURRENT_XBE_HEADER->NumberOfSections;
+    PXBE_SECTION_HEADER section_header_addr = CURRENT_XBE_HEADER->PointerToSectionTable;
+
+    for (DWORD i = 0; i < num_sections; i++) {
+        if (memcmp(section_header_addr[i].SectionName, ".edataxb", 8) == 0) {
+            return (PIMAGE_EXPORT_DIRECTORY)section_header_addr[i].VirtualAddress;
+        }
+    }
+
+    return NULL;
+}
+
 FARPROC GetProcAddress (HMODULE hModule, LPCSTR lpProcName)
 {
-    // FIXME: If hModule is NULL, the symbol is looked up in the current module
+    if (hModule == NULL) {
+        // When no dll handle is given, the symbol gets looked up in the main module
+
+        PIMAGE_EXPORT_DIRECTORY exportdir = find_edataxb();
+        if (!exportdir) {
+            SetLastError(ERROR_PROC_NOT_FOUND);
+            return NULL;
+        }
+
+        for (DWORD i = 0; i < exportdir->NumberOfNames; i++) {
+            const char **nametable = (const char **)(exportdir->AddressOfNames + XBE_DEFAULT_BASE);
+            const char *name_addr = (const char *)(nametable[i] + XBE_DEFAULT_BASE);
+
+            if (strcmp(lpProcName, name_addr) == 0) {
+                // Found a matching name and its index. This index is not valid for the address table, that index needs to be looked up in the ordinal table!
+                WORD *ordtable = (WORD *)(exportdir->AddressOfNameOrdinals + XBE_DEFAULT_BASE);
+                BYTE **proctable = (BYTE **)(exportdir->AddressOfFunctions + XBE_DEFAULT_BASE);
+                return (FARPROC)proctable[ordtable[i]] + XBE_DEFAULT_BASE;
+            }
+        }
+
+        SetLastError(ERROR_PROC_NOT_FOUND);
+        return NULL;
+    }
 
     // FIXME: If the module handle is invalid, fail with ERROR_MOD_NOT_FOUND
 

--- a/lib/winapi/winnt.h
+++ b/lib/winapi/winnt.h
@@ -226,4 +226,85 @@ typedef struct _IMAGE_TLS_DIRECTORY32
     };
 } IMAGE_TLS_DIRECTORY_32, *PIMAGE_TLS_DIRECTORY_32;
 
+
+// The XBE_ prefixed functionality is an nxdk-specific extension, and not usually found in winnt.h
+
+typedef struct _XBE_CERTIFICATE_HEADER
+{
+    DWORD SizeOfHeader;
+    DWORD TimeDateStamp;
+    DWORD TitleID;
+    WCHAR TitleName[40];
+    DWORD AlternateTitleIDs[16];
+    DWORD AllowedMedia;
+    DWORD GameRegion;
+    DWORD GameRatings;
+    DWORD DiscNumber;
+    DWORD Version;
+    BYTE LANKey[16];
+    BYTE SignatureKey[16];
+    BYTE AlternateSignatureKeys[16*16];
+} XBE_CERTIFICATE_HEADER, *PXBE_CERTIFICATE_HEADER;
+
+typedef struct _XBE_LIBRARY_HEADER
+{
+    CHAR LibraryName[8];
+    WORD MajorVersion;
+    WORD MinorVersion;
+    WORD BuildVersion;
+    DWORD LibraryFlags;
+} XBE_LIBRARY_HEADER, *PXBE_LIBRARY_HEADER;
+
+typedef struct _XBE_SECTION_HEADER
+{
+    DWORD Flags;
+    DWORD VirtualAddress;
+    DWORD VirtualSize;
+    DWORD FileAddress;
+    DWORD FileSize;
+    PCSZ SectionName;
+    LONG SectionReferenceCount;
+    WORD *HeadReferenceCount;
+    WORD *TailReferenceCount;
+    BYTE CheckSum[20];
+} XBE_SECTION_HEADER, *PXBE_SECTION_HEADER;
+
+typedef struct _XBE_FILE_HEADER
+{
+    WORD Magic;
+    UCHAR Signature[256];
+    DWORD ImageBase;
+    DWORD SizeOfHeaders;
+    DWORD SizeOfImage;
+    DWORD SizeOfImageHeader;
+    DWORD TimeDateStamp;
+    PXBE_CERTIFICATE_HEADER CertificateHeader;
+    DWORD NumberOfSections;
+    PXBE_SECTION_HEADER PointerToSectionTable;
+    DWORD InitFlags;
+    DWORD AddressOfEntryPoint;
+    PIMAGE_TLS_DIRECTORY_32 PointerToTlsDirectory;
+    DWORD SizeOfStack;
+    DWORD SizeOfHeapReserve;
+    DWORD SizeOfHeapCommit;
+    DWORD PeImageBase;
+    DWORD PeSizeOfImage;
+    DWORD PeImageCheckSum;
+    DWORD PeTimeDateStamp;
+    DWORD PeDebugPath;
+    DWORD PeDebugFilename;
+    DWORD PeDebugFilenameUnicode;
+    DWORD PointerToKernelThunkTable;
+    DWORD PointerToDebugImportTable;
+    DWORD NumberOfLibraries;
+    PXBE_LIBRARY_HEADER PointerToLibraries;
+    PXBE_LIBRARY_HEADER PointerToKernelLibrary;
+    PXBE_LIBRARY_HEADER PointerToXapiLibrary;
+    DWORD PointerToLogoBitmap;
+    DWORD SizeOfLogoBitmap;
+} XBE_FILE_HEADER, *PXBE_FILE_HEADER;
+
+#define XBE_DEFAULT_BASE (0x10000)
+#define CURRENT_XBE_HEADER ((PXBE_FILE_HEADER)XBE_DEFAULT_BASE)
+
 #endif

--- a/lib/winapi/winnt.h
+++ b/lib/winapi/winnt.h
@@ -13,4 +13,217 @@ typedef LPCWSTR LPCTSTR;
 typedef LPCSTR LPCTSTR;
 #endif
 
+#define IMAGE_DOS_SIGNATURE 0x5A4D
+#define IMAGE_NT_SIGNATURE 0x00004550
+
+typedef struct _IMAGE_DOS_HEADER
+{
+    WORD e_magic;
+    WORD e_cblp;
+    WORD e_cp;
+    WORD e_crlc;
+    WORD e_cparhdr;
+    WORD e_minalloc;
+    WORD e_maxalloc;
+    WORD e_ss;
+    WORD e_sp;
+    WORD e_csum;
+    WORD e_ip;
+    WORD e_cs;
+    WORD e_lfarlc;
+    WORD e_ovno;
+    WORD e_res[4];
+    WORD e_oemid;
+    WORD e_oeminfo;
+    WORD e_res2[10];
+    LONG e_lfanew;
+} IMAGE_DOS_HEADER, *PIMAGE_DOS_HEADER;
+
+typedef struct _IMAGE_DATA_DIRECTORY
+{
+    DWORD VirtualAddress;
+    DWORD Size;
+} IMAGE_DATA_DIRECTORY, *PIMAGE_DATA_DIRECTORY;
+
+#define IMAGE_NT_OPTIONAL_HDR32_MAGIC 0x10b
+#define IMAGE_NT_OPTIONAL_HDR64_MAGIC 0x20b
+#define IMAGE_ROM_OPTIONAL_HDR_MAGIC 0x107
+#define IMAGE_NT_OPTIONAL_HDR_MAGIC IMAGE_NT_OPTIONAL_HDR32_MAGIC
+
+#define IMAGE_SUBSYSTEM_UNKNOWN 0
+#define IMAGE_SUBSYSTEM_NATIVE 1
+#define IMAGE_SUBSYSTEM_WINDOWS_GUI 2
+#define IMAGE_SUBSYSTEM_WINDOWS_CUI 3
+#define IMAGE_SUBSYSTEM_OS2_CUI 5
+#define IMAGE_SUBSYSTEM_POSIX_CUI 7
+#define IMAGE_SUBSYSTEM_WINDOWS_CE_GUI 9
+#define IMAGE_SUBSYSTEM_EFI_APPLICATION 10
+#define IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER 11
+#define IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER 12
+#define IMAGE_SUBSYSTEM_EFI_ROM 13
+#define IMAGE_SUBSYSTEM_XBOX 14
+#define IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION 16
+
+#define IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE 0x0040
+#define IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY 0x0080
+#define IMAGE_DLLCHARACTERISTICS_NX_COMPAT 0x0100
+#define IMAGE_DLLCHARACTERISTICS_NO_ISOLATION 0x0200
+#define IMAGE_DLLCHARACTERISTICS_NO_SEH 0x0400
+#define IMAGE_DLLCHARACTERISTICS_NO_BIND 0x0800
+#define IMAGE_DLLCHARACTERISTICS_WDM_DRIVER 0x2000
+#define IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE 0x8000
+
+#define IMAGE_NUMBEROF_DIRECTORY_ENTRIES 16
+#define IMAGE_DIRECTORY_ENTRY_EXPORT 0
+#define IMAGE_DIRECTORY_ENTRY_IMPORT 1
+#define IMAGE_DIRECTORY_ENTRY_RESOURCE 2
+#define IMAGE_DIRECTORY_ENTRY_EXCEPTION 3
+#define IMAGE_DIRECTORY_ENTRY_SECURITY 4
+#define IMAGE_DIRECTORY_ENTRY_BASERELOC 5
+#define IMAGE_DIRECTORY_ENTRY_DEBUG 6
+#define IMAGE_DIRECTORY_ENTRY_ARCHITECTURE 7
+#define IMAGE_DIRECTORY_ENTRY_GLOBALPTR 8
+#define IMAGE_DIRECTORY_ENTRY_TLS 9
+#define IMAGE_DIRECTORY_ENTRY_LOAD_CONFIG 10
+#define IMAGE_DIRECTORY_ENTRY_BOUND_IMPORT 11
+#define IMAGE_DIRECTORY_ENTRY_IAT 12
+#define IMAGE_DIRECTORY_ENTRY_DELAY_IMPORT 13
+#define IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR 14
+
+typedef struct _IMAGE_OPTIONAL_HEADER
+{
+    WORD Magic;
+    BYTE MajorLinkerVersion;
+    BYTE MinorLinkerVersion;
+    DWORD SizeOfCode;
+    DWORD SizeOfInitializedData;
+    DWORD SizeOfUninitializedData;
+    DWORD AddressOfEntryPoint;
+    DWORD BaseOfCode;
+    DWORD BaseOfData;
+    DWORD ImageBase;
+    DWORD SectionAlignment;
+    DWORD FileAlignment;
+    WORD MajorOperatingSystemVersion;
+    WORD MinorOperatingSystemVersion;
+    WORD MajorImageVersion;
+    WORD MinorImageVersion;
+    WORD MajorSubsystemVersion;
+    WORD MinorSubsystemVersion;
+    DWORD Win32VersionValue;
+    DWORD SizeOfImage;
+    DWORD SizeOfHeaders;
+    DWORD CheckSum;
+    WORD Subsystem;
+    WORD DllCharacteristics;
+    DWORD SizeOfStackReserve;
+    DWORD SizeOfStackCommit;
+    DWORD SizeOfHeapReserve;
+    DWORD SizeOfHeapCommit;
+    DWORD LoaderFlags;
+    DWORD NumberOfRvaAndSizes;
+    IMAGE_DATA_DIRECTORY DataDirectory[IMAGE_NUMBEROF_DIRECTORY_ENTRIES];
+} IMAGE_OPTIONAL_HEADER32, *PIMAGE_OPTION_HEADER32;
+
+#define IMAGE_FILE_MACHINE_I386 0x014c
+#define IMAGE_FILE_MACHINE_IA64 0x0200
+#define IMAGE_FILE_MACHINE_AMD64 0x8664
+
+#define IMAGE_FILE_RELOCS_STRIPPED 0x0001
+#define IMAGE_FILE_EXECUTABLE_IMAGE 0x0002
+#define IMAGE_FILE_LINE_NUMS_STRIPPED 0x0004
+#define IMAGE_FILE_LOCAL_SYMS_STRIPPED 0x008
+#define IMAGE_FILE_AGGRESIVE_WS_TRIM 0x0010
+#define IMAGE_FILE_LARGE_ADDRESS_AWARE 0x0020
+#define IMAGE_FILE_BYTES_REVERSED_LO 0x0080
+#define IMAGE_FILE_32BIT_MACHINE 0x0100
+#define IMAGE_FILE_DEBUG_STRIPPED 0x0200
+#define IMAGE_FILE_REMOVABLE_RUN_FROM_SWAP 0x0400
+#define IMAGE_FILE_NET_RUN_FROM_SWAP 0x0800
+#define IMAGE_FILE_SYSTEM 0x1000
+#define IMAGE_FILE_DLL 0x2000
+#define IMAGE_FILE_UP_SYSTEM_ONLY 0x4000
+#define IMAGE_FILE_BYTES_REVERSED_HI 0x8000
+
+typedef struct _IMAGE_FILE_HEADER
+{
+    WORD Machine;
+    WORD NumberOfSections;
+    DWORD TimeDateStamp;
+    DWORD PointerToSymbolTable;
+    DWORD NumberOfSymbols;
+    WORD SizeOfOptionalHeader;
+    WORD Characteristics;
+} IMAGE_FILE_HEADER, *PIMAGE_FILE_HEADER;
+
+typedef struct _IMAGE_NT_HEADERS32
+{
+    DWORD Signature;
+    IMAGE_FILE_HEADER FileHeader;
+    IMAGE_OPTIONAL_HEADER32 OptionalHeader;
+} IMAGE_NT_HEADERS32, *PIMAGE_NT_HEADERS32;
+
+#define IMAGE_SIZEOF_SHORT_NAME 8
+
+typedef struct _IMAGE_SECTION_HEADER
+{
+    BYTE Name[IMAGE_SIZEOF_SHORT_NAME];
+    union {
+        DWORD PhysicalAddress;
+        DWORD VirtualSize;
+    } Misc;
+    DWORD VirtualAddress;
+    DWORD SizeOfRawData;
+    DWORD PointerToRawData;
+    DWORD PointerToRelocations;
+    DWORD PointerToLinenumbers;
+    WORD NumberOfRelocations;
+    WORD NumberOfLinenumbers;
+    DWORD Characteristics;
+} IMAGE_SECTION_HEADER, *PIMAGE_SECTION_HEADER;
+
+typedef struct _IMAGE_IMPORT_DESCRIPTOR
+{
+    union {
+        DWORD Characteristics;
+        DWORD OriginalFirstThunk;
+    } DUMMYUNIONNAME;
+    DWORD TimeDateStamp;
+    DWORD ForwarderChain;
+    DWORD Name;
+    DWORD FirstThunk;
+} IMAGE_IMPORT_DESCRIPTOR, *PIMAGE_IMPORT_DESCRIPTOR;
+
+typedef struct _IMAGE_EXPORT_DIRECTORY
+{
+    DWORD Characteristics;
+    DWORD TimeDateStamp;
+    WORD MajorVersion;
+    WORD MinorVersion;
+    DWORD Name;
+    DWORD Base;
+    DWORD NumberOfFunctions;
+    DWORD NumberOfNames;
+    DWORD AddressOfFunctions;
+    DWORD AddressOfNames;
+    DWORD AddressOfNameOrdinals;
+} IMAGE_EXPORT_DIRECTORY, *PIMAGE_EXPORT_DIRECTORY;
+
+typedef struct _IMAGE_TLS_DIRECTORY32
+{
+    DWORD StartAddressOfRawData;
+    DWORD EndAddressOfRawData;
+    DWORD AddressOfIndex;
+    DWORD AddressOfCallBacks;
+    DWORD SizeOfZeroFill;
+    union {
+        DWORD Characteristics;
+        struct {
+            DWORD Reserved0 : 20;
+            DWORD Alignment : 4;
+            DWORD Reserved1 : 8;
+        };
+    };
+} IMAGE_TLS_DIRECTORY_32, *PIMAGE_TLS_DIRECTORY_32;
+
 #endif

--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -15,6 +15,7 @@ typedef int INT, *PINT, *LPINT;
 typedef long LONG, *PLONG, *LPLONG;
 typedef long long LONGLONG, *PLONGLONG;
 
+typedef unsigned char BYTE;
 typedef unsigned char UCHAR, *PUCHAR;
 typedef unsigned short USHORT, *PUSHORT, CSHORT;
 typedef unsigned short WORD, WCHAR, *PWSTR;

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -68,7 +68,6 @@ typedef LONG KPRIORITY;
 typedef ULONG DEVICE_TYPE;
 typedef ULONG LOGICAL;
 
-typedef unsigned char BYTE;
 typedef const char *PCSZ, *PCSTR, *LPCSTR;
 typedef char *PSZ, *PSTR;
 typedef CONST WCHAR *LPCWSTR, *PCWSTR;


### PR DESCRIPTION
This grew a bit larger than anticipated. It implements the ability to look up functions marked with `__declspec(dllexport)` by calling `GetProcAddress` with NULL as the handle. JFR and I briefly talked about this in #335, but we wrongfully assumed that this would look up the exports of the module calling `GetProcAddress`, while it actually looks up the exports of the main module, i.e. the currently running xbe in this case. I have confirmed that this is the correct behavior by testing on Windows 7 with VS 2017.

8df5cb2 is required to be able to do this at all. To look up exports, we need the `IMAGE_EXPORT_DIRECTORY` header. This header is referenced in the PE optional header, but the xbe format does not have such a reference. The struct gets its own section called `.edata`, but modern versions of MSVC and lld merge this section into `.rdata` by default. This commit overrides this behavior by adding a merge rule that merges `.edata` into a new section called `.edataxb`, so we can look up that section name during runtime and gain access to `IMAGE_EXPORT_DIRECTORY` this way. Unfortunately, this currently makes lld emit a warning - this is a quirk of lld, overriding the default behavior should not result in a warning, nor does it on MS's linker.

1905ebf is there to make dealing with XBE headers during runtime at least somewhat sane. The structs are loosely based on caustik's spec, but I tried to name the fields similar to their PE counterparts, with one notable exception being `SizeOfStack` - caustik's spec names this field `PE Stack Commit` and claims it can be directly copied from the similarly named PE field, which is incorrect (see #86). I'm not fully sure `winnt.h` is the best place for these structs, as they're not usually found there, but the PE headers are there, too, and the XBE headers reuse some of their structs.

A simple demo that show what this can do now can be found here: https://gist.github.com/thrimbor/8d48c81dd2ba6585c6e4f3a98f567e15