### PR TITLE
winapi: Fix MoveFileA/DeleteFileA parameter type

### DIFF
--- a/lib/winapi/fileapi.h
+++ b/lib/winapi/fileapi.h
@@ -36,10 +36,10 @@ HANDLE FindFirstFileA (LPCSTR lpFileName, LPWIN32_FIND_DATAA lpFindFileData);
 BOOL FindNextFileA (HANDLE hFindFile, LPWIN32_FIND_DATAA lpFindFileData);
 BOOL FindClose (HANDLE hFindFile);
 
-BOOL DeleteFileA (LPCTSTR lpFileName);
+BOOL DeleteFileA (LPCSTR lpFileName);
 BOOL RemoveDirectoryA (LPCSTR lpPathName);
 BOOL CreateDirectoryA (LPCSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttributes);
-BOOL MoveFileA (LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName);
+BOOL MoveFileA (LPCSTR lpExistingFileName, LPCSTR lpNewFileName);
 BOOL CopyFileA (LPCSTR lpExistingFileName, LPCSTR lpNewFileName, BOOL bFailIfExists);
 
 BOOL GetDiskFreeSpaceExA (LPCSTR lpDirectoryName, PULARGE_INTEGER lpFreeBytesAvailableToCaller, PULARGE_INTEGER lpTotalNumberOfBytes, PULARGE_INTEGER lpTotalNumberOfFreeBytes);

--- a/lib/winapi/filemanip.c
+++ b/lib/winapi/filemanip.c
@@ -172,7 +172,7 @@ static NTSTATUS DeleteHandle (HANDLE handle)
     return NtSetInformationFile(handle, &ioStatusBlock, &dispositionInformation, sizeof(dispositionInformation), FileDispositionInformation);
 }
 
-BOOL DeleteFileA (LPCTSTR lpFileName)
+BOOL DeleteFileA (LPCSTR lpFileName)
 {
     NTSTATUS status;
     HANDLE handle;
@@ -271,7 +271,7 @@ BOOL CreateDirectoryA (LPCSTR lpPathName, LPSECURITY_ATTRIBUTES lpSecurityAttrib
     }
 }
 
-BOOL MoveFileA (LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName)
+BOOL MoveFileA (LPCSTR lpExistingFileName, LPCSTR lpNewFileName)
 {
     NTSTATUS status;
     HANDLE handle;


### PR DESCRIPTION
This changes the parameter type for these two functions from `LPCTSTR`(a const T-string pointer) to `LPCSTR` (a const ASCII-string pointer).

Closes #502 