### PR TITLE
samples: Change titles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ $(OUTPUT_DIR):
 ifneq ($(GEN_XISO),)
 $(GEN_XISO): $(OUTPUT_DIR)/default.xbe $(EXTRACT_XISO)
 	@echo "[ XISO     ] $@"
-	$(VE) $(EXTRACT_XISO) -c $(OUTPUT_DIR) $(XISO_FLAGS) $@ $(QUIET)
+	$(VE) $(EXTRACT_XISO) -c $(OUTPUT_DIR) $(XISO_FLAGS) "$@" $(QUIET)
 endif
 
 $(SRCS): $(SHADER_OBJS)

--- a/samples/gamma-fade/Makefile
+++ b/samples/gamma-fade/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = gamma-fade
+XBE_TITLE = nxdk\ sample\ -\ gamma-fade
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/gamma/Makefile
+++ b/samples/gamma/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = gamma
+XBE_TITLE = nxdk\ sample\ -\ gamma
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/hello++/Makefile
+++ b/samples/hello++/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = hello++
+XBE_TITLE = nxdk\ sample\ -\ hello++
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.cpp
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/hello/Makefile
+++ b/samples/hello/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = hello
+XBE_TITLE = nxdk\ sample\ -\ hello
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/httpd/Makefile
+++ b/samples/httpd/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = httpd
+XBE_TITLE = nxdk\ sample\ -\ httpd
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c $(CURDIR)/httpserver.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/httpd_bsd/Makefile
+++ b/samples/httpd_bsd/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = httpd_bsd
+XBE_TITLE = nxdk\ sample\ -\ httpd_bsd
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c $(CURDIR)/httpserver.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/led/Makefile
+++ b/samples/led/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = led
+XBE_TITLE = nxdk\ sample\ -\ led
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/mesh/Makefile
+++ b/samples/mesh/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = mesh
+XBE_TITLE = nxdk\ sample\ -\ mesh
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/math3d.c $(CURDIR)/main.c
 SHADER_OBJS = ps.inl vs.inl

--- a/samples/sdl/Makefile
+++ b/samples/sdl/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = sdl
+XBE_TITLE = nxdk\ sample\ -\ SDL2
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/sdl_gamecontroller/Makefile
+++ b/samples/sdl_gamecontroller/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = sdl_gamecontroller
+XBE_TITLE = nxdk\ sample\ -\ SDL2_GameController
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/sdl_image/Makefile
+++ b/samples/sdl_image/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = sdl_image
+XBE_TITLE = nxdk\ sample\ -\ SDL2_image
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/sdl_ttf/Makefile
+++ b/samples/sdl_ttf/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = sdl_ttf
+XBE_TITLE = nxdk\ sample\ -\ SDL2_ttf
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/triangle/Makefile
+++ b/samples/triangle/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = triangle
+XBE_TITLE = nxdk\ sample\ -\ triangle
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 SHADER_OBJS = ps.inl vs.inl

--- a/samples/winapi_drivelist/Makefile
+++ b/samples/winapi_drivelist/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = winapi_drivelist
+XBE_TITLE = nxdk\ sample\ -\ winapi_drivelist
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/winapi_filefind/Makefile
+++ b/samples/winapi_filefind/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = winapi_filefind
+XBE_TITLE = nxdk\ sample\ -\ winapi_filefind
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..

--- a/samples/xaudio/Makefile
+++ b/samples/xaudio/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE = xaudio
+XBE_TITLE = nxdk\ sample\ -\ xaudio
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..


### PR DESCRIPTION
On a side note, as I mentioned in the related issue, XBE_TITLE requires just quotation marks to use spaces and special characters, but GEN_XISO requires quotation marks *and* the \ escape character, thus I wasn't able to make GEN_XISO use the XBE_TITLE. Theoretically, it should have been possible to use \ in XBE_TITLE, but, when used, a simple hex view of the xbe shows that \ is also written to the XBE's title, and doesn't actually escape anything.

The samples have also been tested to load and run fine with this fix, so it should cause no issues.

If anyone has a way to fix this or a better way to do the naming, I'll gladly accept it.

Closes #372. 