### PR TITLE
nxdk: Provide function to find XBE section by name

### DIFF
--- a/lib/nxdk/Makefile
+++ b/lib/nxdk/Makefile
@@ -1,7 +1,8 @@
 NXDK_SRCS := \
 	$(NXDK_DIR)/lib/nxdk/format.c \
 	$(NXDK_DIR)/lib/nxdk/mount.c \
-	$(NXDK_DIR)/lib/nxdk/path.c
+	$(NXDK_DIR)/lib/nxdk/path.c \
+	$(NXDK_DIR)/lib/nxdk/xbe.c
 
 NXDK_OBJS = $(addsuffix .obj, $(basename $(NXDK_SRCS)))
 

--- a/lib/nxdk/xbe.c
+++ b/lib/nxdk/xbe.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Stefan Schmidt
+ *
+ * Licensed under the MIT License
+ */
+
+#include "xbe.h"
+#include <string.h>
+#include <winnt.h>
+
+PXBE_SECTION_HEADER nxXbeGetSectionByName (const char *name)
+{
+    for (DWORD i = 0; i < CURRENT_XBE_HEADER->NumberOfSections; i++) {
+        XBE_SECTION_HEADER *const sectionHeader = &CURRENT_XBE_HEADER->PointerToSectionTable[i];
+
+        if (strcmp(name, sectionHeader->SectionName) == 0) {
+            return sectionHeader;
+        }
+    }
+
+    return NULL;
+}

--- a/lib/nxdk/xbe.h
+++ b/lib/nxdk/xbe.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Stefan Schmidt
+ *
+ * Licensed under the MIT License
+ */
+
+#ifndef __NXDK_XBE_H__
+#define __NXDK_XBE_H__
+
+#include <xboxkrnl/xboxdef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+PXBE_SECTION_HEADER nxXbeGetSectionByName (const char *name);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/winapi/winnt.h
+++ b/lib/winapi/winnt.h
@@ -267,20 +267,6 @@ typedef struct _XBE_LIBRARY_HEADER
     WORD LibraryFlags;
 } XBE_LIBRARY_HEADER, *PXBE_LIBRARY_HEADER;
 
-typedef struct _XBE_SECTION_HEADER
-{
-    DWORD Flags;
-    DWORD VirtualAddress;
-    DWORD VirtualSize;
-    DWORD FileAddress;
-    DWORD FileSize;
-    PCSZ SectionName;
-    LONG SectionReferenceCount;
-    WORD *HeadReferenceCount;
-    WORD *TailReferenceCount;
-    BYTE CheckSum[20];
-} XBE_SECTION_HEADER, *PXBE_SECTION_HEADER;
-
 typedef struct _XBE_FILE_HEADER
 {
     DWORD Magic;

--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -184,4 +184,18 @@ typedef struct _RTL_CRITICAL_SECTION
 #define FILE_ATTRIBUTE_TEMPORARY 0x00000100
 #define INVALID_FILE_ATTRIBUTES 0xFFFFFFFF
 
+typedef struct _XBE_SECTION_HEADER
+{
+    DWORD Flags;
+    DWORD VirtualAddress;
+    DWORD VirtualSize;
+    DWORD FileAddress;
+    DWORD FileSize;
+    PCSZ SectionName;
+    LONG SectionReferenceCount;
+    WORD *HeadReferenceCount;
+    WORD *TailReferenceCount;
+    BYTE CheckSum[20];
+} XBE_SECTION_HEADER, *PXBE_SECTION_HEADER;
+
 #endif

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -874,20 +874,6 @@ typedef enum _FIRMWARE_REENTRY
     HalMaximumRoutine
 } FIRMWARE_REENTRY;
 
-typedef struct _XBEIMAGE_SECTION
-{
-    ULONG SectionFlags;
-    ULONG virtualAddress;
-    ULONG VirtuaSize;
-    ULONG PointerToRawData;
-    ULONG SizeOfRawData;
-    PUCHAR SectionName;
-    ULONG SectionReferenceCount;
-    PSHORT HeadSharedPageReferenceCount;
-    PSHORT TailSharedPageReferenceCount;
-    UCHAR SectionDigest[20];
-} XBEIMAGE_SECTION, *PXBEIMAGE_SECTION;
-
 typedef struct _OBJECT_TYPE
 {
     PVOID AllocateProcedure;
@@ -1574,7 +1560,7 @@ typedef VOID (NTAPI *PKSYSTEM_ROUTINE) (
  */
 XBAPI NTSTATUS NTAPI XeUnloadSection
 (
-    IN OUT PXBEIMAGE_SECTION Section
+    IN OUT PXBE_SECTION_HEADER Section
 );
 
 XBAPI UCHAR XePublicKeyData[284];
@@ -1586,7 +1572,7 @@ XBAPI UCHAR XePublicKeyData[284];
  */
 XBAPI NTSTATUS NTAPI XeLoadSection
 (
-    IN PXBEIMAGE_SECTION Section
+    IN PXBE_SECTION_HEADER Section
 );
 
 XBAPI ANSI_STRING XeImageFileName[1];


### PR DESCRIPTION
Title pretty much says it all. Can be tested with something simple like this (output will usually be 11000):
```
PXBE_SECTION_HEADER xh = nxXbeGetSectionByName(".text");
if (xh) {
    debugPrint("%lx\n", xh->VirtualAddress);
}
```

Closes #477.