### PR TITLE
Use less kernel exports where appropriate

### DIFF
--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -371,7 +371,7 @@ void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 		SIZE_T previousFBSize = MmQueryAllocationSize(previousFB);
 		// If the previous framebuffer is the same size as the one we want to create, don't create a new one and use that instead
 		if (previousFBSize == screenSize) {
-			RtlZeroMemory(previousFB, screenSize);
+			memset(previousFB, 0, screenSize);
 			_fb = (unsigned char *)previousFB;
 		} else {
 			MmPersistContiguousMemory(previousFB, previousFBSize, FALSE);

--- a/lib/nxdk/format.c
+++ b/lib/nxdk/format.c
@@ -84,7 +84,7 @@ bool nxFormatVolume (const char *volumePath, uint32_t bytesPerCluster)
         return false;
     }
 
-    RtlFillMemory(buffer, alignment, 0xFF);
+    memset(buffer, 0xFF, alignment);
     FATX_SUPERBLOCK *superblock = (FATX_SUPERBLOCK *)buffer;
     superblock->Signature = FATX_SIGNATURE;
     superblock->SectorsPerCluster = bytesPerCluster / diskGeometry.BytesPerSector;
@@ -104,8 +104,7 @@ bool nxFormatVolume (const char *volumePath, uint32_t bytesPerCluster)
         if (!NT_SUCCESS(status)) {
             goto close_and_return;
         }
-
-        RtlZeroMemory(buffer, alignment);
+        memset(buffer, 0, alignment);
     }
 
     // Following the superblock, write the cluster table
@@ -127,7 +126,7 @@ bool nxFormatVolume (const char *volumePath, uint32_t bytesPerCluster)
     }
 
     // Following the cluster table, write an empty root directory cluster
-    RtlFillMemory(buffer, alignment, 0xFF);
+    memset(buffer, 0xFF, alignment);
     for (size_t remainingBytes = bytesPerCluster; remainingBytes > 0; remainingBytes -= alignment, offset.QuadPart += alignment) {
         status = NtWriteFile(handle, NULL, NULL, NULL, &ioStatus, buffer, alignment, &offset);
         if (!NT_SUCCESS(status)) {


### PR DESCRIPTION
As discussed in https://github.com/XboxDev/nxdk/issues/491#issuecomment-856235343 the tool chain currently uses many kernel exports which are unable to be properly optimized by the compiler. We should strive to move away from such exports, example Nt class exports.

Another example although unused in the tool chain itself is `XboxHardwareInfo` which is a struct containing information from known memory locations (but the compiler doesn't know this). We should ideally offer a way for users to get this information without relying on the kernel (or having to know the exact memory location of the values).