### PR TITLE
(DRAFT) Rust support

### DIFF
--- a/samples/rust/.cargo/config
+++ b/samples/rust/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "xbox.json"

--- a/samples/rust/Cargo.toml
+++ b/samples/rust/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "rustnxdk"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+# Default cargo profile
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/samples/rust/Makefile
+++ b/samples/rust/Makefile
@@ -18,7 +18,7 @@ endif
 
 all:
 	@mkdir -p $(OUTPUT_DIR)
-	@cargo build $(RUSTFLAGS)
+	@cargo +nightly build $(RUSTFLAGS)
 	@cp $(EXEC_DIR)/$(PROJECT_NAME).exe ./main.exe
 	$(CXBE) -OUT:default.xbe -TITLE:$(XBE_TITLE) ./main.exe
 	@mv default.xbe $(OUTPUT_DIR)

--- a/samples/rust/Makefile
+++ b/samples/rust/Makefile
@@ -1,0 +1,25 @@
+PROJECT_NAME = rustnxdk
+XISO_NAME = rusttest
+XBE_TITLE = rusttest
+NXDK_DIR = /home/$(USER)/nxdk
+OUTPUT_DIR = bin
+RUSTFLAGS := --target xbox.json -Zbuild-std=core
+
+CXBE = $(NXDK_DIR)/tools/cxbe/cxbe
+XISO = $(NXDK_DIR)/tools/extract-xiso/build/extract-xiso
+
+EXEC_DIR = target/xbox/release
+
+ifeq ($(DEBUG),y)
+    EXEC_DIR = target/xbox/debug
+else
+    RUSTFLAGS += --release
+endif
+
+all:
+	@mkdir -p $(OUTPUT_DIR)
+	@cargo build $(RUSTFLAGS)
+	@cp $(EXEC_DIR)/$(PROJECT_NAME).exe ./main.exe
+	$(CXBE) -OUT:default.xbe -TITLE:$(XBE_TITLE) ./main.exe
+	@mv default.xbe $(OUTPUT_DIR)
+	$(XISO) -c $(OUTPUT_DIR) $(XISO_NAME).iso

--- a/samples/rust/build.rs
+++ b/samples/rust/build.rs
@@ -1,0 +1,21 @@
+extern crate core;
+use std::env;
+
+fn main() {
+    let nxdk_dir = match env::var("NXDK_DIR") {
+        Ok(value) => value,
+        Err(e) => panic!("Error getting NXDK_DIR variable: {}", e)
+    };
+
+    println!("cargo:build-std=core");
+    println!("cargo:rustc-link-search={}/lib/xboxkrnl", nxdk_dir);
+    println!("cargo:rustc-link-lib=static=libxboxkrnl");
+    println!("cargo:rustc-link-search={}/lib/", nxdk_dir);
+    println!("cargo:rustc-link-lib=static=libpdclib");
+    println!("cargo:rustc-link-lib=static=libwinapi");
+    println!("cargo:rustc-link-lib=static=libxboxrt");
+    println!("cargo:rustc-link-lib=static=libnxdk_hal");
+
+
+
+}

--- a/samples/rust/src/main.rs
+++ b/samples/rust/src/main.rs
@@ -1,0 +1,28 @@
+#![no_std] // don't link the Rust standard library
+#![no_main] // disable all Rust-level entry points
+
+use core::panic::PanicInfo;
+
+#[link (name="libnxdk_hal")]
+extern "C" {
+    fn XVideoSetMode(_: i32, _: i32, _: i32, _:i32);
+    fn debugPrint(_: &str);
+}
+
+#[no_mangle]
+fn main() -> i32 {
+    unsafe {
+        // 640x480, 32bpp, 60Hz
+        XVideoSetMode(640, 480, 32, 60);
+        debugPrint("Hello from Rust");
+    }
+    loop {
+
+    }
+}
+
+// This function is called on panic.
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    loop {}
+}

--- a/samples/rust/xbox.json
+++ b/samples/rust/xbox.json
@@ -1,0 +1,32 @@
+{
+  "abi-return-struct-as-int": true,
+  "arch": "x86",
+  "cpu": "pentium3",
+  "data-layout": "e-m:x-p:32:32-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32-a:0:32-S32",
+  "dll-prefix": "",
+  "dll-suffix": ".dll",
+  "env": "msvc",
+  "exe-suffix": ".exe",
+  "executables": true,
+  "is-like-msvc": false,
+  "is-like-windows": true,
+  "linker-flavor": "lld-link",
+  "linker-is-gnu": false,
+  "lld-flavor": "link",
+  "llvm-target": "i386-pc-win32",
+  "max-atomic-width": 64,
+  "os": "none",
+  "pre-link-args": {
+    "lld-link": [
+      "-subsystem:windows",
+      "-fixed",
+      "-base:0x00010000",
+      "-stack:65536",
+      "-merge:.edata=.edataxb"
+    ]
+  },
+  "requires-uwtable": true,
+  "target-pointer-width": "32",
+  "target-family": "windows",
+  "vendor": "pc"
+}


### PR DESCRIPTION
After some experimenting, I managed to get freestanding Rust executables compiling and running on Xbox (or, more accurately, xemu, as it was the only way to check with a debugger since there was no visual change). It worked, so I'm pushing what I have right now and opening this PR as a progress report for Rust support in nxdk. Please close if inappropriate.

The sample is located in the `samples/rust` directory and a `make` should fix it right up.

This is *NOT* meant for use on an actual Xbox.

Arguably, I shouldn't have opened this PR without Xbox testing (as this is an Xbox toolchain, not an Xbox emulator toolchain), but IMO getting it running on an emulator is progress enough for the prototype.

I am open to anything you all might have to say and suggest, and I'm looking forward to your feedback!

# Notes:

~~It uses [`cross`](https://github.com/rust-embedded/cross) for cross-compiling to 32-bit Windows and then runs the generated .exe through CXBE. I am using `cross` for this as it's more convenient to set up than a GNU/MinGW compiler toolchain. More info on how to set up `cross` in the linked repository.~~ This has changed as of b66ab5706d0f179bac0881736666a3a88fe36ff4 to use stock `cargo` with a custom Xbox target file with `-Zbuild-std=core` to build the core standard library parts that we can currently get.

The GitHub CI builds don't work due to ~~how `cross` is not installed in the environment by default~~ the required toolchain not being installed (as of b66ab5706d0f179bac0881736666a3a88fe36ff4).

The build system can (and should) get an improvement. This will happen eventually. (Kind of changed in b66ab5706d0f179bac0881736666a3a88fe36ff4 to use a Rust build script to link against nxdk libs. Still must be improved.)

As I said, this is just a quickly hacked-together prototype/proof-of-concept for now. It will all be improved and fixed up eventually.

We should at one point make a standard library port and runtime port and perhaps Rust bindings for our C APIs such as SDL 2 and WinAPI and xaudio and whatnot. (As of b66ab5706d0f179bac0881736666a3a88fe36ff4, it's possible to call WinAPI, xboxkrnl, xboxrt and pdclib using `extern "C"` blocks)



~~The binary sometimes works, but most of the time it doesn't even get into the BIOS screen when booting with xemu. This is currently being investigated, however as I don't know what might be the cause there's no ETA.~~ Fixed as of b66ab5706d0f179bac0881736666a3a88fe36ff4 when linking with some nxdk libs.

It's currently a very small step (and perhaps not even properly tested-fixed), but IMO it's enough to start this "progress monitor".

Good day to everyone!