### PR TITLE
build: Undefine __STDC_NO_THREADS__ for compatibility with clang 14

### DIFF
--- a/bin/nxdk-cc
+++ b/bin/nxdk-cc
@@ -15,4 +15,5 @@ clang \
     -I${NXDK_DIR}/lib/xboxrt/vcruntime \
     -DNXDK \
     -D__STDC__=1 \
+    -U__STDC_NO_THREADS__ \
     "$@"

--- a/bin/nxdk-cxx
+++ b/bin/nxdk-cxx
@@ -16,5 +16,6 @@ clang \
     -I${NXDK_DIR}/lib/xboxrt/vcruntime \
     -DNXDK \
     -D__STDC__=1 \
+    -U__STDC_NO_THREADS__ \
     -fno-exceptions \
     "$@"


### PR DESCRIPTION
The current git version of clang, which will become clang 14 once released, defines `__STDC_NO_THREADS__`, because MSVC does not provide C11 threads: https://reviews.llvm.org/D112081
nxdk, however, does, and the define breaks building our C11 threads implementation. This adds a parameter to our compiler wrappers to remove that define again.

Tested with this morning's git version of LLVM (https://github.com/llvm/llvm-project/commit/75db002725156fba9e9c38b7cefe57b7ed713734).