### PR TITLE
network init API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ endif
 
 ifneq ($(NXDK_ONLY),)
 NXDK_CXX = y
-NXDK_NET = y
 NXDK_SDL = y
 TARGET = main.exe
 endif
@@ -76,9 +75,7 @@ ifneq ($(NXDK_CXX),)
 include $(NXDK_DIR)/lib/libcxx/Makefile.nxdk
 endif
 
-ifneq ($(NXDK_NET),)
 include $(NXDK_DIR)/lib/net/Makefile
-endif
 
 ifneq ($(NXDK_SDL),)
 include $(NXDK_DIR)/lib/sdl/SDL2/Makefile.xbox

--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -359,6 +359,11 @@
  */
 #define LWIP_SINGLE_NETIF               1
 
+/**
+ * LWIP_NETIF_API==1: Support netif api (in netifapi.c)
+ */
+#define LWIP_NETIF_API                  1
+
 /*
    ------------------------------------
    ---------- LOOPIF options ----------

--- a/lib/nxdk/Makefile
+++ b/lib/nxdk/Makefile
@@ -1,4 +1,5 @@
 NXDK_SRCS := \
+	$(NXDK_DIR)/lib/nxdk/configsector.c \
 	$(NXDK_DIR)/lib/nxdk/format.c \
 	$(NXDK_DIR)/lib/nxdk/mount.c \
 	$(NXDK_DIR)/lib/nxdk/path.c \

--- a/lib/nxdk/Makefile
+++ b/lib/nxdk/Makefile
@@ -2,6 +2,7 @@ NXDK_SRCS := \
 	$(NXDK_DIR)/lib/nxdk/configsector.c \
 	$(NXDK_DIR)/lib/nxdk/format.c \
 	$(NXDK_DIR)/lib/nxdk/mount.c \
+	$(NXDK_DIR)/lib/nxdk/net.c \
 	$(NXDK_DIR)/lib/nxdk/path.c \
 	$(NXDK_DIR)/lib/nxdk/xbe.c
 

--- a/lib/nxdk/configsector.c
+++ b/lib/nxdk/configsector.c
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2021 Luke Usher
+// SPDX-FileCopyrightText: 2022 Stefan Schmidt
+
+#include "configsector.h"
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <winbase.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+#define NXDK_HDD_SECTOR_SIZE 512
+
+#define NXDK_NETWORK_CONFIG_SECTOR 0
+#define NXDK_MACHINE_ACCOUNT_CONFIG_SECTOR 1
+#define NXDK_USER_ACCOUNT_CONFIG_SECTOR 2
+#define NXDK_CONFIG_SECTOR_COUNT 23
+
+#define NXDK_CONFIG_SECTOR_HEADER 0x79132568
+#define NXDK_CONFIG_SECTOR_FOOTER 0xAA550000
+#define NXDK_CONFIG_DATA_SIZE 492
+
+typedef struct
+{
+    DWORD header;
+    DWORD unknown1; // Always set to 1?
+    DWORD unknown2; // Always set to 1?
+    CHAR data[NXDK_CONFIG_DATA_SIZE];
+    DWORD checksum;
+    DWORD footer;
+}  __attribute__ ((packed)) NXDK_CONFIG_SECTOR;
+
+#define NXDK_NETWORK_CONFIG_FOOTER 'XBCP'
+
+HANDLE nxOpenConfigPartition ()
+{
+    ANSI_STRING str;
+    RtlInitAnsiString(&str, "\\Device\\Harddisk0\\partition0");
+
+    OBJECT_ATTRIBUTES obj;
+    InitializeObjectAttributes(&obj, &str, OBJ_CASE_INSENSITIVE, NULL, NULL);
+
+    HANDLE hPartition;
+    IO_STATUS_BLOCK statusBlock;
+
+    NTSTATUS status = NtOpenFile(&hPartition, GENERIC_READ | GENERIC_WRITE | SYNCHRONIZE, &obj, &statusBlock, FILE_SHARE_READ | FILE_SHARE_WRITE, FILE_SYNCHRONOUS_IO_ALERT);
+    if (!NT_SUCCESS(status)) {
+        return INVALID_HANDLE_VALUE;
+    }
+
+    return hPartition;
+}
+
+void nxCloseConfigPartition (HANDLE hPartition)
+{
+    if (hPartition != INVALID_HANDLE_VALUE) {
+        NtClose(hPartition);
+    }
+}
+
+DWORD nxNetworkConfigChecksum(NXDK_CONFIG_SECTOR *sectorData, UINT size)
+{
+    DWORD* data = (DWORD *)sectorData;
+
+    DWORD sum = 0;
+    DWORD carry = 0;
+
+    for (int i = size >> 2; i; --i) {
+        carry += (*data > (*data + sum));
+
+        sum += *data;
+        data++;
+    }
+
+    return (carry > (carry + sum)) + carry + sum;
+}
+
+bool nxLoadNetworkConfigSector(HANDLE hPartition, UINT sectorIndex, BYTE *buffer, UINT size)
+{
+    NXDK_CONFIG_SECTOR configSector;
+
+    _Static_assert(sizeof(configSector) == 512, "NXDK_CONFIG_SECTOR size mismatch");
+
+    assert(hPartition != INVALID_HANDLE_VALUE);
+    if (hPartition == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    assert(sectorIndex < NXDK_CONFIG_SECTOR_COUNT);
+    if (sectorIndex >= NXDK_CONFIG_SECTOR_COUNT) {
+        return false;
+    }
+
+    if (size != NXDK_CONFIG_DATA_SIZE) {
+        return false;
+    }
+
+    LARGE_INTEGER offset;
+    offset.QuadPart = (8 + sectorIndex) * NXDK_HDD_SECTOR_SIZE;
+
+    IO_STATUS_BLOCK statusBlock;
+    NTSTATUS status = NtReadFile(hPartition, 0, NULL, NULL, &statusBlock, &configSector, NXDK_HDD_SECTOR_SIZE, &offset);
+
+    if (!NT_SUCCESS(status)) {
+        return false;
+    }
+
+    if (configSector.header != NXDK_CONFIG_SECTOR_HEADER ||
+        configSector.footer != NXDK_CONFIG_SECTOR_FOOTER ||
+        configSector.unknown1 != 1 ||
+        configSector.unknown2 != 1) {
+        return false;
+    }
+
+    DWORD checksum = configSector.checksum;
+    configSector.checksum = 0;
+    DWORD newChecksum =  ~nxNetworkConfigChecksum(&configSector, NXDK_HDD_SECTOR_SIZE);
+    if (checksum != newChecksum) {
+        return false;
+    }
+    configSector.checksum = checksum;
+
+    memcpy(buffer, configSector.data, NXDK_CONFIG_DATA_SIZE);
+
+    return true;
+}
+
+bool nxLoadNetworkConfig(nxdk_network_config_sector_t *config)
+{
+    HANDLE hPartition = nxOpenConfigPartition();
+
+    assert(hPartition != INVALID_HANDLE_VALUE);
+    if (hPartition == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    nxLoadNetworkConfigSector(hPartition, NXDK_NETWORK_CONFIG_SECTOR, (BYTE *)config, NXDK_CONFIG_DATA_SIZE);
+
+    // If the footer is invalid, config is invalid
+    if (config->footer != NXDK_NETWORK_CONFIG_FOOTER) {
+        memset(config, 0, sizeof(nxdk_network_config_sector_t));
+        config->footer = NXDK_NETWORK_CONFIG_FOOTER;
+    }
+
+    nxCloseConfigPartition(hPartition);
+
+    return true;
+}

--- a/lib/nxdk/configsector.h
+++ b/lib/nxdk/configsector.h
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2021 Luke Usher
+// SPDX-FileCopyrightText: 2022 Stefan Schmidt
+
+#ifndef __NXDK_CONFIGSECTOR_H__
+#define __NXDK_CONFIGSECTOR_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#define NXDK_NETWORK_CONFIG_MANUAL_IP 0x00000004
+#define NXDK_NETWORK_CONFIG_MANUAL_DNS 0x00000008
+
+typedef struct
+{
+    uint8_t unknown1[0x40];
+
+    uint32_t dhcpFlags;
+    uint32_t unknown2;
+
+    struct
+    {
+        uint32_t ip;
+        uint32_t subnetMask;
+        uint32_t defaultGateway;
+        uint32_t primaryDns;
+        uint32_t secondaryDns;
+    } __attribute__ ((packed)) manual;
+
+    uint8_t unknown3[0x104];
+
+    struct
+    {
+        uint32_t ip;
+        uint32_t subnetMask;
+        uint32_t defaultGateway;
+        uint32_t primaryDns;
+        uint32_t secondaryDns;
+    } __attribute__ ((packed)) automatic;
+
+    uint8_t unknown4[0x74];
+    uint32_t footer;
+} __attribute__ ((packed)) nxdk_network_config_sector_t;
+
+bool nxLoadNetworkConfig(nxdk_network_config_sector_t *config);
+
+#endif

--- a/lib/nxdk/net.c
+++ b/lib/nxdk/net.c
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2022 Stefan Schmidt
+
+#include "net.h"
+
+#include <assert.h>
+#include <stdbool.h>
+
+#include <nxdk/configsector.h>
+#include <netif/etharp.h>
+#include <lwip/dhcp.h>
+#include <lwip/dns.h>
+#include <lwip/netif.h>
+#include <lwip/netifapi.h>
+#include <lwip/tcpip.h>
+#include <lwip/timeouts.h>
+#include <pktdrv.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+
+err_t nforceif_init(struct netif *netif);
+
+struct netif *g_pnetif;
+static struct netif nforce_netif;
+
+static void tcpip_init_done(void *arg)
+{
+    KEVENT *init_complete = arg;
+    KeSetEvent(init_complete, IO_NO_INCREMENT, FALSE);
+}
+
+static void packet_timer(void *arg)
+{
+    LWIP_UNUSED_ARG(arg);
+    Pktdrv_ReceivePackets();
+    sys_timeout(5 /* ms */, packet_timer, NULL);
+}
+
+int nxNetInit(const nx_net_parameters_t *parameters)
+{
+    ip4_addr_t ipaddr, netmask, gateway;
+    bool ipv4_dhcp;
+    ip_addr_t dns[2];
+    bool dns_override = false;
+
+    if (!parameters || parameters->ipv4_mode == NX_NET_AUTO) {
+        nxdk_network_config_sector_t configSector;
+        if (!nxLoadNetworkConfig(&configSector)) {
+            return -1;
+        }
+
+        if (configSector.dhcpFlags & NXDK_NETWORK_CONFIG_MANUAL_IP) {
+            ipv4_dhcp = false;
+            IP4_ADDR(&ipaddr, configSector.manual.ip >>  0 & 0xff,
+                             (configSector.manual.ip >>  8 & 0xff),
+                             (configSector.manual.ip >> 16 & 0xff),
+                             (configSector.manual.ip >> 24 & 0xff));
+            IP4_ADDR(&gateway, configSector.manual.defaultGateway >>  0 & 0xff,
+                              (configSector.manual.defaultGateway >>  8 & 0xff),
+                              (configSector.manual.defaultGateway >> 16 & 0xff),
+                              (configSector.manual.defaultGateway >> 24 & 0xff));
+            IP4_ADDR(&netmask, configSector.manual.subnetMask >>  0 & 0xff,
+                              (configSector.manual.subnetMask >>  8 & 0xff),
+                              (configSector.manual.subnetMask >> 16 & 0xff),
+                              (configSector.manual.subnetMask >> 24 & 0xff));;
+        } else {
+            ipv4_dhcp = true;
+        }
+
+        if (configSector.dhcpFlags & NXDK_NETWORK_CONFIG_MANUAL_DNS) {
+            IP4_ADDR(&dns[0].u_addr.ip4, configSector.manual.primaryDns >>  0 & 0xff,
+                                 (configSector.manual.primaryDns >>  8 & 0xff),
+                                 (configSector.manual.primaryDns >> 16 & 0xff),
+                                 (configSector.manual.primaryDns >> 24 & 0xff));
+            IP4_ADDR(&dns[1].u_addr.ip4, configSector.manual.secondaryDns >>  0 & 0xff,
+                                 (configSector.manual.secondaryDns >>  8 & 0xff),
+                                 (configSector.manual.secondaryDns >> 16 & 0xff),
+                                 (configSector.manual.secondaryDns >> 24 & 0xff));
+            dns[0].type = IPADDR_TYPE_V4;
+            dns[1].type = IPADDR_TYPE_V4;
+            dns_override = true;
+        }
+    } else if (parameters->ipv4_mode == NX_NET_DHCP) {
+        ipv4_dhcp = true;
+    } else if (parameters->ipv4_mode == NX_NET_STATIC) {
+        ipv4_dhcp = false;
+        IP4_ADDR(&ipaddr, parameters->ipv4_ip >>  0 & 0xff,
+                         (parameters->ipv4_ip >>  8 & 0xff),
+                         (parameters->ipv4_ip >> 16 & 0xff),
+                         (parameters->ipv4_ip >> 24 & 0xff));
+        IP4_ADDR(&gateway, parameters->ipv4_gateway >>  0 & 0xff,
+                          (parameters->ipv4_gateway >>  8 & 0xff),
+                          (parameters->ipv4_gateway >> 16 & 0xff),
+                          (parameters->ipv4_gateway >> 24 & 0xff));
+        IP4_ADDR(&netmask, parameters->ipv4_netmask >>  0 & 0xff,
+                          (parameters->ipv4_netmask >>  8 & 0xff),
+                          (parameters->ipv4_netmask >> 16 & 0xff),
+                          (parameters->ipv4_netmask >> 24 & 0xff));
+    } else {
+        assert(false);
+        return -1;
+    }
+
+    if (ipv4_dhcp) {
+        IP4_ADDR(&gateway, 0, 0, 0, 0);
+        IP4_ADDR(&ipaddr, 0, 0, 0, 0);
+        IP4_ADDR(&netmask, 0, 0, 0, 0);
+    }
+
+    KEVENT tcpip_init_complete;
+    KeInitializeEvent(&tcpip_init_complete, SynchronizationEvent, FALSE);
+    tcpip_init(tcpip_init_done, &tcpip_init_complete);
+    KeWaitForSingleObject(&tcpip_init_complete, Executive, KernelMode, FALSE, NULL);
+
+    g_pnetif = &nforce_netif;
+    err_t err = netifapi_netif_add(&nforce_netif, &ipaddr, &netmask, &gateway, NULL, nforceif_init, ethernet_input);
+    if (err != ERR_OK) {
+        debugPrint("netif_add failed\n");
+        return -1;
+    }
+
+    netifapi_netif_set_default(&nforce_netif);
+    netifapi_netif_set_up(&nforce_netif);
+
+    packet_timer(NULL);
+
+    if (ipv4_dhcp) {
+        netifapi_dhcp_start(&nforce_netif);
+
+        LARGE_INTEGER duration;
+        duration.QuadPart = ((LONGLONG)1000) * -10000;
+        int i = 0;
+        while (dhcp_supplied_address(&nforce_netif) == 0) {
+            i++;
+            if (i == 10) {
+                return -2;
+            }
+            KeDelayExecutionThread(KernelMode, FALSE, &duration);
+        }
+    }
+
+    if (parameters) {
+        if (parameters->ipv4_dns1 != 0 || parameters->ipv4_dns2 != 0) {
+            IP4_ADDR(&dns[0].u_addr.ip4, parameters->ipv4_dns1 >>  0 & 0xff,
+                                 (parameters->ipv4_dns1 >>  8 & 0xff),
+                                 (parameters->ipv4_dns1 >> 16 & 0xff),
+                                 (parameters->ipv4_dns1 >> 24 & 0xff));
+            IP4_ADDR(&dns[1].u_addr.ip4, parameters->ipv4_dns2 >>  0 & 0xff,
+                                 (parameters->ipv4_dns2 >>  8 & 0xff),
+                                 (parameters->ipv4_dns2 >> 16 & 0xff),
+                                 (parameters->ipv4_dns2 >> 24 & 0xff));
+            dns[0].type = IPADDR_TYPE_V4;
+            dns[1].type = IPADDR_TYPE_V4;
+            dns_override = true;
+        }
+    }
+
+    if (dns_override) {
+        dns_setserver(2, dns);
+    }
+
+    return 0;
+}

--- a/lib/nxdk/net.h
+++ b/lib/nxdk/net.h
@@ -1,0 +1,31 @@
+#ifndef __NXDK_NET_H__
+#define __NXDK_NET_H__
+
+#include <stdint.h>
+
+typedef enum nx_net_mode_t_
+{
+    NX_NET_AUTO = 0,
+    NX_NET_DHCP,
+    NX_NET_STATIC
+} nx_net_mode_t;
+
+typedef struct nx_net_parameters_t_
+{
+    nx_net_mode_t ipv4_mode;
+    nx_net_mode_t ipv6_mode;
+
+    uint32_t ipv4_ip;
+    uint32_t ipv4_gateway;
+    uint32_t ipv4_netmask;
+    uint32_t ipv4_dns1;
+    uint32_t ipv4_dns2;
+    // TODO:
+    // ipv6 static ip fields
+} nx_net_parameters_t;
+
+int nxNetInit(const nx_net_parameters_t *parameters);
+int nxNetShutdown();
+
+
+#endif

--- a/samples/httpd/main.c
+++ b/samples/httpd/main.c
@@ -1,95 +1,20 @@
-#include "lwip/debug.h"
-#include "lwip/dhcp.h"
-#include "lwip/init.h"
-#include "lwip/netif.h"
-#include "lwip/sys.h"
-#include "lwip/tcpip.h"
-#include "lwip/timeouts.h"
-#include "netif/etharp.h"
-#include "pktdrv.h"
+#include <lwip/debug.h>
+#include <lwip/tcpip.h>
 #include <hal/video.h>
-#include <hal/xbox.h>
-#include <xboxkrnl/xboxkrnl.h>
 #include <hal/debug.h>
+#include <nxdk/net.h>
 
-#define USE_DHCP         1
-#define PKT_TMR_INTERVAL 5 /* ms */
 #define DEBUGGING        0
 
 #include "httpserver.h"
 
-struct netif nforce_netif, *g_pnetif;
-
-err_t nforceif_init(struct netif *netif);
-void http_server_netconn_init(void);
-static void packet_timer(void *arg);
-
-static void tcpip_init_done(void *arg)
-{
-	sys_sem_t *init_complete = arg;
-	sys_sem_signal(init_complete);
-}
-
-static void packet_timer(void *arg)
-{
-  LWIP_UNUSED_ARG(arg);
-  Pktdrv_ReceivePackets();
-  sys_timeout(PKT_TMR_INTERVAL, packet_timer, NULL);
-}
+extern struct netif *g_pnetif;
 
 int main(void)
 {
-	sys_sem_t init_complete;
-	const ip4_addr_t *ip;
-	static ip4_addr_t ipaddr, netmask, gw;
-
-#if DEBUGGING
-	asm volatile ("jmp .");
-	debug_flags = LWIP_DBG_ON;
-#else
-	debug_flags = 0;
-#endif
-
-#if USE_DHCP
-	IP4_ADDR(&gw, 0,0,0,0);
-	IP4_ADDR(&ipaddr, 0,0,0,0);
-	IP4_ADDR(&netmask, 0,0,0,0);
-#else
-	IP4_ADDR(&gw, 10,0,1,1);
-	IP4_ADDR(&ipaddr, 10,0,1,7);
-	IP4_ADDR(&netmask, 255,255,255,0);
-#endif
-
-	/* Initialize the TCP/IP stack. Wait for completion. */
-	sys_sem_new(&init_complete, 0);
-	tcpip_init(tcpip_init_done, &init_complete);
-	sys_sem_wait(&init_complete);
-	sys_sem_free(&init_complete);
-
 	XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
 
-	g_pnetif = netif_add(&nforce_netif, &ipaddr, &netmask, &gw,
-	                     NULL, nforceif_init, ethernet_input);
-	if (!g_pnetif) {
-		debugPrint("netif_add failed\n");
-		return 1;
-	}
-
-	netif_set_default(g_pnetif);
-	netif_set_up(g_pnetif);
-
-#if USE_DHCP
-	dhcp_start(g_pnetif);
-#endif
-
-	packet_timer(NULL);
-
-#if USE_DHCP
-	debugPrint("Waiting for DHCP...\n");
-	while (dhcp_supplied_address(g_pnetif) == 0)
-		NtYieldExecution();
-	debugPrint("DHCP bound!\n");
-#endif
+	nxNetInit(NULL);
 
 	debugPrint("\n");
 	debugPrint("IP address.. %s\n", ip4addr_ntoa(netif_ip4_addr(g_pnetif)));
@@ -99,6 +24,5 @@ int main(void)
 
 	http_server_netconn_init();
 	while (1) NtYieldExecution();
-	Pktdrv_Quit();
 	return 0;
 }

--- a/samples/httpd_bsd/main.c
+++ b/samples/httpd_bsd/main.c
@@ -1,48 +1,18 @@
 #include <lwip/debug.h>
-#include <lwip/dhcp.h>
-#include <lwip/init.h>
-#include <lwip/netif.h>
-#include <lwip/sys.h>
 #include <lwip/tcpip.h>
-#include <lwip/timeouts.h>
-#include <netif/etharp.h>
-#include <pktdrv.h>
 #include <hal/video.h>
-#include <hal/xbox.h>
-#include <xboxkrnl/xboxkrnl.h>
 #include <hal/debug.h>
+#include <nxdk/net.h>
 
-#define USE_DHCP         1
-#define PKT_TMR_INTERVAL 5 /* ms */
 #define DEBUGGING        0
 
 #include "httpserver.h"
 
-struct netif nforce_netif, *g_pnetif;
-
-err_t nforceif_init(struct netif *netif);
-void http_server_netconn_init(void);
-static void packet_timer(void *arg);
-
-static void tcpip_init_done(void *arg)
-{
-    sys_sem_t *init_complete = arg;
-    sys_sem_signal(init_complete);
-}
-
-static void packet_timer(void *arg)
-{
-    LWIP_UNUSED_ARG(arg);
-    Pktdrv_ReceivePackets();
-    sys_timeout(PKT_TMR_INTERVAL, packet_timer, NULL);
-}
+extern struct netif *g_pnetif;
 
 int main(void)
 {
     XVideoSetMode(640,480,32,REFRESH_DEFAULT);
-    sys_sem_t init_complete;
-    const ip4_addr_t *ip;
-    static ip4_addr_t ipaddr, netmask, gw;
 
 #if DEBUGGING
     asm volatile ("jmp .");
@@ -51,44 +21,7 @@ int main(void)
     debug_flags = 0;
 #endif
 
-#if USE_DHCP
-    IP4_ADDR(&gw, 0,0,0,0);
-    IP4_ADDR(&ipaddr, 0,0,0,0);
-    IP4_ADDR(&netmask, 0,0,0,0);
-#else
-    IP4_ADDR(&gw, 10,0,1,1);
-    IP4_ADDR(&ipaddr, 10,0,1,7);
-    IP4_ADDR(&netmask, 255,255,255,0);
-#endif
-
-    /* Initialize the TCP/IP stack. Wait for completion. */
-    sys_sem_new(&init_complete, 0);
-    tcpip_init(tcpip_init_done, &init_complete);
-    sys_sem_wait(&init_complete);
-    sys_sem_free(&init_complete);
-
-    g_pnetif = netif_add(&nforce_netif, &ipaddr, &netmask, &gw,
-                         NULL, nforceif_init, ethernet_input);
-    if (!g_pnetif) {
-        debugPrint("netif_add failed\n");
-        return 1;
-    }
-
-    netif_set_default(g_pnetif);
-    netif_set_up(g_pnetif);
-
-#if USE_DHCP
-    dhcp_start(g_pnetif);
-#endif
-
-    packet_timer(NULL);
-
-#if USE_DHCP
-    debugPrint("Waiting for DHCP...\n");
-    while (dhcp_supplied_address(g_pnetif) == 0)
-        NtYieldExecution();
-    debugPrint("DHCP bound!\n");
-#endif
+    nxNetInit(NULL);
 
     debugPrint("\n");
     debugPrint("IP address.. %s\n", ip4addr_ntoa(netif_ip4_addr(g_pnetif)));
@@ -97,6 +30,5 @@ int main(void)
     debugPrint("\n");
 
     http_server_bsd();
-    Pktdrv_Quit();
     return 0;
 }


### PR DESCRIPTION
This adds a new network initialization API, with the ability to read and use the settings from the HDD. This is a breaking change, and the samples have been adapted accordingly. When using this API, there shouldn't be another breaking change when our new NIC driver lands.
The three supported ways to initialize are `AUTO`, which will try to use the config sector (this is the same as passing `NULL` to `nxNetInit`), `DHCP`, and`STATIC`. All three modes allow overriding the DNS settings by setting the DNS fields to a non-null value.
The static IP fields are simple `uint32_t` to not introduce a dependency on headers from other libraries, especially since I plan to add a wrapper to provide the winsock API in the future.
A shutdown function is not provided because lwIP doesn't provide a way for the tcpip processing thread to quit.

To make building the libraries easier, the network code is now always built.
Most of the network config sector code comes from @LukeUsher.

/edit: IPv6 support for this API is not implemented yet. I plan to add this at a later time.