### PR TITLE
Format string checking

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -131,7 +131,7 @@ void debugPrintNum(int i)
 	num[8] = n2c((i >> 4) & 0x0F);
 	num[9] = n2c((i >> 0) & 0x0F);
 	num[10] = 0;
-	debugPrint(num);
+	debugPrint("%s", num);
 }
 
 void debugPrintBinary( int num )
@@ -145,7 +145,7 @@ void debugPrintBinary( int num )
 		 binNum[x++] = ' ';
    }
    binNum[x] = 0;
-   debugPrint( binNum );
+   debugPrint("%s", binNum);
 }
 
 void debugPrint(const char *format, ...)
@@ -261,6 +261,6 @@ void debugPrintHex(const char *buffer, int length)
 	for (int i = 0; i < length; i++)
 	{
 		sprintf(tmp, "%02x ", buffer[i] & 0xFF);
-		debugPrint(tmp);
+		debugPrint("%s", tmp);
 	}
 }

--- a/lib/hal/debug.h
+++ b/lib/hal/debug.h
@@ -23,7 +23,7 @@ extern "C"
  * Prints a message to whatever debug facilities might
  * be available.
  */
-void debugPrint(const char *format, ...);
+void debugPrint(const char *format, ...) __attribute__((format(printf, 1, 2)));
 void debugPrintNum(int i);
 void debugPrintBinary( int num );
 void debugPrintHex(const char *buffer, int length);

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -549,7 +549,7 @@ static void pb_subprog(DWORD subprogID, DWORD paramA, DWORD paramB)
             break;
 
         default:
-            debugPrint( "Unknown subProgID %d has been detected by DPC (A=%x B=%x).\n",
+            debugPrint( "Unknown subProgID %lu has been detected by DPC (A=%lx B=%lx).\n",
                     subprogID,
                     paramA,
                     paramB  );
@@ -671,11 +671,11 @@ static DWORD pb_gr_handler(void)
                             if (nsource&NV_PGRAPH_NSOURCE_TEX_A_PROTECTION_PENDING) debugPrint("GPU Error : texture A protection error!\n");
                             if (nsource&NV_PGRAPH_NSOURCE_TEX_B_PROTECTION_PENDING) debugPrint("GPU Error : texture B protection error!\n");
 
-                            debugPrint( "Error binary flags : %08x\n"
+                            debugPrint( "Error binary flags : %08lx\n"
                                     "Channel ID : %d (0=3D)\n"
-                                    "Channel class : %x\n"
-                                    "Push buffer inner register target : %04x\n"
-                                    "Push buffer data (lo) or instance : %08x\n"
+                                    "Channel class : %lx\n"
+                                    "Push buffer inner register target : %04lx\n"
+                                    "Push buffer data (lo) or instance : %08lx\n"
                                     "Push buffer data (hi) or instance : %08x\n"
                                     "Multi-purpose register A [0x1D8C] : %08x\n"
                                     "Multi-purpose register B [0x1D90] : %08x\n\n",
@@ -848,7 +848,7 @@ static DWORD pb_fifo_handler(void)
     if (status&NV_PFIFO_INTR_0_DMA_PUSHER_PENDING)
     {
         pb_show_debug_screen();
-        debugPrint("Software Put=%08x\n",pb_Put);
+        debugPrint("Software Put=%08lx\n",(DWORD)pb_Put);
         debugPrint("Hardware Put=%08x\n",VIDEOREG(NV_PFIFO_CACHE1_DMA_PUT));
         debugPrint("Hardware Get=%08x\n",VIDEOREG(NV_PFIFO_CACHE1_DMA_GET));
         debugPrint("Dma push buffer engine encountered invalid data at these addresses.\n");
@@ -2189,7 +2189,7 @@ void pb_end(uint32_t *pEnd)
             TimeStamp2=KeTickCount;
             if (TimeStamp2-TimeStamp1>TICKSTIMEOUT)
             {
-                debugPrint("pb_end: Busy for too long (%d) (%08x)\n",
+                debugPrint("pb_end: Busy for too long (%lu) (%08x)\n",
                     ((DWORD)(pb_Put)-(DWORD)(pb_Head)),
                     VIDEOREG(NV_PFIFO_CACHE1_DMA_GET)
                     );
@@ -2817,7 +2817,7 @@ int pb_init(void)
         {
             //This PLL configuration doesn't create a 233.33 Mhz freq from Xtal
             //Have this issure reported so we can update source for that case
-            debugPrint("PLL=%d\n",((DW_XTAL_16MHZ*ndiv)/(odiv<<pdiv))/mdiv);
+            debugPrint("PLL=%lu\n",((DW_XTAL_16MHZ*ndiv)/(odiv<<pdiv))/mdiv);
             return -5;
         }
     }

--- a/lib/xboxrt/c_runtime/check_stack.c
+++ b/lib/xboxrt/c_runtime/check_stack.c
@@ -16,9 +16,9 @@ void _cdecl _xlibc_check_stack (DWORD requested_size, DWORD stack_ptr)
     {
         _print("\n"
                "Stack overflow caught!\n"
-               "stack pointer: 0x%x\n"
-               "request size:  0x%x\n"
-               "stack limit:   0x%x\n"
+               "stack pointer: 0x%lx\n"
+               "request size:  0x%lx\n"
+               "stack limit:   0x%lx\n"
                "\n",
                stack_ptr, requested_size, (DWORD)current_thread->StackLimit);
 

--- a/samples/winapi_drivelist/main.c
+++ b/samples/winapi_drivelist/main.c
@@ -29,7 +29,7 @@ int main(void)
         Sleep(5000);
         return 1;
     }
-    debugPrint("Drive bitmask: 0x%x\n\n", driveBits);
+    debugPrint("Drive bitmask: 0x%lx\n\n", driveBits);
 
 
     // Reserve buffer long enough for all possible drive strings plus null-terminator

--- a/samples/winapi_filefind/main.c
+++ b/samples/winapi_filefind/main.c
@@ -48,7 +48,7 @@ int main(void)
     if (error == ERROR_NO_MORE_FILES) {
         debugPrint("Done!\n");
     } else {
-        debugPrint("error: %x\n", error);
+        debugPrint("error: %lx\n", error);
     }
 
     FindClose(hFind);


### PR DESCRIPTION
This enables format string checking for `debugPrint()`. This means that errors like this can be caught by the compiler and a warning will be issued:
```
debugPrint("i: %d\n"); // ,i is missing
```

I (and others) have been bitten by this kind of error a few times already while debugging.

Format string warnings caused by the code in the nxdk repo are fixed by the other commits, but there are remaining ones in the submodules.