### PR TITLE
build: Fix Docker entrypoint not getting cli arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV NXDK_DIR=/usr/src/nxdk
 
 WORKDIR /usr/src/app
 
-ENTRYPOINT /usr/src/nxdk/docker_entry.sh
+ENTRYPOINT ["/usr/src/nxdk/docker_entry.sh"]
 
 LABEL org.opencontainers.image.documentation='https://github.com/XboxDev/nxdk/wiki'
 LABEL org.opencontainers.image.licenses='(Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT)'


### PR DESCRIPTION
While going through a GH Actions log, I realized that the Docker container was no longer building the samples, despite the command exiting without an error. Checking the Docker docs, I realized that the two different syntaxes for `ENTRYPOINT` have different behavior, and the one we were using was suppressing cli arguments, so our entrypoint script was getting no command to run, and just happily quit.

Due to this screw-up on my part, all Docker images built since https://github.com/XboxDev/nxdk/pull/518 was merged were broken.