### PR TITLE
winapi: Fix LTO optimizing away the fls_init constructor

### DIFF
--- a/lib/winapi/fiber.c
+++ b/lib/winapi/fiber.c
@@ -24,6 +24,7 @@ static __cdecl VOID fls_init (VOID)
     InitializeCriticalSection(&fls_lock);
     InitializeListHead(&fls_nodes_list);
 }
+#pragma comment(linker, "/include:___fls_init_p")
 __attribute__((section(".CRT$XXT"))) void (__cdecl *const __fls_init_p)(void) = fls_init;
 
 VOID fls_register_thread (VOID)


### PR DESCRIPTION
This fixes a crash that happens when building `winapi` with LTO. LLVM detects there are no references to `__fls_init_p` (it is never called directly, only via iterating over the `.CRT$XXT` subsection which contains these special constructors)  and removes it, but this function pointer is necessary to initialize the variables used by `fls_register_thread`, which is run whenever a new thread is created. The uninitialized variables cause the latter function to cause a crash in kernel code.

The fix is to force the linker to include the symbol whenever the object file containing `fls_register_thread` is being included.

Fixes #552.

My initial checks with LLVM 13.0.1 suggested that this is only an issue with specific versions of LLVM, however, I've been able to reproduce it with this version now as well, suggesting that my initial test was flawed (potentially caused by leftover files).