### PR TITLE
Add several missing exception usage

### DIFF
--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -57,6 +57,15 @@ typedef struct _FLOATING_SAVE_AREA
     DWORD Cr0NpxState;
 } __attribute__((packed)) FLOATING_SAVE_AREA, *PFLOATING_SAVE_AREA;
 
+// ContextFlags usage
+#define CONTEXT_X86                                0x00010000  // generic x86 processor flag
+#define CONTEXT_i386                 CONTEXT_X86               // backward compatiblity
+#define CONTEXT_CONTROL             (CONTEXT_X86 | 0x00000001)
+#define CONTEXT_INTEGER             (CONTEXT_X86 | 0x00000002)
+#define CONTEXT_SEGMENTS            (CONTEXT_X86 | 0x00000004)
+#define CONTEXT_FLOATING_POINT      (CONTEXT_X86 | 0x00000008)
+#define CONTEXT_EXTENDED_REGISTERS  (CONTEXT_X86 | 0x00000020) // cpu specific extensions
+
 typedef struct _CONTEXT
 {
     DWORD ContextFlags;

--- a/lib/xboxrt/vcruntime/excpt.h
+++ b/lib/xboxrt/vcruntime/excpt.h
@@ -13,6 +13,8 @@ typedef struct _EXCEPTION_REGISTRATION
 
 #define GetExceptionCode _exception_code
 
+#define GetExceptionInformation() ((struct _EXCEPTION_POINTERS*)_exception_info())
+
 #define EXCEPTION_EXECUTE_HANDLER 1
 #define EXCEPTION_CONTINUE_SEARCH 0
 #define EXCEPTION_CONTINUE_EXECUTION (-1)


### PR DESCRIPTION
After writing some verbose information when exception is raise. I found out CONTEXT flags and GetExceptionInformation macro are missing.

By having these changes upstream can allow [xbox kernel test suite](https://github.com/Cxbx-Reloaded/xbox_kernel_test_suite) to use them directly for testing purpose.

If there are any further addition needed, feel free to update this pull request.