### PR TITLE
bin/nxdk-pkg-config: Fix bashism

### DIFF
--- a/bin/nxdk-pkg-config
+++ b/bin/nxdk-pkg-config
@@ -9,7 +9,7 @@ export PKG_CONFIG_PATH=""
 export PKG_CONFIG_SYSROOT_DIR=""
 export PKG_CONFIG_LIBDIR=${NXDK_DIR}/lib/pkgconfig:${NXDK_DIR}/share/pkgconfig
 
-[[ "$1" == '--version' ]] && exec pkg-config --version
+[ "$1" = '--version' ] && exec pkg-config --version
 exec pkg-config \
     --define-variable=NXDK_DIR=${NXDK_DIR} \
     --define-prefix \


### PR DESCRIPTION
It runs as `sh` and so should be POSIX shell compatible.