### PR TITLE
usb: Fix small debugPrint warning

### DIFF
--- a/lib/usb/libusbohci_xbox/usbh_xbox.c
+++ b/lib/usb/libusbohci_xbox/usbh_xbox.c
@@ -89,5 +89,5 @@ void *usbh_virt_to_dma(void *virtual_address) {
 
 void usbh_sysprintf(const char *buffer)
 {
-    debugPrint(buffer);
+    debugPrint("%s", buffer);
 }


### PR DESCRIPTION
With `-Wall -Wextra` flags, this line gives a warning.
No big deal, but one less warning is one better. :)