### PR TITLE
build: Add fallback for situations where $SHELL is unset

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -22,5 +22,5 @@ if [ "$1" = "-s" ]; then cat <<- DONE
     export PATH="$PATH";
 DONE
 else
-    exec "${@:-$SHELL}"
+    exec "${@:-${SHELL:-sh}}"
 fi


### PR DESCRIPTION
This fixes a small issue I noticed when experimenting with a Debian Docker image.
Running `bin/activate` would fail there, because not going through a normal login process leaves `$SHELL` unset. `bash`, which is used as the default interactive shell in the image, seems to have an integrated fallback for that, which simply inserts a path to `bash` itself whenever `$SHELL` is used but not set, but `dash`, which is used as the standard shell for scripts, does not.
Therefore, this adds a fallback to `sh` if `SHELL` is unset, which makes the script work ootb.