### PR TITLE
winapi: Don't rename .edata section to .edataxb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ NXDK_ASFLAGS = -target i386-pc-win32 -march=pentium3 \
                -nostdlib -I$(NXDK_DIR)/lib -I$(NXDK_DIR)/lib/xboxrt
 NXDK_CXXFLAGS = -I$(NXDK_DIR)/lib/libcxx/include $(NXDK_CFLAGS) -fno-exceptions
 NXDK_LDFLAGS = -subsystem:windows -fixed -base:0x00010000 \
-               -stack:65536 -merge:.edata=.edataxb
+               -stack:65536 -merge:.edata=.edata
 
 ifeq ($(DEBUG),y)
 NXDK_ASFLAGS += -g -gdwarf-4

--- a/lib/winapi/libloaderapi.c
+++ b/lib/winapi/libloaderapi.c
@@ -31,13 +31,13 @@ BOOL FreeLibrary (HMODULE hLibModule)
     return TRUE;
 }
 
-static PIMAGE_EXPORT_DIRECTORY find_edataxb (void)
+static PIMAGE_EXPORT_DIRECTORY find_edata (void)
 {
     DWORD num_sections = CURRENT_XBE_HEADER->NumberOfSections;
     PXBE_SECTION_HEADER section_header_addr = CURRENT_XBE_HEADER->PointerToSectionTable;
 
     for (DWORD i = 0; i < num_sections; i++) {
-        if (memcmp(section_header_addr[i].SectionName, ".edataxb", 8) == 0) {
+        if (strcmp(section_header_addr[i].SectionName, ".edata") == 0) {
             return (PIMAGE_EXPORT_DIRECTORY)section_header_addr[i].VirtualAddress;
         }
     }
@@ -50,7 +50,7 @@ FARPROC GetProcAddress (HMODULE hModule, LPCSTR lpProcName)
     if (hModule == NULL) {
         // When no dll handle is given, the symbol gets looked up in the main module
 
-        PIMAGE_EXPORT_DIRECTORY exportdir = find_edataxb();
+        PIMAGE_EXPORT_DIRECTORY exportdir = find_edata();
         if (!exportdir) {
             SetLastError(ERROR_PROC_NOT_FOUND);
             return NULL;


### PR DESCRIPTION
This lets the `.edata` section, which stores the export directory, keep its original name, instead of getting renamed to `.edataxb`.

Also see #419.