### PR TITLE
debug: Ensure unsigned char when printing hex bytes

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -260,7 +260,7 @@ void debugPrintHex(const char *buffer, int length)
 	char tmp[10];
 	for (int i = 0; i < length; i++)
 	{
-		sprintf(tmp, "%02x ", buffer[i]);
+		sprintf(tmp, "%02x ", buffer[i] & 0xFF);
 		debugPrint(tmp);
 	}
 }


### PR DESCRIPTION
Currently when printing a hex value using `debugPrintHex` with a sign bit, it would print the 32bit two's complement hex version

i.e printing `0x80` would print `0xffffff80`

Before:
![image](https://user-images.githubusercontent.com/21236406/110760250-6e2fc480-829e-11eb-8579-422d1152efd0.png)

After:
![image](https://user-images.githubusercontent.com/21236406/110760257-70921e80-829e-11eb-9ca4-d31758fa128a.png)

 