### PR TITLE
pktdrv: Silence network init

### DIFF
--- a/lib/net/pktdrv/pktdrv.c
+++ b/lib/net/pktdrv/pktdrv.c
@@ -34,8 +34,6 @@
 
 #include "pktdrv.h"
 
-#define DISPLAYMSG
-
 //Defines number of Rx & Tx descriptors, and number of buffers -ring- for received pkts
 #define NBBUFF	32
 


### PR DESCRIPTION
Having link speed and EEPROM MAC address debugPrint'ed on startup is not always desirable.

Setting `NXDK_NET_SILENT` to `y` in your Makefile removes this clutter.