### PR TITLE
usb: Fix xid device removal

### DIFF
--- a/lib/usb/libusbohci_xbox/xid_driver.c
+++ b/lib/usb/libusbohci_xbox/xid_driver.c
@@ -63,8 +63,16 @@ static xid_dev_t *alloc_xid_device(void) {
 }
 
 static void free_xid_device(xid_dev_t *xid_dev) {
-    //Find the device head in the linked list
     xid_dev_t *head = pxid_list;
+
+    //If the xid is at the head of the list, remove now.
+    if (xid_dev == head)
+    {
+        pxid_list = head->next;
+        head = NULL;
+    }
+
+    //Find the device head in the linked list
     while (head != NULL && head->next != xid_dev)
     {
         head = head->next;


### PR DESCRIPTION
This is a bug I missed in the initial xid driver.

Upsteam usb host lib manages devices by linked lists, so I did the same, however I missed the case if the device is at the head of the list.
SDL_Gamecontroller API almost makes this a non-issue which is why I missed it, but under some scenarios calling `SDL_XBOX_JoystickGetDevicePlayerIndex` or `SDL_XBOX_JoystickGetCount` may not return the expected values. It becomes a bigger is working with the driver directly.

You can recreate the issue using the SDL Gamecontroler sample:
1. Connect a controller to port 1.
2. Controller a controller to port 2.
3. Disconnect then reconnect port 1.
4. Connect a controller to Port 3. The controller index will be '1', but it should be '2' (0 = First controller)

You can also see this issue more clearly using https://github.com/Ryzee119/nxdk_ohci_test.
1. Connect a  controller to port 1
2. Connect a controller to port 2
3. Remove controller from port 1. All controllers will dissapear (including Port 2 controller)


