### PR TITLE
pdclib: Update submodule to 54341cc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,8 @@ NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
 NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions
-NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 -entry:XboxCRTEntry \
-               -stack:65536 -safeseh:no -include:__fltused -include:__xlibc_check_stack -merge:.edata=.edataxb
+NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 \
+               -stack:65536 -safeseh:no -merge:.edata=.edataxb
 
 ifeq ($(DEBUG),y)
 NXDK_ASFLAGS += -g -gdwarf-4

--- a/lib/winapi/thread.c
+++ b/lib/winapi/thread.c
@@ -5,8 +5,9 @@
 #include <process.h>
 #include <fibersapi_internal_.h>
 #include <winbase.h>
-#include <pdclib/_PDCLIB_xbox_tls.h>
 #include <xboxkrnl/xboxkrnl.h>
+
+extern const IMAGE_TLS_DIRECTORY_32 _tls_used;
 
 uintptr_t __cdecl _beginthreadex (void *_Security, unsigned _StackSize, _beginthreadex_proc_type _StartAddress, void *_ArgList, unsigned _InitFlag, unsigned *_ThrdAddr)
 {


### PR DESCRIPTION
This updates the submodule to include the latest changes to PDCLib, such as using the `IMAGE_TLS_DIRECTORY_32` struct from winapi, the added workaround for LTO symbol issues, the SafeSEH fix for `_tls_array.s`, the renamed entry point and the initialization of the stack protection cookie on startup.