### PR TITLE
debug: Use safer print formatting

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -154,7 +154,7 @@ void debugPrint(const char *format, ...)
 	unsigned short len;
 	va_list argList;
 	va_start(argList, format);
-	vsprintf(buffer, format, argList);
+	vsnprintf(buffer, sizeof(buffer), format, argList);
 	va_end(argList);
 
 	synchronizeFramebuffer();


### PR DESCRIPTION
I got a crash caused by debugPrint which took me a long time to solve.
The cause was me debugging with too much debug info to debug this debug issue.

Currently this just fails silently in a crash from an overflow. This PR makes it use snprint instead.