### PR TITLE
cg: Add NVIDIA license info

### DIFF
--- a/LICENSES/LicenseRef-NVIDIA-CG.txt
+++ b/LICENSES/LicenseRef-NVIDIA-CG.txt
@@ -1,0 +1,138 @@
+License For Customer Use of NVIDIA Software
+
+IMPORTANT NOTICE -- READ CAREFULLY: This License For Customer Use of
+NVIDIA Software ("LICENSE") is the agreement which governs use of the
+software of NVIDIA Corporation and its subsidiaries ("NVIDIA") downloadable
+herefrom, including computer software and associated printed materials
+("SOFTWARE"). By downloading, installing, copying, or otherwise using the
+SOFTWARE, you agree to be bound by the terms of this LICENSE.  If you do
+not agree to the terms of this LICENSE, do not download the SOFTWARE.
+
+RECITALS
+
+Use of NVIDIA's products requires three elements: the SOFTWARE, the hardware
+on a graphics controller board, and a personal computer. The SOFTWARE is
+protected by copyright laws and international copyright treaties, as well as
+other intellectual property laws and treaties.  The SOFTWARE is not sold, and
+instead is only licensed for use, strictly in accordance with this document.
+The hardware is protected by various patents, and is sold, but this agreement
+does not cover that sale, since it may not necessarily be sold as a package
+with the SOFTWARE. This agreement sets forth the terms and conditions of the
+SOFTWARE LICENSE only.
+
+1.  DEFINITIONS
+
+1.1  Customer.  Customer means the entity or individual that downloads the
+     SOFTWARE.
+
+2.  GRANT OF LICENSE
+
+2.1  Rights and Limitations of Grant.  NVIDIA hereby grants Customer the
+     following non-exclusive, worldwide, royalty-free, non-transferable right
+     to use the SOFTWARE, with the following limitations:
+
+2.1.1  Rights.   Customer may use, reproduce, distribute, publicly display
+       and publicly perform the SOFTWARE.
+
+2.1.2  Limitations.
+
+No Reverse Engineering.  Customer may not reverse engineer, decompile, or
+disassemble the SOFTWARE, nor attempt in any other manner to obtain the
+source code.
+
+No Modification.  The SOFTWARE may be redistributed providing that distributed
+Cg compiler and runtime binaries are unmodified, except for decompression and
+compression.
+
+No Rental.  Customer may not rent or lease the SOFTWARE to someone else.
+
+No Support.  NVIDIA will not be responsible for providing maintenance and
+support to Customer or any other end users for the Software distributed by
+Customer or others.
+
+3.  TERMINATION
+
+This LICENSE will automatically terminate if Customer fails to comply with
+any of the terms and conditions hereof.  In such event, Customer must destroy
+all copies of the SOFTWARE and all of its component parts.
+
+4.  COPYRIGHT
+
+All title and copyrights in and to the SOFTWARE (including but not limited to
+all images, photographs, animations, video, audio, music, text, and other
+information incorporated into the SOFTWARE), the accompanying printed
+materials, and any copies of the SOFTWARE, are owned by NVIDIA, or its
+suppliers.  The SOFTWARE is protected by copyright laws and international
+treaty provisions.  Accordingly, Customer is required to treat the SOFTWARE
+like any other copyrighted material. 
+
+Customer  agrees that the Software is proprietary information of NVIDIA and
+that NVIDIA owns all right, title and interest therein. There are no implied
+licenses under this License, and any rights not expressly granted are reserved
+by NVIDIA. The Software is not sold, and instead is only licensed for use,
+strictly in accordance with this License. All copies of the Software shall
+contain NVIDIA's proprietary rights notices as provided therein. Customer
+shall not remove or modify any such proprietary rights notices of NVIDIA. This
+License will automatically terminate if Customer fails to comply with any of
+the terms and conditions hereof. In such event, Customer must cease
+reproducing, distributing, or otherwise using the Software and destroy all
+copies thereof.
+
+5.  APPLICABLE LAW
+
+This agreement shall be deemed to have been made in, and shall be construed
+pursuant to, the laws of the State of Delaware.  Any suit or controversy
+arising hereunder shall be brought in the federal or state courts located in
+Santa Clara County, California, and each party submits to the venue and
+jurisdiction thereof.
+
+6.  DISCLAIMER OF WARRANTIES AND LIMITATION ON LIABILITY
+
+6.1  No Warranties.  TO THE MAXIMUM EXTENT PERMITTED BY
+     APPLICABLE LAW, THE SOFTWARE IS PROVIDED "AS IS" AND NVIDIA
+     AND ITS SUPPLIERS DISCLAIM ALL WARRANTIES, EITHER EXPRESS
+     OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, IMPLIED
+     WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE AND NONINFRINGEMENT. 
+
+6.2  No Liability for Consequential Damages.  TO THE MAXIMUM
+     EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL
+     NVIDIA OR ITS SUPPLIERS BE LIABLE FOR ANY SPECIAL,
+     INCIDENTAL, INDIRECT, OR CONSEQUENTIAL DAMAGES WHATSOEVER
+     (INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOSS OF
+     BUSINESS PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS
+     INFORMATION, OR ANY OTHER PECUNIARY LOSS) ARISING OUT OF
+     THE USE OF OR INABILITY TO USE THE SOFTWARE, EVEN IF NVIDIA
+     HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.  THESE
+     LIMITATIONS SHALL APPLY NOTWITHSTANDING ANY FAILURE OF
+     ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.  NVIDIA SHALL HAVE
+     NO CONTRACTUAL OBLIGATION TO INDEMNIFY CUSTOMER UNDER
+     THIS LICENSE. CUSTOMER AND/OR END-USERS OF THE SOFTWARE
+     DISTRIBUTED BY CUSTOMER ASSUME THE ENTIRE COST OF ANY
+     DAMAGE, LOSS, OR EXPENSE RESULTING FROM THEIR USE OR
+     EXPLOITATION OF THE SOFTWARE.
+
+7.  MISCELLANEOUS
+
+The United Nations Convention on Contracts for the International Sale of
+Goods is specifically disclaimed.    This agreement is the final, complete
+and exclusive agreement between the parties relating to the subject matter
+hereof, and supersedes all prior or contemporaneous understandings and
+agreements relating to such subject matter, whether oral or written.
+Customer agrees that it will not ship, transfer or export the SOFTWARE
+into any country, or use the SOFTWARE in any manner, prohibited by the
+United States Bureau of Export Administration or any export laws,
+restrictions or regulations.  
+
+If any provision of this License is held to be invalid or unenforceable
+for any reason, the remaining provisions will continue in full force
+without being impaired or invalidated in any way.
+
+No term or provisions hereof shall be deemed waived, and no breach excused,
+unless such waiver or consent is in writing and signed by the party claimed
+to have waived or consented. The waiver by either party of a breach of any
+provision of this License will not operate or be interpreted as a waiver of
+any other or subsequent breach.
+
+This License may be changed only by mutual agreement in writing of the
+authorized representatives of the parties.

--- a/tools/cg/linux/cgc.i386.license
+++ b/tools/cg/linux/cgc.i386.license
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: LicenseRef-NVIDIA-CG
+
+// SPDX-FileCopyrightText: Copyright © 2004-2012 NVIDIA Corporation

--- a/tools/cg/linux/cgc.license
+++ b/tools/cg/linux/cgc.license
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: LicenseRef-NVIDIA-CG
+
+// SPDX-FileCopyrightText: Copyright © 2004-2012 NVIDIA Corporation

--- a/tools/cg/mac/cgc.license
+++ b/tools/cg/mac/cgc.license
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: LicenseRef-NVIDIA-CG
+
+// SPDX-FileCopyrightText: Copyright © 2004-2012 NVIDIA Corporation

--- a/tools/cg/win/cgc.exe.license
+++ b/tools/cg/win/cgc.exe.license
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: LicenseRef-NVIDIA-CG
+
+// SPDX-FileCopyrightText: Copyright © 2004-2012 NVIDIA Corporation


### PR DESCRIPTION
This adds the copyright and license info for the Cg binaries we distribute.