### PR TITLE
samples: Fix style consistency in Makefile of winapi_filefind

### DIFF
--- a/samples/winapi_filefind/Makefile
+++ b/samples/winapi_filefind/Makefile
@@ -1,4 +1,4 @@
-XBE_TITLE=winapi_filefind
+XBE_TITLE = winapi_filefind
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 NXDK_DIR = $(CURDIR)/../..


### PR DESCRIPTION
Follow up of PR #371 
This one Makefile got away without being fixed. Whoops! 😬 