### PR TITLE
build: Remove -Wno-ignored-attributes clang parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -I$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
                -I$(NXDK_DIR)/lib/winapi \
                -I$(NXDK_DIR)/lib/xboxrt/vcruntime \
-               -Wno-ignored-attributes -DNXDK -D__STDC__=1
+               -DNXDK -D__STDC__=1
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions


### PR DESCRIPTION
This removes the `-Wno-ignored-attributes` parameter from `NXDK_CFLAGS`. It doesn't appear to produce any difference when building nxdk code, not even when also using `-Wall -pedantic`.