### PR TITLE
Fix strict prototype warnings

### DIFF
--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -115,7 +115,7 @@ static BOOLEAN __stdcall ISR(PKINTERRUPT Interrupt, PVOID ServiceContext)
 }
 
 
-void XDumpAudioStatus()
+void XDumpAudioStatus(void)
 {
 	volatile AC97_DEVICE *pac97device = &ac97Device;
 	if (pac97device)
@@ -196,7 +196,7 @@ void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, 
 	pac97device->mmio[0x170>>2] = MmGetPhysicalAddress((void *)spdifAddress);
 
 	// default to being silent...
-	XAudioPause(pac97device);
+	XAudioPause();
 
 	// reset buffer status
 	analogBufferCount = 0;
@@ -221,7 +221,7 @@ void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, 
 }
 
 // tell the chip it is OK to play...
-void XAudioPlay()
+void XAudioPlay(void)
 {
 	AC97_DEVICE *pac97device = &ac97Device;
 	volatile unsigned char *pb = (unsigned char *)pac97device->mmio;
@@ -230,7 +230,7 @@ void XAudioPlay()
 }
 
 // tell the chip it is paused.
-void XAudioPause()
+void XAudioPause(void)
 {
 	AC97_DEVICE *pac97device = &ac97Device;
 	volatile unsigned char *pb = (unsigned char *)pac97device->mmio;

--- a/lib/hal/audio.h
+++ b/lib/hal/audio.h
@@ -35,8 +35,8 @@ typedef struct
 // are provided to cope with future enhancements. Currently supported samples
 // are 16 bit, 2 channels (stereo)
 void XAudioInit(int sampleSizeInBits, int numChannels, XAudioCallback callback, void *data);
-void XAudioPlay();
-void XAudioPause();
+void XAudioPlay(void);
+void XAudioPause(void);
 void XAudioProvideSamples(unsigned char *buffer, unsigned short bufferLength, int isFinal);
 
 #ifdef __cplusplus

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -74,9 +74,9 @@ If a value of 0 is provided for the bpp a default value of 32bpp is used.
 */
 BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p);
 
-void XVideoWaitForVBlank();
-unsigned char* XVideoGetVideoBase();
-int XVideoVideoMemorySize();
+void XVideoWaitForVBlank(void);
+unsigned char* XVideoGetVideoBase(void);
+int XVideoVideoMemorySize(void);
 
 #ifdef __cplusplus
 }

--- a/lib/hal/xbox.h
+++ b/lib/hal/xbox.h
@@ -7,7 +7,7 @@ extern "C"
 {
 #endif
 
-void XReboot();
+void XReboot(void);
 
 void XLaunchXBE(char *xbePath);
 

--- a/lib/winapi/processthreadsapi.h
+++ b/lib/winapi/processthreadsapi.h
@@ -21,7 +21,7 @@ BOOL SwitchToThread (VOID);
 
 BOOL SetThreadPriority (HANDLE hThread, int nPriority);
 
-DWORD TlsAlloc ();
+DWORD TlsAlloc (void);
 BOOL TlsFree (DWORD dwTlsIndex);
 LPVOID TlsGetValue (DWORD dwTlsIndex);
 BOOL TlsSetValue (DWORD dwTlsIndex, LPVOID lpTlsValue);

--- a/lib/winapi/windef.h
+++ b/lib/winapi/windef.h
@@ -15,6 +15,6 @@ typedef HANDLE HWND;
 typedef HANDLE HINSTANCE;
 typedef HINSTANCE HMODULE;
 
-typedef int (FAR WINAPI *FARPROC)();
+typedef int (FAR WINAPI *FARPROC)(void);
 
 #endif

--- a/lib/winapi/winmm/timeapi.h
+++ b/lib/winapi/winmm/timeapi.h
@@ -14,7 +14,7 @@ extern "C"
 
 MMRESULT timeBeginPeriod (UINT uPeriod);
 MMRESULT timeEndPeriod (UINT uPeriod);
-DWORD timeGetTime ();
+DWORD timeGetTime (void);
 
 #ifdef __cplusplus
 }

--- a/lib/xboxrt/vcruntime/purecall.c
+++ b/lib/xboxrt/vcruntime/purecall.c
@@ -11,7 +11,7 @@
 
 _purecall_handler current_purecall_handler = NULL;
 
-int __cdecl _purecall ()
+int __cdecl _purecall (void)
 {
     if (current_purecall_handler) {
         current_purecall_handler();


### PR DESCRIPTION
Fixes #468.

Fixes a bunch of C function declarations/definitions that were using the old syntax `()`, but should've used `(void)` instead. The only part of code in the nxdk repo that now triggers a `-Wstrict-prototypes` warning is the (old) USB stack.

Also fixes a call where `XAudioPause` was incorrectly called with a parameter.