### PR TITLE
winapi: Implement SetEndOfFile()

### DIFF
--- a/lib/winapi/fileapi.h
+++ b/lib/winapi/fileapi.h
@@ -31,6 +31,7 @@ BOOL SetFileTime (HANDLE hFile, const FILETIME *lpCreationTime, const FILETIME *
 HANDLE CreateFileA (LPCSTR lpFileName, DWORD dwDesiredAccess, DWORD dwShareMode, LPSECURITY_ATTRIBUTES lpSecurityAttributes, DWORD dwCreationDisposition, DWORD dwFlagsAndAttributes, HANDLE hTemplateFile);
 BOOL ReadFile (HANDLE hFile, LPVOID lpBuffer, DWORD nNumberOfBytesToRead, LPDWORD lpNumberOfBytesRead, LPOVERLAPPED lpOverlapped);
 BOOL WriteFile (HANDLE hFile, LPCVOID lpBuffer, DWORD nNumberOfBytesToWrite, LPDWORD lpNumberOfBytesWritten, LPOVERLAPPED lpOverlapped);
+BOOL SetEndOfFile (HANDLE hFile);
 DWORD SetFilePointer (HANDLE hFile, LONG lDistanceToMove, PLONG lpDistanceToMoveHigh, DWORD dwMoveMethod);
 BOOL SetFilePointerEx (HANDLE hFile, LARGE_INTEGER liDistanceToMove, PLARGE_INTEGER lpNewFilePointer, DWORD dwMoveMethod);
 


### PR DESCRIPTION
In agreement with @kosmas12 this supersedes #556. The code itself is rather old (May 2021, for some reason I didn't upstream it and forgot about it), I just rebased and tested it today.

Closes #471 

Simple test code (this will truncate the file `test.bin` in the same directory as the XBE, I tested with a 1MiB file full of zeroes):
```C
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    HANDLE h = CreateFile("D:\\test.bin", GENERIC_ALL, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
    if (h == INVALID_HANDLE_VALUE) {
        debugPrint("Error: %x\n", GetLastError());
        Sleep(10000);
        return 0;
    }

    SetFilePointer(h, 512*1024, NULL, FILE_BEGIN);
    SetEndOfFile(h);
    CloseHandle(h);

    debugPrint("Done!\n");
    Sleep(10000);

    return 0;
}
```