### PR TITLE
sdl2: Add SDL2_gfx submodule to nxdk/lib/sdl/SDL2_gfx

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -31,3 +31,6 @@
 [submodule "lib/sdl/SDL_image"]
 	path = lib/sdl/SDL2_image
 	url = https://github.com/SDL-mirror/SDL_image.git
+[submodule "lib/sdl/SDL2_gfx"]
+	path = lib/sdl/SDL2_gfx
+	url = https://github.com/Teufelchen1/libSDL_gfx.git

--- a/lib/sdl/Makefile
+++ b/lib/sdl/Makefile
@@ -74,3 +74,30 @@ CLEANRULES += clean-libsdlimage
 .PHONY: clean-libsdlimage
 clean-libsdlimage:
 	$(VE)rm -f $(LIBSDLIMAGE_OBJS) $(NXDK_DIR)/lib/libSDL2_image.lib
+
+SDL_GFX_DIR = $(NXDK_DIR)/lib/sdl/SDL2_gfx
+SDL_GFX_SRCS += $(SDL_GFX_DIR)/SDL2_framerate.c \
+                $(SDL_GFX_DIR)/SDL2_gfxPrimitives.c \
+                $(SDL_GFX_DIR)/SDL2_imageFilter.c \
+                $(SDL_GFX_DIR)/SDL2_rotozoom.c
+
+SDL_GFX_OBJS = $(addsuffix .obj, $(basename $(SDL_GFX_SRCS)))
+
+$(NXDK_DIR)/lib/libSDL_gfx.lib: $(SDL_GFX_OBJS)
+
+NXDK_CFLAGS += -I$(NXDK_DIR)/lib/sdl \
+               -I$(SDL_GFX_DIR) \
+               -DXBOX
+
+NXDK_CXXFLAGS += -I$(NXDK_DIR)/lib/sdl \
+                 -I$(SDL_GFX_DIR) \
+                 -DXBOX
+
+main.exe: $(NXDK_DIR)/lib/libSDL_gfx.lib
+
+CLEANRULES += clean-sdl_gfx
+
+.PHONY: clean-sdl_gfx
+clean-sdl_gfx:
+	$(VE)rm -f $(SDL_gfx_OBJS) \
+             $(NXDK_DIR)/lib/libSDL_gfx.lib


### PR DESCRIPTION
Hi 🙋‍♀️ 

This PR aims to add the [SDL2_gfx library](https://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/) to nxdk. There is no up to date git repo of it, so I created my own instead as advised by Thrimbor.
I never added a submodule before, so I would like to get some feedback. Additionally, I'm not sure if the mirror should stay in my GitHub profile, but could be moved to XboxDev instead. But thats up for debate. 
Thanks for your patience.