### PR TITLE
nxdk: Add `extern "C"` in configsector.h

### DIFF
--- a/lib/nxdk/configsector.h
+++ b/lib/nxdk/configsector.h
@@ -9,6 +9,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define NXDK_NETWORK_CONFIG_MANUAL_IP 0x00000004
 #define NXDK_NETWORK_CONFIG_MANUAL_DNS 0x00000008
 
@@ -44,5 +48,9 @@ typedef struct
 } __attribute__ ((packed)) nxdk_network_config_sector_t;
 
 bool nxLoadNetworkConfig(nxdk_network_config_sector_t *config);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
I seem to have forgotten to add the usual `extern "C"` to this header back when I wrote it, this fixes that so it can be used and the declared function properly linked again from C++.