### PR TITLE
video: Add additional video defines

### DIFF
--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -211,8 +211,8 @@ BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p)
 	}
 	DWORD dwEnc = XVideoGetEncoderSettings();
 	
-	DWORD dwAdapter = dwEnc & 0x000000FF;
-	DWORD dwStandard = dwEnc & 0x0000FF00;
+	DWORD dwAdapter = dwEnc & VIDEO_ADAPTER_MASK;
+	DWORD dwStandard = dwEnc & VIDEO_STANDARD_MASK;
 
 	bool is_pal = (dwStandard == VIDEO_REGION_PAL);
 
@@ -229,7 +229,7 @@ BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p)
 	{
 		if(is_pal)
 		{
-			refresh = (dwEnc & 0x00400000) ? 60 : 50;
+			refresh = (dwEnc & VIDEO_60Hz) ? 60 : 50;
 		} else {
 			refresh = 60;
 		}
@@ -238,7 +238,7 @@ BOOLEAN XVideoListModes(VIDEO_MODE *vm, int bpp, int refresh, void **p)
 	{
 		pVidMode = &vidModes[position];
 
-		if((pVidMode->dwFlags & 0x000000FF) != dwAdapter)
+		if((pVidMode->dwFlags & VIDEO_ADAPTER_MASK) != dwAdapter)
 			continue;
 
 		if(pVidMode->dwStandard != dwStandard)

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -22,10 +22,17 @@ extern "C"
 #define VIDEO_ENC_FLICKERFILTER     11
 #define VIDEO_ENC_SOFTEN_FILTER     14
 
-// Defines for video resolution modes
+// Flags for video settings
 #define VIDEO_MODE_720P   0x20000
 #define VIDEO_MODE_1080I  0x40000
 #define VIDEO_MODE_480P   0x80000
+#define VIDEO_60Hz   0x400000
+#define VIDEO_50Hz   0x800000
+#define VIDEO_WIDESCREEN  0x010000
+#define VIDEO_LETTERBOX   0x100000
+
+#define VIDEO_ADAPTER_MASK  0x000000FF
+#define VIDEO_STANDARD_MASK 0x0000FF00
 
 //Defines for refresh rates
 #define REFRESH_50HZ                50


### PR DESCRIPTION
I had a need to read the widescreen video flag set by MSDash and realised we did not have this defined.

I took the liberty of adding some others and removed some of the magic numbers in video.c