### PR TITLE
winapi: Run fls_init in startup thread, before regular constructors

### DIFF
--- a/lib/nxdk/automount_d.c
+++ b/lib/nxdk/automount_d.c
@@ -11,10 +11,10 @@
 #include <windows.h>
 #include <xboxkrnl/xboxkrnl.h>
 
-__attribute__((constructor)) void automount_d_drive (void)
+__cdecl int automount_d_drive (void)
 {
     if (nxIsDriveMounted('D')) {
-        return;
+        return 0;
     }
 
     // D: doesn't exist yet, so we create it
@@ -31,4 +31,7 @@ __attribute__((constructor)) void automount_d_drive (void)
     BOOL success;
     success = nxMountDrive('D', targetPath);
     assert(success);
+
+    return 0;
 }
+__attribute__((section(".CRT$XIT"))) int (__cdecl *const automount_d_drive_p)(void) = automount_d_drive;

--- a/lib/winapi/fiber.c
+++ b/lib/winapi/fiber.c
@@ -19,11 +19,12 @@ static uint32_t fls_bitmap[FLS_MAXIMUM_AVAILABLE / 32];
 static PFLS_CALLBACK_FUNCTION fls_dtors[FLS_MAXIMUM_AVAILABLE];
 
 // Gets run by the CRT on startup.
-__attribute__((constructor)) static VOID fls_init (VOID)
+static __cdecl VOID fls_init (VOID)
 {
     InitializeCriticalSection(&fls_lock);
     InitializeListHead(&fls_nodes_list);
 }
+__attribute__((section(".CRT$XXT"))) void (__cdecl *const __fls_init_p)(void) = fls_init;
 
 VOID fls_register_thread (VOID)
 {


### PR DESCRIPTION
This, together with https://github.com/XboxDev/nxdk-pdclib/pull/48, fixes the issue where constructors were run before thread-local storage was available by running them from the main thread instead of the startup thread. However, `fls_init` is a special constructor that needs to run before any thread creation, so this introduces and uses a new mechanism which allows for constructors to run in the startup thread instead by putting function pointers in a custom subsection of `.CRT` (the same thing is done automatically by the compiler for regular constructors).

This code can be used to verify that the change works. Before the changes, this would crash during the construction of the global `std::stringstream s`, but with the changes, it should run correctly.

```c++
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>
#include <sstream>

std::stringstream s;

int main(void) {
  XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

  debugPrint("hello\n");

  while (true) {
    Sleep(2000);
  }

  return 0;
}
```

Fixes #496.

This will be combined with a submodule update and turned into a normal PR when https://github.com/XboxDev/nxdk-pdclib/pull/48 is merged.