### PR TITLE
Docker improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ tools/cg/mac
 tools/cg/win
 lib/sdl/SDL2/test
 lib/libcxx/test
+samples/

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -25,6 +25,9 @@ jobs:
         uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Generate timestamp
+        id: timestamp
+        run: echo ::set-output name=timestamp::$(date --rfc-3339=seconds --utc)
       - name: Generate tags
         id: tags
         run: |
@@ -56,3 +59,6 @@ jobs:
           platforms: linux/amd64,linux/386
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.timestamp.outputs.timestamp }}

--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -10,6 +10,16 @@ jobs:
     if: github.repository_owner == 'XboxDev'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        image-name: [nxdk, nxdk-debug, nxdk-lto]
+        include:
+          - image-name: nxdk
+            build-args: buildparams=CFLAGS=-O2 CXXFLAGS=-O2
+          - image-name: nxdk-debug
+            build-args: buildparams=DEBUG=y
+          - image-name: nxdk-lto
+            build-args: buildparams=LTO=y CFLAGS=-O2 CXXFLAGS=-O2
     steps:
       - name: Clone Tree
         uses: actions/checkout@v2
@@ -18,7 +28,7 @@ jobs:
       - name: Generate tags
         id: tags
         run: |
-          DOCKER_IMAGE=xboxdev/nxdk
+          DOCKER_IMAGE=xboxdev/${{ matrix.image-name }}
           TAGS="${DOCKER_IMAGE}:latest"
           TAGS="$TAGS,${DOCKER_IMAGE}:git-${GITHUB_SHA::8}"
           TAGS="$TAGS,ghcr.io/${DOCKER_IMAGE}:latest"
@@ -42,6 +52,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: ${{ matrix.build-args }}
           platforms: linux/amd64,linux/386
           push: true
           tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -7,20 +7,31 @@ jobs:
     name: Docker
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    strategy:
+      matrix:
+        image-name: [nxdk, nxdk-debug, nxdk-lto]
+        include:
+          - image-name: nxdk
+            build-args: buildparams=CFLAGS=-O2 CXXFLAGS=-O2
+          - image-name: nxdk-debug
+            build-args: buildparams=DEBUG=y
+          - image-name: nxdk-lto
+            build-args: buildparams=LTO=y CFLAGS=-O2 CXXFLAGS=-O2
     steps:
       - name: Clone Tree
         uses: actions/checkout@v2
         with:
           submodules: recursive
       - name: Build Docker image
-        run: docker build -t nxdk ./
+        run: |
+          docker build --build-arg buildparams="${{ matrix.build-args }}" -t ${{ matrix.image-name }} ./
       - name: Test Docker image
         run: |
           cd samples
           for dir in */
           do
             cd "$dir"
-            docker run --rm -v `pwd`:/usr/src/app -t nxdk make -j`nproc`
+            docker run --rm -v `pwd`:/usr/src/app -t ${{ matrix.image-name }} make -j`nproc`
             cd ..
           done
   windows:

--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -15,7 +15,14 @@ jobs:
       - name: Build Docker image
         run: docker build -t nxdk ./
       - name: Test Docker image
-        run: docker run nxdk sh -ec "cd /usr/src/nxdk && ./.ci_build_samples.sh"
+        run: |
+          cd samples
+          for dir in */
+          do
+            cd "$dir"
+            docker run --rm -v `pwd`:/usr/src/app -t nxdk make -j`nproc`
+            cd ..
+          done
   windows:
     name: Windows
     runs-on: windows-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM ghcr.io/xboxdev/nxdk-buildbase:git-2c3115b1 AS builder
 COPY ./ /usr/src/nxdk/
 ENV NXDK_DIR=/usr/src/nxdk
 RUN cd /usr/src/nxdk && make tools -j`nproc`
-RUN cd /usr/src/nxdk && make NXDK_ONLY=y -j`nproc`
+ARG buildparams
+RUN cd /usr/src/nxdk && make NXDK_ONLY=y $buildparams -j`nproc`
 
 
 FROM ghcr.io/xboxdev/nxdk-runbase:git-2c3115b1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,9 @@ COPY --from=builder /usr/src/nxdk/ /usr/src/nxdk/
 ENV NXDK_DIR=/usr/src/nxdk
 
 WORKDIR /usr/src/app
+
+LABEL org.opencontainers.image.documentation='https://github.com/XboxDev/nxdk/wiki'
+LABEL org.opencontainers.image.licenses='(Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT)'
+LABEL org.opencontainers.image.source='https://github.com/XboxDev/nxdk.git'
+LABEL org.opencontainers.image.url='https://github.com/XboxDev/nxdk.git'
+LABEL org.opencontainers.image.vendor='XboxDev'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,13 @@
-FROM ghcr.io/xboxdev/nxdk-buildbase:git-2c3115b1
+FROM ghcr.io/xboxdev/nxdk-buildbase:git-2c3115b1 AS builder
 
 COPY ./ /usr/src/nxdk/
+ENV NXDK_DIR=/usr/src/nxdk
+RUN cd /usr/src/nxdk && make tools
 
+
+FROM ghcr.io/xboxdev/nxdk-runbase:git-2c3115b1
+
+COPY --from=builder /usr/src/nxdk/ /usr/src/nxdk/
 ENV NXDK_DIR=/usr/src/nxdk
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ghcr.io/xboxdev/nxdk-buildbase:git-2c3115b1 AS builder
 
 COPY ./ /usr/src/nxdk/
 ENV NXDK_DIR=/usr/src/nxdk
-RUN cd /usr/src/nxdk && make tools
+RUN cd /usr/src/nxdk && make tools -j`nproc`
+RUN cd /usr/src/nxdk && make NXDK_ONLY=y -j`nproc`
 
 
 FROM ghcr.io/xboxdev/nxdk-runbase:git-2c3115b1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/xboxdev/nxdk-buildbase:git-39eb90d1
+FROM ghcr.io/xboxdev/nxdk-buildbase:git-2c3115b1
 
 COPY ./ /usr/src/nxdk/
 

--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,12 @@ NXDK_CXXFLAGS += -g -gdwarf-4
 NXDK_LDFLAGS += -debug
 endif
 
+ifeq ($(LTO),y)
+NXDK_ASFLAGS += -flto
+NXDK_CFLAGS += -flto
+NXDK_CXXFLAGS += -flto
+endif
+
 ifneq ($(GEN_XISO),)
 TARGET += $(GEN_XISO)
 endif

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,13 @@ ifneq ($(GEN_XISO),)
 TARGET += $(GEN_XISO)
 endif
 
+ifneq ($(NXDK_ONLY),)
+NXDK_CXX = y
+NXDK_NET = y
+NXDK_SDL = y
+TARGET = main.exe
+endif
+
 all: $(TARGET)
 
 include $(NXDK_DIR)/lib/Makefile
@@ -123,9 +130,14 @@ endif
 
 $(SRCS): $(SHADER_OBJS)
 
+ifneq ($(NXDK_ONLY),)
+.PHONY: main.exe
+main.exe: $(OBJS)
+else
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
 	$(VE) $(LD) $(NXDK_LDFLAGS) $(LDFLAGS) -out:'$@' $^
+endif
 
 %.lib:
 	@echo "[ LIB      ] $@"

--- a/samples/usb/Makefile
+++ b/samples/usb/Makefile
@@ -1,5 +1,5 @@
 XBE_TITLE = nxdk\ sample\ -\ usb
 GEN_XISO = $(XBE_TITLE).iso
 SRCS = $(CURDIR)/main.c
-NXDK_DIR = $(CURDIR)/../..
+NXDK_DIR ?= $(CURDIR)/../..
 include $(NXDK_DIR)/Makefile


### PR DESCRIPTION
This includes a few changes to improve our Docker images:
* Update the base from Alpine 3.12 to 3.13
* Use a multi-stage Dockerfile to reduce the size of the final image by not including unnecessary Alpine packages
* Prebuild the libraries and tools in the images
* Don't include the samples in the image
* Provide and test three images: nxdk, which is built with -02, nxdk-debug, which is built with debug info, and nxdk-lto, which is built with -O2 and LTO enabled
* Use a build matrix for the Docker images to keep the total runtime of the Actions low (was about 10m without the matrix)
* Add some metadata, like the build time, licenses, repository URL, git revision etc.

a7eee3906108b543c2378bd6e904c4630470a6d2 is a bit of a band-aid for our build system. I'm not too happy about it, but I couldn't integrate the -flto parameter like I did with -02 because Docker has some weird issues with whitespaces in build arguments.

At first I planned to integrate the Dockerfile from https://github.com/XboxDev/nxdk-buildbase into this one, but unfortunately the hash for an image layer takes the timestamp from when the file was last changed into account, so installing the Alpine packages in this Dockerfile would have caused unnecessarily large downloads for users updating the nxdk image. So instead, I updated https://github.com/XboxDev/nxdk-buildbase to provide two images, one with all the packages required to build nxdk itself and the tools, and one smaller one that only includes the packages required to build code with the nxdk image.

86803a10636f50da5ac984772302dd877f6b8fc3 is necessary to be able to build the samples with the Docker image. #446 had the same change for the other samples.