### PR TITLE
pbkit: Build as library

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,10 +1,8 @@
-SRCS += \
-	$(NXDK_DIR)/lib/pbkit/pbkit.c
-
 include $(NXDK_DIR)/lib/Makefile-pdclib
 include $(NXDK_DIR)/lib/winapi/Makefile
 include $(NXDK_DIR)/lib/hal/Makefile
 include $(NXDK_DIR)/lib/nxdk/Makefile
+include $(NXDK_DIR)/lib/pbkit/Makefile
 include $(NXDK_DIR)/lib/usb/Makefile
 include $(NXDK_DIR)/lib/xboxrt/Makefile
 include $(NXDK_DIR)/lib/zlib/Makefile

--- a/lib/pbkit/Makefile
+++ b/lib/pbkit/Makefile
@@ -1,0 +1,14 @@
+PBKIT_SRCS := \
+	$(NXDK_DIR)/lib/pbkit/pbkit.c
+
+PBKIT_OBJS = $(addsuffix .obj, $(basename $(PBKIT_SRCS)))
+
+$(NXDK_DIR)/lib/libnxdk_pbkit.lib: $(PBKIT_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libnxdk_pbkit.lib
+
+CLEANRULES += clean-pbkit
+
+.PHONY: clean-pbkit
+clean-pbkit:
+	$(VE)rm -f $(PBKIT_OBJS) $(NXDK_DIR)/lib/libnxdk_pbkit.lib


### PR DESCRIPTION
Builds pbkit to `libnxdk_pbkit.lib`, similar to the other libraries