### PR TITLE
docs: Update pbkit license

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Copy one of the sample directories to get started. You can copy it anywhere you 
 Credits
 -------
 - [OpenXDK](https://web.archive.org/web/20170624051336/http://openxdk.sourceforge.net:80/) is the inspiration for nxdk, and large parts of it have been reused. (License: GPLv2)
-- Large parts of [pbkit](https://web.archive.org/web/20141024145308/http://forums.xbox-scene.com/index.php?/topic/573524-pbkit/), by openxdkman, are included, with modifications. (License: LGPL)
+- Large parts of [pbkit](https://web.archive.org/web/20141024145308/http://forums.xbox-scene.com/index.php?/topic/573524-pbkit/), by openxdkman, are included, with modifications. (License: MIT)
 - A network stack is included based on [lwIP](http://savannah.nongnu.org/projects/lwip/) (License: Modified BSD)
 - A libc is included based on [PDCLib](https://github.com/DevSolar/pdclib) (License: CC0)
 - Large parts of the runtime library are derived from LLVM's [compiler-rt](https://compiler-rt.llvm.org/) library (License: MIT)


### PR DESCRIPTION
As apart of https://github.com/XboxDev/nxdk/pull/554, pbkit was relicensed to MIT. This PR just updates the readme.