### PR TITLE
nxdk: Add SPDX license and copyright info

### DIFF
--- a/lib/nxdk/automount_d.c
+++ b/lib/nxdk/automount_d.c
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2019 Stefan Schmidt
- *
- * Licensed under the MIT License
- */
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2022 Stefan Schmidt
 
 #include <nxdk/mount.h>
 #include <nxdk/path.h>

--- a/lib/nxdk/fatx.h
+++ b/lib/nxdk/fatx.h
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 #ifndef __NXDK_FATX_H__
 #define __NXDK_FATX_H__
 

--- a/lib/nxdk/format.c
+++ b/lib/nxdk/format.c
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2021-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2021 GXTX
+
 #include <nxdk/format.h>
 #include <nxdk/fatx.h>
 

--- a/lib/nxdk/format.h
+++ b/lib/nxdk/format.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
+
 #ifndef __NXDK_FORMAT_H__
 #define __NXDK_FORMAT_H__
 

--- a/lib/nxdk/mount.c
+++ b/lib/nxdk/mount.c
@@ -1,8 +1,7 @@
-/*
- * Copyright (c) 2019 Stefan Schmidt
- *
- * Licensed under the MIT License
- */
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Kosmas Raptis
 
 #include "mount.h"
 #include <stdio.h>

--- a/lib/nxdk/mount.h
+++ b/lib/nxdk/mount.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2019 Stefan Schmidt
- *
- * Licensed under the MIT License
- */
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
 
 #ifndef __NXDK_MOUNT_H__
 #define __NXDK_MOUNT_H__

--- a/lib/nxdk/path.c
+++ b/lib/nxdk/path.c
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2019 Stefan Schmidt
- *
- * Licensed under the MIT License
- */
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
 
 #include "path.h"
 #include <string.h>

--- a/lib/nxdk/path.h
+++ b/lib/nxdk/path.h
@@ -1,8 +1,7 @@
-/*
- * Copyright (c) 2019 Stefan Schmidt
- *
- * Licensed under the MIT License
- */
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2019 Stefan Schmidt
+// SPDX-FileCopyrightText: 2020 Lucas Jansson
 
 #ifndef __NXDK_PATH_H__
 #define __NXDK_PATH_H__

--- a/lib/nxdk/xbe.c
+++ b/lib/nxdk/xbe.c
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2022 Stefan Schmidt
- *
- * Licensed under the MIT License
- */
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2022 Stefan Schmidt
 
 #include "xbe.h"
 #include <string.h>

--- a/lib/nxdk/xbe.h
+++ b/lib/nxdk/xbe.h
@@ -1,8 +1,6 @@
-/*
- * Copyright (c) 2022 Stefan Schmidt
- *
- * Licensed under the MIT License
- */
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2022 Stefan Schmidt
 
 #ifndef __NXDK_XBE_H__
 #define __NXDK_XBE_H__


### PR DESCRIPTION
This adds SPDX-style license and copyright statements to the nxdk library code.