### PR TITLE
samples: Allow overriding NXDK_DIR

### DIFF
--- a/samples/gamma-fade/Makefile
+++ b/samples/gamma-fade/Makefile
@@ -1,5 +1,6 @@
 XBE_TITLE = nxdk\ sample\ -\ gamma-fade
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
+
 include $(NXDK_DIR)/Makefile

--- a/samples/gamma/Makefile
+++ b/samples/gamma/Makefile
@@ -1,5 +1,6 @@
 XBE_TITLE = nxdk\ sample\ -\ gamma
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
+
 include $(NXDK_DIR)/Makefile

--- a/samples/hello++/Makefile
+++ b/samples/hello++/Makefile
@@ -1,6 +1,7 @@
 XBE_TITLE = nxdk\ sample\ -\ hello++
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.cpp
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 NXDK_CXX = y
+
 include $(NXDK_DIR)/Makefile

--- a/samples/hello/Makefile
+++ b/samples/hello/Makefile
@@ -1,5 +1,6 @@
 XBE_TITLE = nxdk\ sample\ -\ hello
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
+
 include $(NXDK_DIR)/Makefile

--- a/samples/httpd/Makefile
+++ b/samples/httpd/Makefile
@@ -1,6 +1,7 @@
 XBE_TITLE = nxdk\ sample\ -\ httpd
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c $(CURDIR)/httpserver.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 NXDK_NET = y
+
 include $(NXDK_DIR)/Makefile

--- a/samples/httpd_bsd/Makefile
+++ b/samples/httpd_bsd/Makefile
@@ -1,6 +1,7 @@
 XBE_TITLE = nxdk\ sample\ -\ httpd_bsd
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c $(CURDIR)/httpserver.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 NXDK_NET = y
+
 include $(NXDK_DIR)/Makefile

--- a/samples/led/Makefile
+++ b/samples/led/Makefile
@@ -1,5 +1,6 @@
 XBE_TITLE = nxdk\ sample\ -\ led
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
+
 include $(NXDK_DIR)/Makefile

--- a/samples/mesh/Makefile
+++ b/samples/mesh/Makefile
@@ -2,6 +2,6 @@ XBE_TITLE = nxdk\ sample\ -\ mesh
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/math3d.c $(CURDIR)/main.c
 SHADER_OBJS = ps.inl vs.inl
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 
 include $(NXDK_DIR)/Makefile

--- a/samples/sdl/Makefile
+++ b/samples/sdl/Makefile
@@ -1,6 +1,7 @@
 XBE_TITLE = nxdk\ sample\ -\ SDL2
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 NXDK_SDL = y
+
 include $(NXDK_DIR)/Makefile

--- a/samples/sdl_gamecontroller/Makefile
+++ b/samples/sdl_gamecontroller/Makefile
@@ -1,7 +1,7 @@
 XBE_TITLE = nxdk\ sample\ -\ SDL2_GameController
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 NXDK_SDL = y
 
 include $(NXDK_DIR)/Makefile

--- a/samples/sdl_image/Makefile
+++ b/samples/sdl_image/Makefile
@@ -1,8 +1,9 @@
 XBE_TITLE = nxdk\ sample\ -\ SDL2_image
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 NXDK_SDL = y
+
 include $(NXDK_DIR)/Makefile
 
 TARGET += $(OUTPUT_DIR)/testimg.jpg

--- a/samples/sdl_ttf/Makefile
+++ b/samples/sdl_ttf/Makefile
@@ -1,7 +1,7 @@
 XBE_TITLE = nxdk\ sample\ -\ SDL2_ttf
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 NXDK_SDL = y
 
 all_local: cp_font all

--- a/samples/triangle/Makefile
+++ b/samples/triangle/Makefile
@@ -2,5 +2,6 @@ XBE_TITLE = nxdk\ sample\ -\ triangle
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
 SHADER_OBJS = ps.inl vs.inl
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
+
 include $(NXDK_DIR)/Makefile

--- a/samples/winapi_drivelist/Makefile
+++ b/samples/winapi_drivelist/Makefile
@@ -1,5 +1,6 @@
 XBE_TITLE = nxdk\ sample\ -\ winapi_drivelist
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
+
 include $(NXDK_DIR)/Makefile

--- a/samples/winapi_filefind/Makefile
+++ b/samples/winapi_filefind/Makefile
@@ -1,5 +1,6 @@
 XBE_TITLE = nxdk\ sample\ -\ winapi_filefind
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
+
 include $(NXDK_DIR)/Makefile

--- a/samples/xaudio/Makefile
+++ b/samples/xaudio/Makefile
@@ -1,7 +1,7 @@
 XBE_TITLE = nxdk\ sample\ -\ xaudio
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 
 all: nxdk_wav.h
 


### PR DESCRIPTION
This allows overriding the `NXDK_DIR` variable in the samples Makefiles by using the `?=` operator, which only assigns a value if the variable is not defined already. It allows to build the samples with the Docker image and sets a better example.