### PR TITLE
hal: Disable flicker and soften filter on video init

### DIFF
--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -367,8 +367,8 @@ void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 	   set it here, too. */
 	_fb = framebufferMemory;
 
-	XVideoSetFlickerFilter(5);
-	XVideoSetSoftenFilter(TRUE);
+	XVideoSetFlickerFilter(0);
+	XVideoSetSoftenFilter(FALSE);
 
 	for(i = 0; i < 256; i++) {
 		defaultGammaRampEntries[i].red = i;


### PR DESCRIPTION
Is there any reason why we set encoder filters for the user on init?