### PR TITLE
winapi: Use XBE header struct when getting default stack size for thread

### DIFF
--- a/lib/winapi/thread.c
+++ b/lib/winapi/thread.c
@@ -61,9 +61,7 @@ HANDLE CreateThread (LPSECURITY_ATTRIBUTES lpThreadAttributes, SIZE_T dwStackSiz
     HANDLE handle;
 
     if (dwStackSize == 0) {
-        // FIXME: We're directly reading the XBE StackCommit field here.
-        //        A cleaner way with proper structs would be nice.
-        dwStackSize = *((SIZE_T *)0x00010130);
+        dwStackSize = CURRENT_XBE_HEADER->SizeOfStack;
     }
 
     ULONG tlssize;


### PR DESCRIPTION
This is a small and simple change - `CreateThread` so far directly used a memory address to get the stack size field from the XBE header, but since we now have proper structs and the `CURRENT_XBE_HEADER` macro to provide safer access, we can use that instead.