### PR TITLE
Expands XLaunchXBE to allow caller to set LaunchData.

### DIFF
--- a/lib/hal/xbox.h
+++ b/lib/hal/xbox.h
@@ -9,7 +9,35 @@ extern "C"
 
 void XReboot(void);
 
-void XLaunchXBE(char *xbePath);
+/**
+ * Retrieves information persisted by the process that launched the current XBE.
+ * 
+ * launchDataType will (likely) be one of the LDT_* defines in xboxkrnl.h
+ *
+ * Returns non-zero in the case of failure.
+ */
+int XGetLaunchInfo(unsigned long *launchDataType, const unsigned char **launchData);
+
+/**
+ * Launches an XBE.  Examples of xbePath might be:
+ *   c:\\blah.xbe
+ *   c:/foo/bar.xbe
+ * If the XBE is able to be launched, this method will
+ * not return.  If there is a problem, then it return.
+ */
+void XLaunchXBE(const char *xbePath);
+
+/**
+ * Launches an XBE and sets the LAUNCH_DATA_PAGE's LaunchData, which is
+ * retrievable by the newly launched process.
+ *
+ * Examples of xbePath might be:
+ *   c:\\blah.xbe
+ *   c:/foo/bar.xbe
+ * If the XBE is able to be launched, this method will
+ * not return.  If there is a problem, then it return.
+ */
+void XLaunchXBEEx(const char *xbePath, const void *launchData);
 
 #ifdef __cplusplus
 }

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -691,7 +691,9 @@ typedef struct _LAUNCH_DATA_PAGE
     UCHAR LaunchData[3072];
 } LAUNCH_DATA_PAGE, *PLAUNCH_DATA_PAGE;
 
-#define LDT_LAUNCH_DASHBOARD 1
+#define LDT_TITLE                 0
+#define LDT_LAUNCH_DASHBOARD      1
+#define LDT_FROM_DASHBOARD        2
 #define LDT_NONE 0xFFFFFFFF
 
 typedef struct _DISPATCHER_HEADER


### PR DESCRIPTION
* Adds an extended version of `XLaunchXBE` that allows the `LaunchData` member to be set on the persisted launch data struct.
* Adds a helper method to retrieve the launch type and data (with handling of the launch-from-dashboard case).

Basic test at abaire/nxdk_launch_test

Note that there seems to be a bug in the handling of "D:" prefixed paths (see #500).