### PR TITLE
build: Fix activate script within WSL environment

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -8,7 +8,7 @@ if [ $(uname -s) = 'Darwin' ]; then
 fi
 
 export NXDK_DIR="${NXDK_DIR:-$(dirname $(dirname "$(${readlink_cmd} -f "$0")")../)}"
-export PATH=${NXDK_DIR}/bin:$PATH
+export PATH="${NXDK_DIR}/bin:$PATH"
 
 CLANG_VERSION=$(clang --version | grep version | grep -o -m 1 "[0-9]\+\.[0-9]\+\.*[0-9]*" | head -n 1)
 CLANG_VERSION_NUM=$(echo "$CLANG_VERSION" | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/')


### PR DESCRIPTION
Was receiving the following error when attempting to build within WSL2 due to the path not being wrapped in quotes. Additional changes are needed to fully support spaces within the `NXDK_PATH` however.

```
mike@MJD0029:~/projects/nxdk/bin$ ./activate
./activate: 11: export: Files/WindowsApps/CanonicalGroupLimited.Ubuntu20.04onWindows_2004.2021.825.0_x64__79rhkp1fndgsc:/mnt/c/Program: bad variable name
```