### PR TITLE
pbkit: Relicense under MIT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /usr/src/app
 ENTRYPOINT ["/usr/src/nxdk/docker_entry.sh"]
 
 LABEL org.opencontainers.image.documentation='https://github.com/XboxDev/nxdk/wiki'
-LABEL org.opencontainers.image.licenses='(Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-or-later AND LGPL-2.1-or-later AND MIT)'
+LABEL org.opencontainers.image.licenses='(Apache-2.0 AND BSD-3-Clause AND CC0-1.0 AND GPL-2.0-or-later AND MIT)'
 LABEL org.opencontainers.image.source='https://github.com/XboxDev/nxdk.git'
 LABEL org.opencontainers.image.url='https://github.com/XboxDev/nxdk.git'
 LABEL org.opencontainers.image.vendor='XboxDev'

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1,16 +1,13 @@
 //pbKit core functions
-// This library is free software; you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as
-// published by the Free Software Foundation; either version 2.1 of the
-// License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public
-// License along with this library; if not, see <http://www.gnu.org/licenses/>
+
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2007 Guillaume Lamonoca
+// SPDX-FileCopyrightText: 2017 espes
+// SPDX-FileCopyrightText: 2017-2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2018-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019 Lucas Jansson
+// SPDX-FileCopyrightText: 2021 Erik Abair
 
 //#define DBG
 //#define LOG

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -1,16 +1,13 @@
 //pbKit header
-// This library is free software; you can redistribute it and/or modify
-// it under the terms of the GNU Lesser General Public License as
-// published by the Free Software Foundation; either version 2.1 of the
-// License, or (at your option) any later version.
-//
-// This library is distributed in the hope that it will be useful, but
-// WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-// Lesser General Public License for more details.
-//
-// You should have received a copy of the GNU Lesser General Public
-// License along with this library; if not, see <http://www.gnu.org/licenses/>
+
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2007 Guillaume Lamonoca
+// SPDX-FileCopyrightText: 2017 espes
+// SPDX-FileCopyrightText: 2017-2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2018-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019 Lucas Jansson
+// SPDX-FileCopyrightText: 2021 Erik Abair
 
 #ifndef _PBKIT_H_
 #define _PBKIT_H_


### PR DESCRIPTION
I have managed to find the original author and got his permission to relicense this under the MIT license (I can share proof of the conversation in a non-public channel on request).

I've combined the license change with adding proper attribution by using SPDX-tags.

Fixes #448