### PR TITLE
winapi: Add Mutex functions

### DIFF
--- a/lib/winapi/synchapi.h
+++ b/lib/winapi/synchapi.h
@@ -2,6 +2,7 @@
 
 // SPDX-FileCopyrightText: 2019-2020 Stefan Schmidt
 // SPDX-FileCopyrightText: 2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2022 Ryan Wendland
 
 #ifndef __SYNCHAPI_H__
 #define __SYNCHAPI_H__
@@ -62,6 +63,15 @@ DWORD WaitForMultipleObjects (DWORD nCount, const HANDLE *lpHandles, BOOL bWaitA
 
 HANDLE CreateSemaphore (LPSECURITY_ATTRIBUTES lpSemaphoreAttributes, LONG lInitialCount, LONG lMaximumCount, LPCSTR lpName);
 BOOL ReleaseSemaphore (HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousCount);
+
+HANDLE CreateMutexA (LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner, LPCSTR lpName);
+BOOL ReleaseMutex (HANDLE hMutex);
+
+#ifndef UNICODE
+#define CreateMutex CreateMutexA
+#else
+#error nxdk does not support the Unicode API
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add CreateMutex and ReleaseMutex synchapi.h functions

I did a basic test with this code:

```
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>
#include <assert.h>

static HANDLE mutex;
static HANDLE thread;
static int mutex_variable;
DWORD WINAPI increment_variable(LPVOID arg)
{
    while (1)
    {
        WaitForSingleObject(mutex, INFINITE);
        //We have a lock on mutex_variable. Do a couple independent non atomic operations
        //with a big delay between them to test the mutex lock.
        mutex_variable++;
        //Put thread to sleep for a while. If we access mutex_variable from another thread during this sleep,
        //it will be an odd number! Shouldnt happen if mutex is working!
        Sleep(1000);
        mutex_variable++;
        ReleaseMutex(mutex);
    }
    return TRUE;
}

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    mutex_variable = 0;
    mutex = CreateMutex(NULL, FALSE, NULL);
    thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)increment_variable, NULL, 0, NULL);
    while (1)
    {
        WaitForSingleObject(mutex, INFINITE);
        //Printed variable should always be an even number
        debugPrint("mutex_variable: %d\n", mutex_variable);
        assert((mutex_variable % 2) == 0);
        ReleaseMutex(mutex);
    }
    return 0;
}
```