### PR TITLE
winapi: Add license and copyright info

### DIFF
--- a/lib/winapi/badptr.c
+++ b/lib/winapi/badptr.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #include <windows.h>
 
 BOOL IsBadWritePtr (LPVOID lp, UINT_PTR ucb)

--- a/lib/winapi/basetsd.h
+++ b/lib/winapi/basetsd.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #ifndef __BASETSD_H__
 #define __BASETSD_H__
 

--- a/lib/winapi/debug.c
+++ b/lib/winapi/debug.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #include <windows.h>
 #include <winnt.h>
 

--- a/lib/winapi/debugapi.h
+++ b/lib/winapi/debugapi.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __DEBUGAPI_H__
 #define __DEBUGAPI_H__
 

--- a/lib/winapi/errhandlingapi.c
+++ b/lib/winapi/errhandlingapi.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #include <windows.h>
 #include <string.h>
 #include <xboxkrnl/xboxkrnl.h>

--- a/lib/winapi/errhandlingapi.h
+++ b/lib/winapi/errhandlingapi.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __ERRHANDLINGAPI_H__
 #define __ERRHANDLINGAPI_H__
 

--- a/lib/winapi/error.c
+++ b/lib/winapi/error.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #include <winbase.h>
 #include <threads.h>
 

--- a/lib/winapi/fiber.c
+++ b/lib/winapi/fiber.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2022 Stefan Schmidt
+
 #include <windows.h>
 #include <assert.h>
 #include <stdint.h>

--- a/lib/winapi/fibersapi.h
+++ b/lib/winapi/fibersapi.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __FIBERSAPI_H__
 #define __FIBERSAPI_H__
 

--- a/lib/winapi/fibersapi_internal_.h
+++ b/lib/winapi/fibersapi_internal_.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __FIBERSAPI_INTERNAL__H__
 #define __FIBERSAPI_INTERNAL__H__
 

--- a/lib/winapi/fileapi.h
+++ b/lib/winapi/fileapi.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2021 Erik Abair
+
 #ifndef __FILEAPI_H__
 #define __FILEAPI_H__
 

--- a/lib/winapi/fileio.c
+++ b/lib/winapi/fileio.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2021 Stefan Schmidt
+
 #include <fileapi.h>
 #include <winerror.h>
 #include <assert.h>

--- a/lib/winapi/filemanip.c
+++ b/lib/winapi/filemanip.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2021 Erik Abair
+
 #include <fileapi.h>
 #include <handleapi.h>
 #include <winbase.h>

--- a/lib/winapi/findfile.c
+++ b/lib/winapi/findfile.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+
 #include <string.h>
 #include <assert.h>
 #include <stdbool.h>

--- a/lib/winapi/handleapi.c
+++ b/lib/winapi/handleapi.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #include <handleapi.h>
 #include <winbase.h>
 #include <xboxkrnl/xboxkrnl.h>

--- a/lib/winapi/handleapi.h
+++ b/lib/winapi/handleapi.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __HANDLEAPI_H__
 #define __HANDLEAPI_H__
 

--- a/lib/winapi/libloaderapi.c
+++ b/lib/winapi/libloaderapi.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #include <libloaderapi.h>
 #include <winbase.h>
 #include <windef.h>

--- a/lib/winapi/libloaderapi.h
+++ b/lib/winapi/libloaderapi.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #ifndef __LIBLOADERAPI_H__
 #define __LIBLOADERAPI_H__
 

--- a/lib/winapi/memory.c
+++ b/lib/winapi/memory.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+
 #include <memoryapi.h>
 #include <winbase.h>
 #include <winerror.h>

--- a/lib/winapi/memoryapi.h
+++ b/lib/winapi/memoryapi.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __MEMORYAPI_H__
 #define __MEMORYAPI_H__
 

--- a/lib/winapi/minwinbase.h
+++ b/lib/winapi/minwinbase.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Samuel Cuella
+
 #ifndef __MINWINBASE_H__
 #define __MINWINBASE_H__
 
@@ -18,7 +23,7 @@ typedef struct _OVERLAPPED
     HANDLE hEvent;
 } OVERLAPPED, *LPOVERLAPPED;
 
-typedef struct _SYSTEMTIME 
+typedef struct _SYSTEMTIME
 {
     WORD wYear;
     WORD wMonth;

--- a/lib/winapi/process.h
+++ b/lib/winapi/process.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __PROCESS_H__
 #define __PROCESS_H__
 

--- a/lib/winapi/processthreadsapi.h
+++ b/lib/winapi/processthreadsapi.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2021 Stefan Schmidt
+
 #ifndef __PROCESSTHREADSAPI_H__
 #define __PROCESSTHREADSAPI_H__
 

--- a/lib/winapi/profileapi.h
+++ b/lib/winapi/profileapi.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __PROFILEAPI_H__
 #define __PROFILEAPI_H__
 

--- a/lib/winapi/profiling.c
+++ b/lib/winapi/profiling.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #include <profileapi.h>
 #include <assert.h>
 #include <stddef.h>

--- a/lib/winapi/shlobj.h
+++ b/lib/winapi/shlobj.h
@@ -1,1 +1,5 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #include <shlobj_core.h>

--- a/lib/winapi/shlobj_core.c
+++ b/lib/winapi/shlobj_core.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #include <windows.h>
 #include <shlobj_core.h>
 

--- a/lib/winapi/shlobj_core.h
+++ b/lib/winapi/shlobj_core.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #ifndef __SHLOBJ_CORE_H__
 #define __SHLOBJ_CORE_H__
 

--- a/lib/winapi/sync.c
+++ b/lib/winapi/sync.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #include <synchapi.h>
 #include <assert.h>
 #include <stdbool.h>

--- a/lib/winapi/synchapi.h
+++ b/lib/winapi/synchapi.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #ifndef __SYNCHAPI_H__
 #define __SYNCHAPI_H__
 

--- a/lib/winapi/sysinfo.c
+++ b/lib/winapi/sysinfo.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Samuel Cuella
+
 #include <sysinfoapi.h>
 #include <assert.h>
 #include <xboxkrnl/xboxkrnl.h>

--- a/lib/winapi/sysinfoapi.h
+++ b/lib/winapi/sysinfoapi.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Samuel Cuella
+
 #ifndef __SYSINFOAPI_H__
 #define __SYSINFOAPI_H__
 

--- a/lib/winapi/thread.c
+++ b/lib/winapi/thread.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2021 Stefan Schmidt
+
 #include <assert.h>
 #include <errno.h>
 #include <string.h>

--- a/lib/winapi/tls.c
+++ b/lib/winapi/tls.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #include <windows.h>
 
 DWORD TlsAlloc ()

--- a/lib/winapi/winapifamily.h
+++ b/lib/winapi/winapifamily.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+
 #ifndef __WINAPIFAMILY_H__
 #define __WINAPIFAMILY_H__
 

--- a/lib/winapi/winbase.h
+++ b/lib/winapi/winbase.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019-2020 Jannik Vogel
+
 #ifndef __WINBASE_H__
 #define __WINBASE_H__
 

--- a/lib/winapi/windef.h
+++ b/lib/winapi/windef.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2021 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019-2020 Jannik Vogel
+
 #ifndef __WINDEF_H__
 #define __WINDEF_H__
 

--- a/lib/winapi/windows.h
+++ b/lib/winapi/windows.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #ifndef __WINDOWS_H__
 #define __WINDOWS_H__
 

--- a/lib/winapi/winerror.h
+++ b/lib/winapi/winerror.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2004 Craig Edwards
+
 #ifndef __WINERROR_H__
 #define __WINERROR_H__
 

--- a/lib/winapi/winmm/mmsystem.h
+++ b/lib/winapi/winmm/mmsystem.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #ifndef __WINMM_MMSYSTEM_H__
 #define __WINMM_MMSYSTEM_H__
 

--- a/lib/winapi/winmm/timeapi.c
+++ b/lib/winapi/winmm/timeapi.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+
 #include <timeapi.h>
 #include <winerror.h>
 #include <xboxkrnl/xboxkrnl.h>

--- a/lib/winapi/winmm/timeapi.h
+++ b/lib/winapi/winmm/timeapi.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #ifndef __WINMM_TIMEAPI_H__
 #define __WINMM_TIMEAPI_H__
 

--- a/lib/winapi/winnt.c
+++ b/lib/winapi/winnt.c
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #include <winnt.h>
 #include <xboxkrnl/xboxkrnl.h>
 

--- a/lib/winapi/winnt.h
+++ b/lib/winapi/winnt.h
@@ -1,3 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+// SPDX-FileCopyrightText: 2019-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2021 Lucas Jansson
+
 #ifndef __WINNT_H__
 #define __WINNT_H__
 


### PR DESCRIPTION
This adds license and copyright info to all code and header files that are part of the `winapi` lib.