### PR TITLE
net: Use own Makefile, build as library

### DIFF
--- a/lib/net/Makefile
+++ b/lib/net/Makefile
@@ -5,20 +5,33 @@ NETIFFILES := $(filter-out $(LWIPDIR)/netif/slipif.c,$(NETIFFILES))
 LWIPSRCS := $(COREFILES) \
             $(CORE4FILES) \
             $(CORE6FILES) \
-            $(NETIFFILES) \
-            $(APIFILES)
+            $(APIFILES) \
+            $(NETIFFILES)
 
 # Include driver sources
 DRIVERSRCS := $(NXDK_DIR)/lib/net/pktdrv/pktdrv.c \
               $(NXDK_DIR)/lib/net/nforceif/src/driver.c \
               $(NXDK_DIR)/lib/net/nforceif/src/sys_arch.c
 
-SRCS += $(LWIPSRCS) $(DRIVERSRCS)
+NET_SRCS := \
+	$(LWIPSRCS) \
+	$(DRIVERSRCS)
 
-# Add includes
-CFLAGS += -I $(LWIPDIR)/include
-CFLAGS += -I $(NXDK_DIR)/lib/net/nforceif/include
-CFLAGS += -I $(NXDK_DIR)/lib/net/pktdrv
-CXXFLAGS += -I $(LWIPDIR)/include
-CXXFLAGS += -I $(NXDK_DIR)/lib/net/nforceif/include
-CXXFLAGS += -I $(NXDK_DIR)/lib/net/pktdrv
+NET_OBJS = $(addsuffix .obj, $(basename $(NET_SRCS)))
+
+NXDK_CFLAGS += -I$(LWIPDIR)/include
+NXDK_CFLAGS += -I$(NXDK_DIR)/lib/net/nforceif/include
+NXDK_CFLAGS += -I$(NXDK_DIR)/lib/net/pktdrv
+NXDK_CXXFLAGS += -I$(LWIPDIR)/include
+NXDK_CXXFLAGS += -I$(NXDK_DIR)/lib/net/nforceif/include
+NXDK_CXXFLAGS += -I$(NXDK_DIR)/lib/net/pktdrv
+
+$(NXDK_DIR)/lib/libnxdk_net.lib: $(NET_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libnxdk_net.lib
+
+CLEANRULES += clean-net
+
+.PHONY: clean-net
+clean-net:
+	$(VE)rm -f $(NET_OBJS) $(NXDK_DIR)/lib/libnxdk_net.lib


### PR DESCRIPTION
Hi 🙋‍♀️ 

This PR addresses #454 by adjusting the `nxdk/lib/net/Makefile` to yield a `nxdk/lib/libnxdk_net.lib`.

I'm unsure about my work:

- I could have moved the inclusion of `nxdk/lib/net/Makefile` from `nxdk/Makefile` to `nxdk/lib/Makefile`
- The include `CFLAGS` for net are in the net-Makefile, I could have moved them into `nxdk/Makefile`(following the other libs examples(hal, pdclib, winapi, etc.). But that feels wrong - so I wonder, why are the other libs included there and not in their own Makefile(i.e. like libpng does)?
- Why does the net-Makefile has extra `CXXFLAGS` while other libraries don't? Can't find the reason 🙈😅
- Why can we do `#include <hal/debug.h>` but do `#include "lwip/debug.h"` in the samples? ("" vs <>) I switched it to <> and it still works. Note: I know the general difference between these two include methods, I just don't understand it in this context(nxdk, complex build systems, libs, etc. etc.).

___

I currently have no methods of running xbes, so I could only test by compiling. 
