### PR TITLE
libc: Provide MS's _aligned_malloc() / _aligned_free()

### DIFF
--- a/lib/xboxrt/libc_extensions/stdlib_ext_.h
+++ b/lib/xboxrt/libc_extensions/stdlib_ext_.h
@@ -73,3 +73,13 @@ inline static lldiv_t div (long long __x, long long __y) _NXDK_NOEXCEPT
 #undef _NXDK_NOEXCEPT
 
 #endif
+
+static void *_aligned_malloc (size_t size, size_t alignment)
+{
+    return aligned_alloc(alignment, size);
+}
+
+static void _aligned_free (void *memblock)
+{
+    free(memblock);
+}


### PR DESCRIPTION
This should provide the necessary functionality to get libc++'s aligned `new` working. Depends on https://github.com/XboxDev/nxdk-pdclib/pull/52