### PR TITLE
winapi: Implement SetFileTime()/GetFileTime()

### DIFF
--- a/lib/winapi/fileapi.h
+++ b/lib/winapi/fileapi.h
@@ -14,6 +14,7 @@ DWORD GetFileAttributesA (LPCSTR lpFileName);
 BOOL GetFileAttributesExA (LPCSTR lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId, LPVOID lpFileInformation);
 BOOL SetFileAttributesA (LPCSTR lpFileName, DWORD dwFileAttributes);
 
+BOOL GetFileTime (HANDLE hFile, LPFILETIME lpCreationTime, LPFILETIME lpLastAccessTime, LPFILETIME lpLastWriteTime);
 BOOL SetFileTime (HANDLE hFile, const FILETIME *lpCreationTime, const FILETIME *lpLastAccessTime, const FILETIME *lpLastWriteTime);
 
 #define CREATE_NEW 1

--- a/lib/winapi/fileapi.h
+++ b/lib/winapi/fileapi.h
@@ -14,6 +14,8 @@ DWORD GetFileAttributesA (LPCSTR lpFileName);
 BOOL GetFileAttributesExA (LPCSTR lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId, LPVOID lpFileInformation);
 BOOL SetFileAttributesA (LPCSTR lpFileName, DWORD dwFileAttributes);
 
+BOOL SetFileTime (HANDLE hFile, const FILETIME *lpCreationTime, const FILETIME *lpLastAccessTime, const FILETIME *lpLastWriteTime);
+
 #define CREATE_NEW 1
 #define CREATE_ALWAYS 2
 #define OPEN_EXISTING 3

--- a/lib/winapi/filemanip.c
+++ b/lib/winapi/filemanip.c
@@ -100,6 +100,36 @@ BOOL SetFileAttributesA (LPCSTR lpFileName, DWORD dwFileAttributes)
     return TRUE;
 }
 
+BOOL GetFileTime (HANDLE hFile, LPFILETIME lpCreationTime, LPFILETIME lpLastAccessTime, LPFILETIME lpLastWriteTime)
+{
+    NTSTATUS status;
+    IO_STATUS_BLOCK ioStatusBlock;
+    FILE_NETWORK_OPEN_INFORMATION openInfo;
+
+    status = NtQueryInformationFile(hFile, &ioStatusBlock, &openInfo, sizeof(openInfo), FileNetworkOpenInformation);
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return FALSE;
+    }
+
+    if (lpCreationTime) {
+        lpCreationTime->dwLowDateTime = openInfo.CreationTime.LowPart;
+        lpCreationTime->dwHighDateTime = openInfo.CreationTime.HighPart;
+    }
+
+    if (lpLastAccessTime) {
+        lpLastAccessTime->dwLowDateTime = openInfo.LastAccessTime.LowPart;
+        lpLastAccessTime->dwHighDateTime = openInfo.LastAccessTime.HighPart;
+    }
+
+    if (lpLastWriteTime) {
+        lpLastWriteTime->dwLowDateTime = openInfo.LastWriteTime.LowPart;
+        lpLastWriteTime->dwHighDateTime = openInfo.LastWriteTime.HighPart;
+    }
+
+    return TRUE;
+}
+
 BOOL SetFileTime (HANDLE hFile, const FILETIME *lpCreationTime, const FILETIME *lpLastAccessTime, const FILETIME *lpLastWriteTime)
 {
     NTSTATUS status;

--- a/lib/winapi/filemanip.c
+++ b/lib/winapi/filemanip.c
@@ -100,6 +100,38 @@ BOOL SetFileAttributesA (LPCSTR lpFileName, DWORD dwFileAttributes)
     return TRUE;
 }
 
+BOOL SetFileTime (HANDLE hFile, const FILETIME *lpCreationTime, const FILETIME *lpLastAccessTime, const FILETIME *lpLastWriteTime)
+{
+    NTSTATUS status;
+    IO_STATUS_BLOCK ioStatusBlock;
+    FILE_BASIC_INFORMATION fileBasicInfo;
+
+    ZeroMemory(&fileBasicInfo, sizeof(fileBasicInfo));
+
+    if (lpCreationTime) {
+        fileBasicInfo.CreationTime.LowPart = lpCreationTime->dwLowDateTime;
+        fileBasicInfo.CreationTime.HighPart = lpCreationTime->dwHighDateTime;
+    }
+
+    if (lpLastAccessTime) {
+        fileBasicInfo.LastAccessTime.LowPart = lpLastAccessTime->dwLowDateTime;
+        fileBasicInfo.LastAccessTime.HighPart = lpLastAccessTime->dwHighDateTime;
+    }
+
+    if (lpLastWriteTime) {
+        fileBasicInfo.LastWriteTime.LowPart = lpLastWriteTime->dwLowDateTime;
+        fileBasicInfo.LastWriteTime.HighPart = lpLastWriteTime->dwHighDateTime;
+    }
+
+    status = NtSetInformationFile(hFile, &ioStatusBlock, &fileBasicInfo, sizeof(fileBasicInfo), FileBasicInformation);
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
 BOOL DeleteFileA (LPCTSTR lpFileName)
 {
     NTSTATUS status;


### PR DESCRIPTION
Implements `SetFileTime()` and `GetFileTime()` (I just read up on file attributes again and decided to go for these). Not tested beyond compilation yet.

Fixes #470 