### PR TITLE
ci: Update existing GitHub workflows

### DIFF
--- a/.ci_build_samples.sh
+++ b/.ci_build_samples.sh
@@ -7,10 +7,9 @@ else
     NUMCORES=$(nproc)
 fi
 
-cd samples
-for dir in */
+for dir in samples/*/
 do
     cd "$dir"
     make -j${NUMCORES}
-    cd ..
+    cd ../..
 done

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -12,9 +12,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
-          fetch-depth: 1
           submodules: recursive
       - name: Generate tags
         id: tags

--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -9,70 +9,67 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
-          fetch-depth: 1
           submodules: recursive
       - name: Build Docker image
-        run: |
-          docker build -t nxdk ./
+        run: docker build -t nxdk ./
       - name: Test Docker image
-        run: |
-          docker run nxdk sh -c "cd /usr/src/nxdk && sh ./.ci_build_samples.sh"
+        run: docker run nxdk sh -ec "cd /usr/src/nxdk && ./.ci_build_samples.sh"
   windows:
     name: Windows
     runs-on: windows-latest
     timeout-minutes: 20
+    env:
+      POWERSHELL_TELEMETRY_OPTOUT: 1
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
-          fetch-depth: 1
           submodules: recursive
       - name: Install MSYS2 & Dependencies
         run: |
           echo "Downloading MSYS2 environment..."
-          Invoke-WebRequest -Uri "https://github.com/XboxDev/nxdk-ci-environment-msys2/releases/latest/download/msys64.7z" -OutFile "msys64.7z"
+          curl -fLO "https://github.com/XboxDev/nxdk-ci-environment-msys2/releases/latest/download/msys64.7z"
           echo "Extracting MSYS2 environment..."
           7z x -y msys64.7z "-oC:\tools\"
           echo "Updating MSYS2 environment..."
-          C:\tools\msys64\usr\bin\bash.exe -lc "pacman -Syu --noconfirm"
+          C:\tools\msys64\usr\bin\bash.exe -elc "pacman -Syu --noconfirm"
       - name: Build
         env:
           MSYS2_ARCH: x86_64
           MSYSTEM: MINGW64
-        run: C:\tools\msys64\usr\bin\bash.exe -lc "cd $(cygpath $env:GITHUB_WORKSPACE) && ./.ci_build_samples.sh"
+        run: C:\tools\msys64\usr\bin\bash.exe -elc "cd $(cygpath $env:GITHUB_WORKSPACE) && ./.ci_build_samples.sh"
   macos:
     name: macOS
     runs-on: macOS-latest
     timeout-minutes: 20
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
-          fetch-depth: 1
           submodules: recursive
       - name: Install Dependencies
+        env:
+          HOMEBREW_NO_ANALYTICS: 1
+          HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          export HOMEBREW_NO_INSTALL_CLEANUP=1
           brew doctor || true
           brew update-reset && brew install llvm
       - name: Build
-        run: sh ./.ci_build_samples.sh
+        run: ./.ci_build_samples.sh
   ubuntu:
     name: Ubuntu
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
         with:
-          fetch-depth: 1
           submodules: recursive
       - name: Install Dependencies
         run: |
-          sudo apt-get update -y && sudo apt-get install -y flex bison clang llvm lld
+          sudo apt-get -y update
+          sudo apt-get -y install llvm lld
       - name: Build
-        run: |
-          export PATH=$PATH:/usr/lib/llvm-6.0/bin
-          sh ./.ci_build_samples.sh
+        run: ./.ci_build_samples.sh


### PR DESCRIPTION
```
.ci_build_samples.sh:
 Use one less cd command.
 chmod +x
Upgrade checkout to v2.
Use -e when invoking shell(s).
Run .ci_build_samples.sh directly.
build_samples.yml:
 Don't use multi-line syntax for one command.
 Windows:
  Opt out of PowerShell telemetry.
  Use curl instead of Invoke-WebRequest.
 macOS:
  Move exported variables to env:.
  Opt out of brew analytics.
 Simplify ci_build_samples commands.
 Ubuntu:
  Remove unneeded packages.
  Remove unneeded PATH addition.
```