### PR TITLE
Addition of issue forms to NXDK

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug-Report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug-Report.yml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: Report a general issue with nxdk, specific to issues within this repository
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please, fill out this form with concise information.
+  - type: textarea
+    attributes:
+      label: Bug Description
+      description: |
+        A brief description of the problem, including steps to reproduce the issue and any relevant screenshots of the problem.
+
+        Tip: You can attach images by clicking this area to highlight it and then dragging files in.
+      placeholder: |
+        Insert the issue you are having here
+
+        Steps to reproduce this issue:
+        1. ...
+        2. ...
+        3. ...
+        etc.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A brief description of the expected behavior.
+      placeholder: |
+        The expected way this should function should be *insert answer here*
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: Additional information of how you have identified this issue/test cases to help prove (and potentially fix the issue occurring, if applicable)
+      placeholder: |
+        *insert testcase/other valid information here

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: XboxDev
     url: https://discord.gg/WxJPPyz
-    about: Visit the discord server for questions about developing xbox software using nxdk.
+    about: Visit the discord server for questions about developing Xbox software using nxdk.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: XboxDev
+    url: https://discord.gg/WxJPPyz
+    about: Visit the discord server for questions about developing xbox software using nxdk.


### PR DESCRIPTION
This will require enabling on the organization end, however this adds a bug report issue form to NXDK, and we can add forms for other forms of issues as well, this first form is based on the implementation of issue forms over at the xemu project, specifically this commit here (https://github.com/mborgerson/xemu/commit/cc6d19e0990ab94aa55632302afb76b22f3ca09d).

Documentation here: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository

I've also added a config.yml file that disallows blank issues and also adds a link to the XboxDev discord server

I'm very free to further workshop these forms and perhaps add forms for different topics.