### PR TITLE
winapi: Fix size of LibraryFlags in XBE_LIBRARY_HEADER

### DIFF
--- a/lib/winapi/winnt.h
+++ b/lib/winapi/winnt.h
@@ -264,7 +264,7 @@ typedef struct _XBE_LIBRARY_HEADER
     WORD MajorVersion;
     WORD MinorVersion;
     WORD BuildVersion;
-    DWORD LibraryFlags;
+    WORD LibraryFlags;
 } XBE_LIBRARY_HEADER, *PXBE_LIBRARY_HEADER;
 
 typedef struct _XBE_SECTION_HEADER


### PR DESCRIPTION
`LibraryFlags` had the wrong size. The erroneous size came from caustik's XBE doc.

I noticed the error while looking at an XBE in Ghidra, and confirmed that `WORD` is indeed correct by comparing with the cxbe code.