### PR TITLE
Add license info to smaller files

### DIFF
--- a/.ci_build_samples.sh
+++ b/.ci_build_samples.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
+
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2018-2021 Stefan Schmidt
+# SPDX-FileCopyrightText: 2021 Margen67
+
 set -e
 
 eval $(./bin/activate -s)

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2020 Stefan Schmidt
+
 root = true
 
 [*]

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2015 espes
+# SPDX-FileCopyrightText: 2016 Matt Borgerson
+# SPDX-FileCopyrightText: 2017 Luke Usher
+# SPDX-FileCopyrightText: 2018-2019 Stefan Schmidt
+# SPDX-FileCopyrightText: 2019 Jannik Vogel
+
 .DS_Store
 *.exe
 *.exe.manifest

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,11 @@
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2016-2019 Matt Borgerson
+# SPDX-FileCopyrightText: 2018 Lucas Jansson
+# SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
+# SPDX-FileCopyrightText: 2021 Margen67
+# SPDX-FileCopyrightText: 2021 Ryan Wendland
+
 [submodule "tools/extract-xiso"]
 	path = tools/extract-xiso
 	url = https://github.com/XboxDev/extract-xiso.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2020-2022 Stefan Schmidt
+
 FROM ghcr.io/xboxdev/nxdk-buildbase:git-2c3115b1 AS builder
 
 COPY ./ /usr/src/nxdk/

--- a/bin/activate
+++ b/bin/activate
@@ -1,5 +1,10 @@
 #!/usr/bin/env sh
 
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2021-2022 Stefan Schmidt
+# SPDX-FileCopyrightText: 2021 Mike Davis
+
 readlink_cmd="readlink"
 
 if [ $(uname -s) = 'Darwin' ]; then

--- a/bin/nxdk-as
+++ b/bin/nxdk-as
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 clang \
     -target i386-pc-win32 \
     -march=pentium3 \

--- a/bin/nxdk-cc
+++ b/bin/nxdk-cc
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2021-2022 Stefan Schmidt
+
 clang \
     -target i386-pc-win32 \
     -march=pentium3 \

--- a/bin/nxdk-cmake
+++ b/bin/nxdk-cmake
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 cmake \
     -DCMAKE_TOOLCHAIN_FILE=$NXDK_DIR/share/toolchain-nxdk.cmake \
     "$@"

--- a/bin/nxdk-cxx
+++ b/bin/nxdk-cxx
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2021-2022 Stefan Schmidt
+
 clang \
     -target i386-pc-win32 \
     -march=pentium3 \

--- a/bin/nxdk-lib
+++ b/bin/nxdk-lib
@@ -1,4 +1,8 @@
 #!/usr/bin/env sh
 
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 llvm-lib \
     "$@"

--- a/bin/nxdk-link
+++ b/bin/nxdk-link
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 lld -flavor link \
     -subsystem:windows \
     -fixed \

--- a/bin/nxdk-pkg-config
+++ b/bin/nxdk-pkg-config
@@ -1,5 +1,9 @@
 #!/usr/bin/env sh
 
+# SPDX-License-Identifier: CC0-1.0
+
+# SPDX-FileCopyrightText: 2021 Stefan Schmidt
+
 export PKG_CONFIG_DIR=""
 export PKG_CONFIG_PATH=""
 export PKG_CONFIG_SYSROOT_DIR=""

--- a/samples/xaudio/nxdk.wav.license
+++ b/samples/xaudio/nxdk.wav.license
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: CC0-1.0
+
+// SPDX-FileCopyrightText: 2019 Matt Borgerson


### PR DESCRIPTION
This adds SPDX-style licensing info to some of our smaller files that don't warrant a separate PR, such as the build scripts.