### PR TITLE
build: Remove NXDK_STACKSIZE variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,6 @@ ifeq ($(OUTPUT_DIR),)
 OUTPUT_DIR = bin
 endif
 
-ifeq ($(NXDK_STACKSIZE),)
-NXDK_STACKSIZE = 65536
-endif
-
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 
@@ -68,7 +64,7 @@ NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions
 NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 -entry:XboxCRTEntry \
-               -stack:$(NXDK_STACKSIZE) -safeseh:no -include:__fltused -include:__xlibc_check_stack -merge:.edata=.edataxb
+               -stack:65536 -safeseh:no -include:__fltused -include:__xlibc_check_stack -merge:.edata=.edataxb
 
 ifeq ($(DEBUG),y)
 NXDK_ASFLAGS += -g -gdwarf-4


### PR DESCRIPTION
This removes the `NXDK_STACKSIZE` variable in the Makefile. Overriding the nxdk default stack size is still possible by simply appending another `-stack:` parameter to the linker flags.