### PR TITLE
lib/fmt: New library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,3 +42,7 @@
 [submodule "lib/usb/libusbohci"]
 	path = lib/usb/libusbohci
 	url = https://github.com/XboxDev/libusbohci.git
+[submodule "lib/fmt/fmt"]
+	path = lib/fmt/fmt
+	url = https://github.com/glebm/fmt.git
+	branch = nxdk

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ QUIET=>/dev/null
 endif
 
 DEPS := $(filter %.c.d, $(SRCS:.c=.c.d))
+DEPS += $(filter %.cc.d, $(SRCS:.cc=.cc.d))
 DEPS += $(filter %.cpp.d, $(SRCS:.cpp=.cpp.d))
 
 $(OUTPUT_DIR)/default.xbe: main.exe $(OUTPUT_DIR) $(CXBE)
@@ -127,6 +128,10 @@ endif
 %.obj: %.cpp
 	@echo "[ CXX      ] $@"
 	$(VE) $(CXX) $(NXDK_CXXFLAGS) $(CXXFLAGS) -MD -MP -MT '$@' -MF '$(patsubst %.obj,%.cpp.d,$@)' -c -o '$@' '$<'
+
+%.obj: %.cc
+	@echo "[ CXX      ] $@"
+	$(VE) $(CXX) $(NXDK_CXXFLAGS) $(CXXFLAGS) -MD -MP -MT '$@' -MF '$(patsubst %.obj,%.cc.d,$@)' -c -o '$@' '$<'
 
 %.obj: %.c
 	@echo "[ CC       ] $@"

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -8,3 +8,4 @@ include $(NXDK_DIR)/lib/xboxrt/Makefile
 include $(NXDK_DIR)/lib/zlib/Makefile
 include $(NXDK_DIR)/lib/libpng/Makefile
 include $(NXDK_DIR)/lib/libjpeg/Makefile
+include $(NXDK_DIR)/lib/fmt/Makefile

--- a/lib/fmt/Makefile
+++ b/lib/fmt/Makefile
@@ -1,0 +1,18 @@
+FMT_DIR = $(NXDK_DIR)/lib/fmt/fmt
+
+FMT_SRCS = $(FMT_DIR)/src/format.cc \
+           $(FMT_DIR)/src/os.cc
+
+FMT_OBJS = $(addsuffix .obj, $(basename $(FMT_SRCS)))
+
+NXDK_CXXFLAGS += -I$(FMT_DIR)/include -I$(FMT_DIR)/src
+
+$(NXDK_DIR)/lib/fmt.lib: $(FMT_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/fmt.lib
+
+CLEANRULES += clean-fmt
+
+.PHONY: clean-fmt
+clean-fmt:
+	$(VE)rm -f $(FMT_OBJS) $(NXDK_DIR)/lib/fmt.lib

--- a/lib/pkgconfig/fmt.pc
+++ b/lib/pkgconfig/fmt.pc
@@ -1,0 +1,5 @@
+Name: fmt
+Description: A modern formatting library
+Version: 8.1.1
+Libs: ${NXDK_DIR}/lib/fmt.lib
+Cflags: -I${NXDK_DIR}/lib/fmt/fmt/include


### PR DESCRIPTION
libfmt/fmt requires some patching to make it work on NXDK

I've done the patching in my fork https://github.com/glebm/fmt/tree/nxdk

It'd be better to have the fork be in the XboxDev org but I don't have permissions to set it up (please feel free to do so)

Fixes #594