### PR TITLE
Make hal includes relative to lib/ folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,6 @@ TOOLS        = cxbe vp20compiler fp20compiler extract-xiso
 NXDK_CFLAGS  = -target i386-pc-win32 -march=pentium3 \
                -ffreestanding -nostdlib -fno-builtin \
                -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt/libc_extensions \
-               -I$(NXDK_DIR)/lib/hal \
                -isystem $(NXDK_DIR)/lib/pdclib/include \
                -I$(NXDK_DIR)/lib/pdclib/platform/xbox/include \
                -I$(NXDK_DIR)/lib/winapi \

--- a/lib/net/nforceif/include/arch/cc.h
+++ b/lib/net/nforceif/include/arch/cc.h
@@ -36,7 +36,7 @@
 
 /* Include some files for defining library routines */
 #include <string.h>
-#include <debug.h>
+#include <hal/debug.h>
 #include <windows.h>
 
 #define printf debugPrint

--- a/samples/httpd/main.c
+++ b/samples/httpd/main.c
@@ -11,7 +11,7 @@
 #include <hal/video.h>
 #include <hal/xbox.h>
 #include <xboxkrnl/xboxkrnl.h>
-#include <debug.h>
+#include <hal/debug.h>
 
 #define USE_DHCP         1
 #define PKT_TMR_INTERVAL 5 /* ms */

--- a/samples/httpd_bsd/httpserver.c
+++ b/samples/httpd_bsd/httpserver.c
@@ -10,7 +10,7 @@
 #include <string.h>
 #include <hal/xbox.h>
 #include <xboxkrnl/xboxkrnl.h>
-#include <debug.h>
+#include <hal/debug.h>
 
 #if LWIP_SOCKET
 

--- a/samples/httpd_bsd/main.c
+++ b/samples/httpd_bsd/main.c
@@ -11,7 +11,7 @@
 #include <hal/input.h>
 #include <hal/xbox.h>
 #include <xboxkrnl/xboxkrnl.h>
-#include <debug.h>
+#include <hal/debug.h>
 
 #define USE_DHCP         1
 #define PKT_TMR_INTERVAL 5 /* ms */


### PR DESCRIPTION
Apart from the inconsistencies around the code base this has caught me out a few times.

If a user applications has a header file that shares the same name as the hal libs and is in a directory included by `-I` it will include the nxdk's header instead of the application. This is quite common as the hal libs use really common basic filenames.

i.e, if the user application has:
```
inc/debug.h
inc/input.h
```
instances of `#include <debug.h>` or `#include <input.h>` in the user application will include nxdk's headers instead of the users potentially causing some not immediately obvious errors. Using `"` or `< >` makes no difference in this instance.

This was mentioned here:
https://github.com/XboxDev/nxdk/pull/457#discussion_r615170326

This PR makes it so all nxdk hal includes must have <hal/xxxx.h> prefix. This should make the above occurances very rare.
