### PR TITLE
vcruntime: Implement stack smashing detection

### DIFF
--- a/lib/xboxrt/Makefile
+++ b/lib/xboxrt/Makefile
@@ -19,6 +19,7 @@ XBOXRT_SRCS := \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/check_stack.c \
 	$(NXDK_DIR)/lib/xboxrt/c_runtime/chkstk.s \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/purecall.c \
+	$(NXDK_DIR)/lib/xboxrt/vcruntime/stack_protection.c \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/threadsafe_statics.c \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_exception.cpp \
 	$(NXDK_DIR)/lib/xboxrt/vcruntime/vcruntime_typeinfo.cpp \

--- a/lib/xboxrt/vcruntime/stack_protection.c
+++ b/lib/xboxrt/vcruntime/stack_protection.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#define _CRT_RAND_S
+#include <stdlib.h>
+#include <windows.h>
+#include <hal/xbox.h>
+
+#define DEFAULT_SECURITY_COOKIE 0x0BADC0DE
+
+// The stack canary value. A default value is provided, but for proper security a call to __security_init_cookie() is mandatory
+UINT_PTR __security_cookie  = DEFAULT_SECURITY_COOKIE;
+
+void __attribute__((no_stack_protector)) __cdecl __security_init_cookie (void)
+{
+    if (__security_cookie != DEFAULT_SECURITY_COOKIE) {
+        return;
+    }
+
+    UINT_PTR tmpcookie;
+    rand_s(&tmpcookie);
+    if (tmpcookie == DEFAULT_SECURITY_COOKIE) {
+        tmpcookie++;
+    }
+    __security_cookie = tmpcookie;
+}
+
+void __attribute__((no_stack_protector)) __fastcall __security_check_cookie (UINT_PTR cookie)
+{
+    assert (cookie == __security_cookie);
+
+    if (cookie == __security_cookie) {
+        return;
+    }
+
+    DbgPrint("STACK SMASHING DETECTED\ncookie: %x\nexpected: %x", cookie, __security_cookie);
+    XReboot();
+}


### PR DESCRIPTION
This implements stack smashing detection support. When stack protection is enabled, this will catch attempts to overwrite the return address on the stack by overflowing stack buffers.
At the moment, a static default value is used as the canary value, but a call to `__security_init_cookie()` will be added to PDCLib soon.

To test, add the `-fstack-protector-all` clang parameter and try the following code:
```c
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>

void tfunc ()
{
    char buf[3];
    memcpy(buf, "abcdefghiuaoiegboegboub", 16); // Buffer overflow
}

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    while(1) {
        debugPrint("Hello nxdk!\n");
        tfunc();
        Sleep(2000);
    }

    return 0;
}
```