### PR TITLE
libc: Add Win32 byteswapping functions

### DIFF
--- a/lib/xboxrt/libc_extensions/stdlib_ext_.c
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.c
@@ -66,6 +66,21 @@ int rand_s (unsigned int *randomValue)
     return 0;
 }
 
+unsigned short _byteswap_ushort (unsigned short val)
+{
+    return __builtin_bswap16(val);
+}
+
+unsigned long _byteswap_ulong (unsigned long val)
+{
+    return __builtin_bswap32(val);
+}
+
+unsigned __int64 _byteswap_uint64 (unsigned __int64 val)
+{
+    return __builtin_bswap64(val);
+}
+
 
 double strtod( const char * _PDCLIB_restrict nptr, char * * _PDCLIB_restrict endptr )
 {

--- a/lib/xboxrt/libc_extensions/stdlib_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.h
@@ -12,6 +12,11 @@ extern "C" {
 int rand_s (unsigned int *randomValue);
 #endif
 
+// Win32 extension for reversing byte order
+unsigned short _byteswap_ushort (unsigned short val);
+unsigned long _byteswap_ulong (unsigned long val);
+unsigned __int64 _byteswap_uint64 (unsigned __int64 val);
+
 typedef void (__cdecl *_purecall_handler)(void);
 
 _purecall_handler __cdecl _get_purecall_handler (void);


### PR DESCRIPTION
This implements `_byteswap_ushort`, `_byteswap_ulong` and `_byteswap_uint64`, as they're required by zstd. #418 also implemented them, but this PR implements them as normal functions, which is the way MS does it in their crt.

Also, as laid out in the Discord, I plan to create a new repo for library ports, and put zstd there instead.