### PR TITLE
nxdk: Fix implicit declaration warning in format.c

### DIFF
--- a/lib/nxdk/format.c
+++ b/lib/nxdk/format.c
@@ -2,6 +2,7 @@
 #include <nxdk/fatx.h>
 
 #include <stdlib.h>
+#include <string.h>
 #include <windows.h>
 #include <xboxkrnl/xboxkrnl.h>
 


### PR DESCRIPTION
This fixes a warning about implicitly declaring `memset` in `format.h`, apparently I forgot to include the `string.h` header.