### PR TITLE
hal: Relicense audio code to MIT

### DIFF
--- a/lib/hal/audio.c
+++ b/lib/hal/audio.c
@@ -1,3 +1,12 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2003 Andy Green
+// SPDX-FileCopyrightText: 2004 Craig Edwards
+// SPDX-FileCopyrightText: 2005-2006 Richard Osborne
+// SPDX-FileCopyrightText: 2006 Guillaume Lamonoca
+// SPDX-FileCopyrightText: 2017-2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2020-2021 Stefan Schmidt
+
 #include <string.h>
 #include <stdbool.h>
 #include <hal/audio.h>

--- a/lib/hal/audio.h
+++ b/lib/hal/audio.h
@@ -1,3 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2003 Andy Green
+// SPDX-FileCopyrightText: 2004 Craig Edwards
+// SPDX-FileCopyrightText: 2019-2021 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2021 Bennet Blischke
+
 #ifndef HAL_AUDIO_H
 #define HAL_AUDIO_H
 


### PR DESCRIPTION
I have managed to find the original authors and got their permission to relicense this under the MIT license (I can share proof of the conversations in a non-public channel on request).

I've combined the license change with adding proper attribution by using SPDX-tags.