### PR TITLE
Revert #424, free persistent framebuffer

### DIFF
--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -336,6 +336,14 @@ void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 
 	XVideoSetVideoEnable(FALSE);
 
+	PVOID previousFB = AvGetSavedDataAddress();
+	if (previousFB != NULL) {
+		SIZE_T previousFBSize = MmQueryAllocationSize(previousFB);
+		MmPersistContiguousMemory(previousFB, previousFBSize, FALSE);
+		MmFreeContiguousMemory(previousFB);
+		AvSetSavedDataAddress(NULL);
+	}
+
 	if (framebufferMemory != NULL) {
 		MmFreeContiguousMemory(framebufferMemory);
 	}

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -296,11 +296,6 @@ void XVideoSetFB(unsigned char *fb)
 {
 	assert(((unsigned int)fb & ~0x7FFFFFFF) == 0);
 	_fb = fb;
-
-	SIZE_T fbSize = MmQueryAllocationSize(_fb);
-	MmPersistContiguousMemory(_fb, fbSize, TRUE);
-	AvSetSavedDataAddress(_fb);
-
 	VIDEOREG(PCRTC_START) = (unsigned int)_fb & 0x7FFFFFFF;
 }
 
@@ -342,7 +337,6 @@ void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 	XVideoSetVideoEnable(FALSE);
 
 	if (framebufferMemory != NULL) {
-		MmPersistContiguousMemory(framebufferMemory, screenSize, FALSE);
 		MmFreeContiguousMemory(framebufferMemory);
 	}
 	framebufferMemory = MmAllocateContiguousMemoryEx(screenSize,
@@ -363,27 +357,7 @@ void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 	/* Store the framebuffer that we set; normally this is done in XVideoSetFB.
 	   However, we're using the kernel's AvSetDisplayMode here instead, so we
 	   set it here, too. */
-
-	// Get previous framebuffer
-	PVOID previousFB = AvGetSavedDataAddress();
-
-	if (previousFB != NULL) {
-		SIZE_T previousFBSize = MmQueryAllocationSize(previousFB);
-		// If the previous framebuffer is the same size as the one we want to create, don't create a new one and use that instead
-		if (previousFBSize == screenSize) {
-			memset(previousFB, 0, screenSize);
-			_fb = (unsigned char *)previousFB;
-		} else {
-			MmPersistContiguousMemory(previousFB, previousFBSize, FALSE);
-			MmFreeContiguousMemory(previousFB);
-			_fb = framebufferMemory;
-			MmPersistContiguousMemory(_fb, screenSize, TRUE);
-		}
-	} else {
-		_fb = framebufferMemory;
-		MmPersistContiguousMemory(_fb, screenSize, TRUE);
-	}
-	AvSetSavedDataAddress(_fb);
+	_fb = framebufferMemory;
 
 	XVideoSetFlickerFilter(5);
 	XVideoSetSoftenFilter(TRUE);


### PR DESCRIPTION
This reverts #424, but adds code that deletes a persistent framebuffer if one exists, so that #357 stays resolved.

I was looking into why #507 might happen for #509, and found that the issue is most likely caused by a fundamental issue with how we treat the allocated memory. Our code treats the memory like it just contains the plain framebuffer, while the XDK code in the dash expects to find a `D3DSurface` (name derived from Cxbx-Reloaded) struct describing the framebuffer, with the data following after that. Rebooting from our code to the dash would then pass a corrupted struct to the dash, which I assume is the reason for the screen corruption. This would also affect other any other xbe launched from nxdk code, hence the removal.

Allowing proper handling of framebuffer persistence is a feature I'd like to have, but this API is just not up to the task, a future redesign/rewrite is necessary.

Fixes #506 
Fixes #507 
Supersedes #509

@abaire: I'd appreciate if you could confirm that this fixes #507 for you.