### PR TITLE
xboxrt: Throw exception on stack overflow

### DIFF
--- a/lib/xboxrt/c_runtime/check_stack.c
+++ b/lib/xboxrt/c_runtime/check_stack.c
@@ -1,5 +1,6 @@
-#include <debug.h>
-#include "xboxkrnl/xboxkrnl.h"
+#include <errhandlingapi.h>
+#include <hal/debug.h>
+#include <xboxkrnl/xboxkrnl.h>
 
 #ifdef DEBUG_CONSOLE
     #define _print DbgPrint
@@ -20,6 +21,7 @@ void _cdecl _xlibc_check_stack (DWORD requested_size, DWORD stack_ptr)
                "stack limit:   0x%x\n"
                "\n",
                stack_ptr, requested_size, (DWORD)current_thread->StackLimit);
-        // TODO: halt execution
+
+        RaiseException(EXCEPTION_STACK_OVERFLOW, EXCEPTION_NONCONTINUABLE, 0, NULL);
     }
 }


### PR DESCRIPTION
Fixes #359.

Previously, we just resumed execution when a stack overflow was detected. In my testing, the subsequent use of the stack would then trigger a stack overflow exception in the kernel and execution would halt, but it's not good to rely on that behavior.

This commit adds an explicit throw of an `EXCEPTION_STACK_OVERFLOW` exception, which will immediately cause the kernel to walk the handler chain in search of a handler for the exception. If no handler is found, execution is halted by the kernel automatically, but a debugger still has a chance to intercept this.