### PR TITLE
xboxrt: Make assembly files SafeSEH-compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions
 NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 \
-               -stack:65536 -safeseh:no -merge:.edata=.edataxb
+               -stack:65536 -merge:.edata=.edataxb
 
 ifeq ($(DEBUG),y)
 NXDK_ASFLAGS += -g -gdwarf-4

--- a/lib/xboxrt/c_runtime/_alldiv.s
+++ b/lib/xboxrt/c_runtime/_alldiv.s
@@ -16,6 +16,9 @@
 
 // Modified for stdcall calling convention for use in nxdk
 
+.include "prelude.s.inc"
+safeseh_prelude
+
 .text
 .balign 4
 .globl __alldiv

--- a/lib/xboxrt/c_runtime/_allmul.s
+++ b/lib/xboxrt/c_runtime/_allmul.s
@@ -5,6 +5,9 @@
 
 // Modified for stdcall calling convention for use in nxdk
 
+.include "prelude.s.inc"
+safeseh_prelude
+
 .text
 .balign 4
 .globl __allmul

--- a/lib/xboxrt/c_runtime/_allrem.s
+++ b/lib/xboxrt/c_runtime/_allrem.s
@@ -17,6 +17,9 @@
 
 // Modified for stdcall calling convention for use in nxdk
 
+.include "prelude.s.inc"
+safeseh_prelude
+
 .text
 .balign 4
 .globl __allrem

--- a/lib/xboxrt/c_runtime/_allshl.s
+++ b/lib/xboxrt/c_runtime/_allshl.s
@@ -1,3 +1,8 @@
+.include "prelude.s.inc"
+safeseh_prelude
+
+.text
+.balign 4
 .globl __allshl
 __allshl:
     shldl %cl, %eax, %edx

--- a/lib/xboxrt/c_runtime/_allshr.s
+++ b/lib/xboxrt/c_runtime/_allshr.s
@@ -1,3 +1,8 @@
+.include "prelude.s.inc"
+safeseh_prelude
+
+.text
+.balign 4
 .globl __allshr
 __allshr:
     shrdl %cl, %edx, %eax

--- a/lib/xboxrt/c_runtime/_aulldiv.s
+++ b/lib/xboxrt/c_runtime/_aulldiv.s
@@ -16,6 +16,9 @@
 
 // Modified for stdcall calling convention for use in nxdk
 
+.include "prelude.s.inc"
+safeseh_prelude
+
 .text
 .balign 4
 .globl __aulldiv

--- a/lib/xboxrt/c_runtime/_aullrem.s
+++ b/lib/xboxrt/c_runtime/_aullrem.s
@@ -17,6 +17,9 @@
 
 // Modified for stdcall calling convention for use in nxdk
 
+.include "prelude.s.inc"
+safeseh_prelude
+
 .text
 .balign 4
 .globl __aullrem

--- a/lib/xboxrt/c_runtime/_aullshl.s
+++ b/lib/xboxrt/c_runtime/_aullshl.s
@@ -1,3 +1,8 @@
+.include "prelude.s.inc"
+safeseh_prelude
+
+.text
+.balign 4
 .globl __aullshl
 __aullshl:
     shldl %cl, %eax, %edx

--- a/lib/xboxrt/c_runtime/_aullshr.s
+++ b/lib/xboxrt/c_runtime/_aullshr.s
@@ -1,3 +1,8 @@
+.include "prelude.s.inc"
+safeseh_prelude
+
+.text
+.balign 4
 .globl __aullshr
 __aullshr:
     shrdl %cl, %edx, %eax

--- a/lib/xboxrt/c_runtime/chkstk.s
+++ b/lib/xboxrt/c_runtime/chkstk.s
@@ -3,7 +3,8 @@
     For details, see: https://creativecommons.org/publicdomain/zero/1.0/
 */
 
-.text
+.include "prelude.s.inc"
+safeseh_prelude
 
 /*
     __chkstk does not comply to any standardized calling convention.
@@ -11,6 +12,7 @@
     accordingly before returning.
     Calling __chkstk has the same effect as "subl %eax, %esp".
 */
+.text
 .globl __chkstk
 __chkstk:
     pushl %ecx

--- a/lib/xboxrt/prelude.s.inc
+++ b/lib/xboxrt/prelude.s.inc
@@ -1,0 +1,11 @@
+// This creates a special symbol with the least significant bit set.
+// It signals to the linker that this code is SafeSEH-compatible.
+.macro safeseh_prelude
+.text
+.def @feat.00;
+.scl  3; // IMAGE_SYM_CLASS_STATIC
+.type 0; // IMAGE_SYM_TYPE_NULL
+.endef
+.globl @feat.00
+.set @feat.00, 1
+.endm


### PR DESCRIPTION
This modifies the assembly files to include the special symbol and value that marks them as SafeSEH compatible. It also removes the linker parameter that was necessary previously.

This does not implement or enable SafeSEH, it only makes the code compatible.