### PR TITLE
xboxkrnl: Improve licensing info

### DIFF
--- a/lib/xboxkrnl/ntstatus.h
+++ b/lib/xboxkrnl/ntstatus.h
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: CC0-1.0
+
+// SPDX-FileCopyrightText: 2020-2021 Stefan Schmidt
+// SPDX-FileCopyrightText: 2021 RadWolfie
+// SPDX-FileCopyrightText: 2022 Ryan Wendland
+
+
 #ifndef _NTSTATUS_
 #define _NTSTATUS_
 

--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: CC0-1.0
+
+// SPDX-FileCopyrightText: 2019-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019-2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2019 Matt Borgerson
+// SPDX-FileCopyrightText: 2022 RadWolfie
+
 #ifndef __XBOXDEF_H__
 #define __XBOXDEF_H__
 

--- a/lib/xboxkrnl/xboxkrnl.exe.def
+++ b/lib/xboxkrnl/xboxkrnl.exe.def
@@ -1,6 +1,6 @@
-; Copyright (C) 2017 Stefan Schmidt
-; This specific file is licensed under the CC0 1.0.
-; Look here for details: https://creativecommons.org/publicdomain/zero/1.0/
+; SPDX-License-Identifier: CC0-1.0
+
+; SPDX-FileCopyrightText: 2017 Stefan Schmidt
 
 LIBRARY xboxkrnl.exe
 

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -1,9 +1,13 @@
+// SPDX-License-Identifier: CC0-1.0
+
+// SPDX-FileCopyrightText: 2017-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2018-2021 Jannik Vogel
+// SPDX-FileCopyrightText: 2018 Sean Koppenhafer
+// SPDX-FileCopyrightText: 2022 Erik Abair
+
 /**
  * @file xboxkrnl.h
- * @author Stefan Schmidt
  * @brief The complete interface to the Xbox-Kernel.
- * This specific file is licensed under the CC0 1.0.
- * Look here for details: https://creativecommons.org/publicdomain/zero/1.0/
  */
 
 #pragma once


### PR DESCRIPTION
This replaces the non-standard and missing license and copyright statements in `xboxkrnl` files with SPDX.