### PR TITLE
ci: Explicitly install llvm package to get llvm-lib

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -71,7 +71,7 @@ jobs:
           submodules: recursive
       - name: Install Dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y flex bison clang lld
+          sudo apt-get update -y && sudo apt-get install -y flex bison clang llvm lld
       - name: Build
         run: |
           export PATH=$PATH:/usr/lib/llvm-6.0/bin


### PR DESCRIPTION
GitHub is currently rolling out a change that makes ubuntu-latest equivalent to ubuntu-20.04 instead of 18.04. On Ubuntu 20.04, the llvm package doesn't seem to be installed out of the box, so for users already affected by the change, Ubuntu CI currently fails.

This commit fixes that by explicitly installing llvm.