### PR TITLE
zlib: Fix build against CXX project

### DIFF
--- a/lib/zlib/Makefile
+++ b/lib/zlib/Makefile
@@ -12,6 +12,7 @@ ZLIB_SRCS = $(ZLIB_DIR)/adler32.c \
 ZLIB_OBJS = $(addsuffix .obj, $(basename $(ZLIB_SRCS)))
 
 NXDK_CFLAGS += -I $(ZLIB_DIR) -DZ_SOLO
+NXDK_CXXFLAGS += -I $(ZLIB_DIR) -DZ_SOLO
 
 $(NXDK_DIR)/lib/libzlib.lib: $(ZLIB_OBJS)
 


### PR DESCRIPTION
When building https://github.com/MakeMHz/xbox-hd-plus-app

I got the following
```
#include <zlib.h>
         ^~~~~~~~
1 error generated.
```

This change in the makefile resolved the problem and I was able to build successfully.