### PR TITLE
winapi: Implement more interlocked functions

### DIFF
--- a/lib/winapi/Makefile
+++ b/lib/winapi/Makefile
@@ -17,7 +17,8 @@ WINAPI_SRCS := \
 	$(NXDK_DIR)/lib/winapi/sync.c \
 	$(NXDK_DIR)/lib/winapi/sysinfo.c \
 	$(NXDK_DIR)/lib/winapi/thread.c \
-	$(NXDK_DIR)/lib/winapi/tls.c
+	$(NXDK_DIR)/lib/winapi/tls.c \
+	$(NXDK_DIR)/lib/winapi/winnt.c
 
 WINAPI_OBJS = $(addsuffix .obj, $(basename $(WINAPI_SRCS)))
 

--- a/lib/winapi/winnt.c
+++ b/lib/winapi/winnt.c
@@ -1,0 +1,29 @@
+#include <winnt.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+LONG64 InterlockedExchange64 (LONG64 volatile *Target, LONG64 Value)
+{
+    // There's no xchg8b in x86, so we implement swapping atomically with cmpxchg8b
+    LARGE_INTEGER old_target_value, new_value;
+    old_target_value.QuadPart = *Target;
+    new_value.QuadPart = Value;
+
+    __asm__ __volatile__("1:\n"
+                         "cmpxchg8b (%2)\n"
+                         "jnz 1b\n" // If the comparison failed, try again with updated edx:eax
+                         : "+a"(old_target_value.LowPart), "+d"(old_target_value.HighPart)
+                         : "r"(Target), "b"(new_value.LowPart), "c"(new_value.HighPart)
+                         : "memory");
+
+    return old_target_value.QuadPart;
+}
+
+PVOID InterlockedExchangePointer (PVOID volatile *Target, PVOID Value)
+{
+    return (PVOID)InterlockedExchange((PLONG)Target, (LONG)Value);
+}
+
+PVOID InterlockedCompareExchangePointer (PVOID volatile *Destination, PVOID Exchange, PVOID Comperand)
+{
+    return (PVOID)InterlockedCompareExchange((PLONG)Destination, (LONG)Exchange, (LONG)Comperand);
+}

--- a/lib/winapi/winnt.h
+++ b/lib/winapi/winnt.h
@@ -7,6 +7,12 @@ typedef LONG HRESULT;
 
 typedef CHAR *LPSTR;
 
+typedef signed __int64 LONG64, *PLONG64;
+
+LONG64 InterlockedExchange64 (LONG64 volatile *Target, LONG64 Value);
+PVOID InterlockedExchangePointer (PVOID volatile *Target, PVOID Value);
+PVOID InterlockedCompareExchangePointer (PVOID volatile *Destination, PVOID Exchange, PVOID Comperand);
+
 #ifdef UNICODE
 typedef LPCWSTR LPCTSTR;
 #else


### PR DESCRIPTION
Implements `InterlockedExchangePointer`, `InterlockedCompareExchangePointer` (both as xboxkrnl wrappers) and `InterlockedExchange64`, all of which are requirements of #321. Sample code for testing the latter is below.

<details>
  <summary>main.c</summary>

  ```c
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    LONG64 target = 0xDEADBEEFBEEFC0DE;
    LONG64 value =  0x0123456789123456;
    LONG64 result = InterlockedExchange64(&target, value);

    debugPrint("target: 0x%08X%08X\n", ((int)(target >> 32)), ((int)(target & 0xFFFFFFFF)));
    debugPrint("result: 0x%08X%08X\n", ((int)(result >> 32)), ((int)(result & 0xFFFFFFFF)));
    debugPrint("value: 0x%08X%08X\n", ((int)(value >> 32)), ((int)(value & 0xFFFFFFFF)));

    // Expected output:
    // target: 0x0123456789123456
    // result: 0xDEADBEEFBEEFC0DE
    // value: 0x0123456789123456


    while(1) {
        Sleep(2000);
    }

    return 0;
}

  ```
  
</details>