### PR TITLE
build: Safety check env setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ ifeq ($(OUTPUT_DIR),)
 OUTPUT_DIR = bin
 endif
 
+ifeq ($(NXDK_ENV),)
+$(error Please setup your shell using $(NXDK_DIR)/bin/activate)
+endif
+
 UNAME_S := $(shell uname -s)
 UNAME_M := $(shell uname -m)
 

--- a/bin/activate
+++ b/bin/activate
@@ -14,6 +14,7 @@ fi
 
 export NXDK_DIR="${NXDK_DIR:-$(dirname $(dirname "$(${readlink_cmd} -f "$0")")../)}"
 export PATH="${NXDK_DIR}/bin:$PATH"
+export NXDK_ENV=1
 
 CLANG_VERSION=$(clang --version | grep version | grep -o -m 1 "[0-9]\+\.[0-9]\+\.*[0-9]*" | head -n 1)
 CLANG_VERSION_NUM=$(echo "$CLANG_VERSION" | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/')
@@ -25,6 +26,7 @@ fi
 if [ "$1" = "-s" ]; then cat <<- DONE
     export NXDK_DIR="$NXDK_DIR";
     export PATH="$PATH";
+    export NXDK_ENV=1;
 DONE
 else
     exec "${@:-${SHELL:-sh}}"


### PR DESCRIPTION
Hi 👋 

This PR adds a check to see if the environment has been set up for nxdk. If this is not the case, an error is issued and the user is informed.

The reason for this is that some users may not read how to use nxdk and simply run `make`; these now get a hint of what to do. Secondly, sometimes people simply forget how things are done or confuse their shells. In both cases, the build system no longer does `undefined behaviour`, but instead aborts.

I solved this by adding another environment variable called `NXDK_ENV` which is set when `bin/activate` is run. The main makefile checks this variable and throws an error if it is not present. 
The advantages of this approach are:
* Minimal change to the current build system. 
* If not desired, this check can be bypassed by running `NXDK_ENV=1 make foo`.

Disadvantages:
* Increases the complexity of the build system (another state to manage!).
* Even running `make clean` will now fail if the environment is not set up for nxdk

-----
(one could also imagine automatically running bin/activate when the env isn't set. I personally would dislike that)