### PR TITLE
cxbe: Simplify license statements and attribution with SPDX

### DIFF
--- a/tools/cxbe/Common.cpp
+++ b/tools/cxbe/Common.cpp
@@ -1,6 +1,7 @@
-// Licensed under GPLv2 or (at your option) any later version.
-// Copyright (C) 2019 Jannik Vogel
-// Copyright (C) 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
 
 #include "Common.h"
 #include "Cxbx.h"

--- a/tools/cxbe/Common.h
+++ b/tools/cxbe/Common.h
@@ -1,6 +1,7 @@
-// Licensed under GPLv2 or (at your option) any later version.
-// Copyright (C) 2019 Jannik Vogel
-// Copyright (C) 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
 
 #ifndef COMMON_H
 #define COMMON_H

--- a/tools/cxbe/Cxbx.h
+++ b/tools/cxbe/Cxbx.h
@@ -1,25 +1,10 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #ifndef CXBX_H
 #define CXBX_H
 

--- a/tools/cxbe/Error.cpp
+++ b/tools/cxbe/Error.cpp
@@ -1,25 +1,10 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #include "Error.h"
 #include "Common.h"
 

--- a/tools/cxbe/Error.h
+++ b/tools/cxbe/Error.h
@@ -1,25 +1,9 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #ifndef ERROR_H
 #define ERROR_H
 

--- a/tools/cxbe/Exe.cpp
+++ b/tools/cxbe/Exe.cpp
@@ -1,25 +1,10 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #include "Exe.h"
 
 #include <stdio.h>

--- a/tools/cxbe/Exe.h
+++ b/tools/cxbe/Exe.h
@@ -1,25 +1,9 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #ifndef EXE_H
 #define EXE_H
 

--- a/tools/cxbe/Logo.cpp
+++ b/tools/cxbe/Logo.cpp
@@ -1,26 +1,9 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *  (c) 2021 Stefan Schmidt
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #include "Xbe.h"
 #include <fstream>
 #include <stdexcept>

--- a/tools/cxbe/Main.cpp
+++ b/tools/cxbe/Main.cpp
@@ -1,25 +1,10 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #include "Exe.h"
 #include "Xbe.h"
 #include "Common.h"

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -1,25 +1,11 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2018 Lucas Jansson
+// SPDX-FileCopyrightText: 2019-2021 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+
 #include "Xbe.h"
 #include "Exe.h"
 

--- a/tools/cxbe/Xbe.h
+++ b/tools/cxbe/Xbe.h
@@ -1,25 +1,10 @@
-// ******************************************************************
-// *
-// *  This file is part of Cxbe
-// *
-// *  This program is free software; you can redistribute it and/or
-// *  modify it under the terms of the GNU General Public License
-// *  as published by the Free Software Foundation; either version 2
-// *  of the License, or (at your option) any later version.
-// *
-// *  This program is distributed in the hope that it will be useful,
-// *  but WITHOUT ANY WARRANTY; without even the implied warranty of
-// *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-// *  GNU General Public License for more details.
-// *
-// *  You should have received a copy of the GNU General Public License
-// *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-// *
-// *  (c) 2002-2003 Aaron Robinson <caustik@caustik.com>
-// *
-// *  All rights reserved
-// *
-// ******************************************************************
+// This file is part of Cxbe
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+// SPDX-FileCopyrightText: 2002-2003 Aaron Robinson <caustik@caustik.com>
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #ifndef XBE_H
 #define XBE_H
 


### PR DESCRIPTION
This changes cxbe's license and copyright statements to use SPDX like we do for other code already, which reduces verbosity and is machine readable (there are tools to check license conformity etc.).