### PR TITLE
Replace pkdrv with nvnetdrv

### DIFF
--- a/lib/net/Makefile
+++ b/lib/net/Makefile
@@ -9,8 +9,8 @@ LWIPSRCS := $(COREFILES) \
             $(NETIFFILES)
 
 # Include driver sources
-DRIVERSRCS := $(NXDK_DIR)/lib/net/pktdrv/pktdrv.c \
-              $(NXDK_DIR)/lib/net/nforceif/src/driver.c \
+DRIVERSRCS := $(NXDK_DIR)/lib/net/nvnetdrv/nvnetdrv.c \
+              $(NXDK_DIR)/lib/net/nvnetdrv/nvnetdrv_lwip.c \
               $(NXDK_DIR)/lib/net/nforceif/src/sys_arch.c
 
 NET_SRCS := \
@@ -21,10 +21,10 @@ NET_OBJS = $(addsuffix .obj, $(basename $(NET_SRCS)))
 
 NXDK_CFLAGS += -I$(LWIPDIR)/include
 NXDK_CFLAGS += -I$(NXDK_DIR)/lib/net/nforceif/include
-NXDK_CFLAGS += -I$(NXDK_DIR)/lib/net/pktdrv
+NXDK_CFLAGS += -I$(NXDK_DIR)/lib/net/nvnetdrv
 NXDK_CXXFLAGS += -I$(LWIPDIR)/include
 NXDK_CXXFLAGS += -I$(NXDK_DIR)/lib/net/nforceif/include
-NXDK_CXXFLAGS += -I$(NXDK_DIR)/lib/net/pktdrv
+NXDK_CXXFLAGS += -I$(NXDK_DIR)/lib/net/nvnetdrv
 
 $(NXDK_DIR)/lib/libnxdk_net.lib: $(NET_OBJS)
 

--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -334,6 +334,7 @@
  * will fit into TCP's 16 bit field.
  */
 #define TCP_WND                         (45 * TCP_MSS)
+#define TCP_SND_BUF                     (TCP_WND)
 
 /*
    ----------------------------------

--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -1,0 +1,781 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2022 Ryan Wendland
+
+#include "nvnetdrv.h"
+#include "nvnetdrv_regs.h"
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+#define NVNET_MIN(a, b) (((a) < (b)) ? (a) : (b))
+#define NVNET_RX_EMPTY (NULL)
+
+struct __attribute__((packed)) descriptor_t
+{
+    uint32_t paddr;
+    uint16_t length;
+    uint16_t flags;
+};
+
+// Struct to hold user TX callback data
+struct tx_misc_t
+{
+    void *bufAddr;
+    size_t length;
+    nvnetdrv_tx_callback_t callback;
+    void *userdata;
+};
+
+// Struct to hold RX callback data
+struct rx_misc_t
+{
+    void *bufAddr;
+    size_t length;
+};
+
+#ifdef NVNETDRV_ENABLE_STATS
+struct nvnetdrv_stats_t
+{
+    uint32_t rx_interrupts;
+    uint32_t rx_extraByteErrors;
+    uint32_t tx_interrupts;
+    uint32_t phy_interrupts;
+    uint32_t rx_receivedPackets;
+    uint32_t rx_framingError;
+    uint32_t rx_overflowError;
+    uint32_t rx_crcError;
+    uint32_t rx_error4;
+    uint32_t rx_error3;
+    uint32_t rx_error2;
+    uint32_t rx_error1;
+    uint32_t rx_missedFrameError;
+};
+static struct nvnetdrv_stats_t nvnetdrv_stats;
+#define INC_STAT(statname, val) do {nvnetdrv_stats.statname += (val);} while(0);
+#else
+#define INC_STAT(statname, val)
+#endif
+
+// FIXME
+#define BASE ((void *)0xFEF00000)
+#define reg32(offset) (*((volatile uint32_t *)((uintptr_t)BASE + (offset))))
+
+// Manage NIC
+static atomic_bool g_running = false;
+static uint8_t g_ethAddr[6];
+static uint32_t g_linkSpeed;
+static ULONG g_irq;
+static KIRQL g_irql;
+static KDPC g_dpcObj;
+static KINTERRUPT g_interrupt;
+static HANDLE g_irqThread;
+static KEVENT g_irqEvent;
+
+// Manage RX ring
+static volatile struct descriptor_t *g_rxRingDescriptors;
+static KSEMAPHORE g_rxRingFreeDescriptors;
+static HANDLE g_rxRingRequeueThread;
+static size_t g_rxRingBeginIndex;
+static size_t g_rxRingEndIndex;
+static uint8_t *g_rxRingBuffers;
+static uint32_t g_rxRingBufferVtoP;
+
+// Manage RX buffer callbacks to user network stack
+static nvnetdrv_rx_callback_t g_rxCallback;
+static KSEMAPHORE g_rxCallbackQueued;
+static HANDLE g_rxCallbackThread;
+struct rx_misc_t *g_rxCallbackQueue;
+static size_t g_rxCallbackEndIndex;
+
+// Manage RX buffer pool to supply RX ring
+static void **g_rxBuffPool;
+static size_t g_rxBuffPoolHead;
+static size_t g_rxBuffCnt;
+static RTL_CRITICAL_SECTION g_rxBuffPoolLock;
+static KSEMAPHORE g_rxFreeBuffers;
+
+// Manage TX ring
+static volatile struct descriptor_t *g_txRingDescriptors;
+static size_t g_txRingBeginIndex;
+static atomic_size_t g_txRingEndIndex;
+static atomic_size_t g_txRingDescriptorsInUseCount;
+static KSEMAPHORE g_txRingFreeDescriptors;
+struct tx_misc_t tx_misc[TX_RING_SIZE];
+
+// Time constants used in nvnetdrv
+static LARGE_INTEGER no_sleep = {.QuadPart = 0};
+static LARGE_INTEGER tenmicros = {.QuadPart = -100};
+static LARGE_INTEGER fiftymicros = {.QuadPart = -500};
+
+static void nvnetdrv_rx_push (void *buffer_virt)
+{
+    RtlEnterCriticalSection(&g_rxBuffPoolLock);
+    g_rxBuffPool[++g_rxBuffPoolHead] = buffer_virt;
+    RtlLeaveCriticalSection(&g_rxBuffPoolLock);
+    KeReleaseSemaphore(&g_rxFreeBuffers, IO_NETWORK_INCREMENT, 1, FALSE);
+}
+
+static void *nvnetdrv_rx_pop (void)
+{
+    void *p;
+    KeWaitForSingleObject(&g_rxFreeBuffers, Executive, KernelMode, FALSE, NULL);
+    RtlEnterCriticalSection(&g_rxBuffPoolLock);
+    p = g_rxBuffPool[g_rxBuffPoolHead--];
+    RtlLeaveCriticalSection(&g_rxBuffPoolLock);
+    return p;
+}
+
+static inline void nvnetdrv_irq_disable (void)
+{
+    reg32(NvRegIrqMask) = 0;
+}
+
+static inline void nvnetdrv_irq_enable (void)
+{
+    reg32(NvRegIrqMask) = NVREG_IRQMASK_THROUGHPUT;
+}
+
+static BOOLEAN NTAPI nvnetdrv_isr (PKINTERRUPT Interrupt, PVOID ServiceContext)
+{
+    nvnetdrv_irq_disable();
+    KeInsertQueueDpc(&g_dpcObj, NULL, NULL);
+    return TRUE;
+}
+
+static void NTAPI nvnetdrv_dpc (PKDPC Dpc, PVOID DeferredContext, PVOID arg1, PVOID arg2)
+{
+    KeSetEvent(&g_irqEvent, IO_NETWORK_INCREMENT, FALSE);
+}
+
+static inline uint32_t nvnetdrv_rx_ptov (uint32_t phys_address)
+{
+    return (phys_address == 0) ? 0 : (phys_address + g_rxRingBufferVtoP);
+}
+
+static inline uint32_t nvnetdrv_rx_vtop (uint32_t virt_address)
+{
+    return (virt_address == 0) ? 0 : (virt_address - g_rxRingBufferVtoP);
+}
+
+static void nvnetdrv_rx_requeue (size_t buffer_index)
+{
+    assert(buffer_index < RX_RING_SIZE);
+    void *rx_buff = nvnetdrv_rx_pop();
+    assert (rx_buff != NULL);
+    g_rxRingDescriptors[buffer_index].paddr = nvnetdrv_rx_vtop((uint32_t)rx_buff);
+    g_rxRingDescriptors[buffer_index].length = NVNET_RX_BUFF_LEN;
+    g_rxRingDescriptors[buffer_index].flags = NV_RX_AVAIL;
+}
+
+static void nvnetdrv_handle_rx_irq (void)
+{
+    LONG freed_descriptors = 0;
+
+    while (g_rxRingDescriptors[g_rxRingBeginIndex].paddr != NVNET_RX_EMPTY) {
+
+        volatile struct descriptor_t *rx_packet = &g_rxRingDescriptors[g_rxRingBeginIndex];
+        uint16_t flags = rx_packet->flags;
+
+        if (flags & NV_RX_AVAIL) {
+            // Reached a descriptor that still belongs to the NIC
+            break;
+        }
+
+        if ((flags & NV_RX_DESCRIPTORVALID) == 0) {
+            goto release_packet;
+        }
+
+        if (!(flags & NV_RX_ERROR) || (flags & NV_RX_FRAMINGERR)) {
+            uint16_t packet_length = rx_packet->length;
+
+            if (flags & NV_RX_SUBTRACT1) {
+                INC_STAT(rx_extraByteErrors, 1);
+                if (packet_length > 0)
+                    packet_length--;
+            }
+
+            if (flags & NV_RX_FRAMINGERR) {
+                INC_STAT(rx_framingError, 1);
+            }
+
+            INC_STAT(rx_receivedPackets, 1);
+
+            // Queue a pending RX callback. We dont want to call it directly from the IRQ thread
+            // incase the users network stack blocks in the callback.
+            g_rxCallbackQueue[g_rxCallbackEndIndex].length = packet_length;
+            g_rxCallbackQueue[g_rxCallbackEndIndex].bufAddr = (void *)nvnetdrv_rx_ptov(rx_packet->paddr);
+            g_rxCallbackEndIndex = (g_rxCallbackEndIndex + 1) % g_rxBuffCnt;
+            KeReleaseSemaphore(&g_rxCallbackQueued, IO_NETWORK_INCREMENT, 1, FALSE);
+            goto next_packet;
+        }
+        else
+        {
+            if (flags & NV_RX_MISSEDFRAME) INC_STAT(rx_missedFrameError, 1);
+            if (flags & NV_RX_OVERFLOW) INC_STAT(rx_overflowError, 1);
+            if (flags & NV_RX_CRCERR) INC_STAT(rx_crcError, 1);
+            if (flags & NV_RX_ERROR4) INC_STAT(rx_error4, 1);
+            if (flags & NV_RX_ERROR3) INC_STAT(rx_error3, 1);
+            if (flags & NV_RX_ERROR2) INC_STAT(rx_error2, 1);
+            if (flags & NV_RX_ERROR1) INC_STAT(rx_error1, 1);
+            goto release_packet;
+        }
+
+    //On error drop packet and release buffer
+    release_packet:
+        nvnetdrv_rx_release((void *)nvnetdrv_rx_ptov(rx_packet->paddr));
+        // Fallthrough
+    //A successful RX the packet is passed to user but we clear it from the RX ring which will be repopulated with
+    //a spare RX buffer if available to keep data flowing while the user holds their buffer.
+    next_packet:
+        rx_packet->paddr = NVNET_RX_EMPTY;
+        freed_descriptors++;
+        g_rxRingBeginIndex = (g_rxRingBeginIndex + 1) % RX_RING_SIZE;
+    }
+    KeReleaseSemaphore(&g_rxRingFreeDescriptors, IO_NETWORK_INCREMENT, freed_descriptors, FALSE);
+    INC_STAT(rx_interrupts, 1);
+}
+
+static void nvnetdrv_handle_tx_irq (void)
+{
+    LONG freed_descriptors = 0;
+
+    while (g_txRingDescriptorsInUseCount > 0) {
+        uint16_t flags = g_txRingDescriptors[g_txRingBeginIndex].flags;
+
+        if (flags & NV_TX_VALID) {
+            // We reached a descriptor that wasn't processed by hw yet
+            // Re-init the transfer to ensure the NIC sends it
+            reg32(NvRegTxRxControl) = NVREG_TXRXCTL_KICK;
+            break;
+        }
+
+        // Buffers get locked before sending and unlocked after sending
+        MmLockUnlockBufferPages(tx_misc[g_txRingBeginIndex].bufAddr, tx_misc[g_txRingBeginIndex].length, TRUE);
+
+        // If registered, call the users tx complete callback funciton.
+        if (tx_misc[g_txRingBeginIndex].callback) {
+            tx_misc[g_txRingBeginIndex].callback(tx_misc[g_txRingBeginIndex].userdata);
+        }
+
+        freed_descriptors++;
+        g_txRingBeginIndex = (g_txRingBeginIndex + 1) % TX_RING_SIZE;
+        g_txRingDescriptorsInUseCount--;
+    }
+
+    KeReleaseSemaphore(&g_txRingFreeDescriptors, IO_NETWORK_INCREMENT, freed_descriptors, FALSE);
+    INC_STAT(tx_interrupts, 1);
+}
+
+static void nvnetdrv_handle_mii_irq (uint32_t miiStatus, bool init)
+{
+    uint32_t adapterControl = reg32(NvRegAdapterControl);
+    uint32_t linkState = PhyGetLinkState(!init);
+
+    if (miiStatus & NVREG_MIISTAT_LINKCHANGE) {
+        nvnetdrv_stop_txrx();
+    }
+
+    if (linkState & XNET_ETHERNET_LINK_10MBPS) {
+        g_linkSpeed = NVREG_LINKSPEED_10MBPS;
+    } else {
+        g_linkSpeed = NVREG_LINKSPEED_100MBPS;
+    }
+
+    if (linkState & XNET_ETHERNET_LINK_FULL_DUPLEX) {
+        reg32(NvRegDuplexMode) &= NVREG_DUPLEX_MODE_FDMASK;
+    } else {
+        reg32(NvRegDuplexMode) |= NVREG_DUPLEX_MODE_HDFLAG;
+    }
+
+    if (miiStatus & NVREG_MIISTAT_LINKCHANGE) {
+        nvnetdrv_start_txrx();
+    }
+
+    INC_STAT(phy_interrupts, 1);
+}
+
+static void nvnetdrv_handle_irq (void)
+{
+    while (true)
+    {
+        uint32_t irq = reg32(NvRegIrqStatus);
+        uint32_t mii = reg32(NvRegMIIStatus);
+
+        //No interrupts left to handle. Leave
+        if (!irq && !mii)
+            break;
+
+        // Acknowledge interrupts
+        reg32(NvRegMIIStatus) = mii;
+        reg32(NvRegIrqStatus) = irq;
+
+        // Handle interrupts
+        if (irq & NVREG_IRQ_RX_ALL) {
+            nvnetdrv_handle_rx_irq();
+        }
+        if (irq & NVREG_IRQ_TX_ALL) {
+            nvnetdrv_handle_tx_irq();
+        }
+        if (irq & NVREG_IRQ_LINK) {
+            nvnetdrv_handle_mii_irq(mii, false);
+        }
+    }
+}
+
+static void NTAPI irq_thread(PKSTART_ROUTINE StartRoutine, PVOID StartContext)
+{
+    (void)StartRoutine;
+    (void)StartContext;
+
+    while (true) {
+        KeWaitForSingleObject(&g_irqEvent, Executive, KernelMode, FALSE, NULL);
+        if (!g_running) break;
+
+        nvnetdrv_handle_irq();
+        nvnetdrv_irq_enable();
+    }
+
+    PsTerminateSystemThread(0);
+}
+
+static void NTAPI rxrequeue_thread(PKSTART_ROUTINE StartRoutine, PVOID StartContext)
+{
+    (void)StartRoutine;
+    (void)StartContext;
+
+    while (true) {
+        //Sleep until there is an empty descriptor in the RX ring
+        if (!g_running) break;
+        KeWaitForSingleObject(&g_rxRingFreeDescriptors, Executive, KernelMode, FALSE, NULL);
+        if (!g_running) break;
+
+        do {
+            nvnetdrv_rx_requeue(g_rxRingEndIndex);
+            g_rxRingEndIndex = (g_rxRingEndIndex + 1) % RX_RING_SIZE;
+        } while (g_running &&
+                 KeWaitForSingleObject(&g_rxRingFreeDescriptors, Executive,
+                                       KernelMode, FALSE, &no_sleep) == STATUS_SUCCESS);
+    }
+    PsTerminateSystemThread(0);
+}
+
+static void NTAPI rxcallback_thread(PKSTART_ROUTINE StartRoutine, PVOID StartContext)
+{
+    (void)StartRoutine;
+    (void)StartContext;
+
+    size_t idx = 0;
+
+    while (true) {
+        //Sleep until there is an RX callback that needs processing
+        if (!g_running) break;
+        KeWaitForSingleObject(&g_rxCallbackQueued, Executive, KernelMode, FALSE, NULL);
+        if (!g_running) break;
+
+        do {
+            g_rxCallback(g_rxCallbackQueue[idx].bufAddr, g_rxCallbackQueue[idx].length);
+            idx = (idx + 1) % g_rxBuffCnt;
+        } while (g_running &&
+                 KeWaitForSingleObject(&g_rxCallbackQueued, Executive,
+                                       KernelMode, FALSE, &no_sleep) == STATUS_SUCCESS);
+    }
+    PsTerminateSystemThread(0);
+}
+
+const uint8_t *nvnetdrv_get_ethernet_addr ()
+{
+    return g_ethAddr;
+}
+
+int nvnetdrv_init(size_t rx_buffer_count, nvnetdrv_rx_callback_t rx_callback)
+{
+    assert(!g_running);
+    assert(rx_callback);
+    assert(rx_buffer_count > 1);
+
+    g_rxCallback = rx_callback;
+    g_rxBuffCnt = rx_buffer_count;
+
+    // Get Mac Address from EEPROM
+    ULONG type;
+    NTSTATUS status = ExQueryNonVolatileSetting(XC_FACTORY_ETHERNET_ADDR, &type, &g_ethAddr, 6, NULL);
+    if (!NT_SUCCESS(status)) {
+        return NVNET_NO_MAC;
+    }
+
+    // Allocate memory for TX and RX ring descriptors.
+    void *descriptors = MmAllocateContiguousMemoryEx((RX_RING_SIZE + TX_RING_SIZE) * sizeof(struct descriptor_t),
+                                                     0, 0xFFFFFFFF, 0, PAGE_READWRITE);
+    if (!descriptors) {
+        return NVNET_NO_MEM;
+    }
+
+    // Allocate memory for RX buffers. TX buffers are supplied by the user.
+    g_rxRingBuffers = MmAllocateContiguousMemoryEx(g_rxBuffCnt * NVNET_RX_BUFF_LEN,
+                                               0, 0xFFFFFFFF, 0, PAGE_READWRITE);
+    if (!g_rxRingBuffers) {
+        MmFreeContiguousMemory(descriptors);
+        return NVNET_NO_MEM;
+    }
+
+    // Allocate memory for storing our push/pop stack for spare RX buffer
+    g_rxBuffPool = (void **)malloc(g_rxBuffCnt * sizeof(void *));
+    if (!g_rxBuffPool) {
+        MmFreeContiguousMemory(descriptors);
+        MmFreeContiguousMemory(g_rxRingBuffers);
+        return NVNET_NO_MEM;
+    }
+
+    // Allocate memory for storing complete RX transfers, ready for callbacks.
+    g_rxCallbackQueue = malloc(g_rxBuffCnt * sizeof(struct rx_misc_t));
+    if (!g_rxCallbackQueue) {
+        MmFreeContiguousMemory(descriptors);
+        MmFreeContiguousMemory(g_rxRingBuffers);
+        free(g_rxBuffPool);
+        return NVNET_NO_MEM;
+    }
+
+    RtlZeroMemory(descriptors, (RX_RING_SIZE + TX_RING_SIZE) * sizeof(struct descriptor_t));
+    RtlZeroMemory(g_rxCallbackQueue, g_rxBuffCnt * sizeof(struct rx_misc_t));
+    RtlZeroMemory(g_rxBuffPool, g_rxBuffCnt * sizeof(void *));
+
+    // Reset NIC. MSDash delays 10us here
+    nvnetdrv_stop_txrx();
+    reg32(NvRegTxRxControl) = NVREG_TXRXCTL_RESET;
+    KeDelayExecutionThread(KernelMode, FALSE, &tenmicros);
+    reg32(NvRegTxRxControl) = 0;
+    KeDelayExecutionThread(KernelMode, FALSE, &tenmicros);
+
+    // Disable interrupts while we initialise the NIC
+    reg32(NvRegIrqMask) = 0;
+    reg32(NvRegMIIMask) = 0;
+
+    // Acknowledge any existing interrupts status bits
+    reg32(NvRegTransmitterStatus) = reg32(NvRegTransmitterStatus);
+    reg32(NvRegReceiverStatus) = reg32(NvRegReceiverStatus);
+    reg32(NvRegIrqStatus) = reg32(NvRegIrqStatus);
+    reg32(NvRegMIIStatus) = reg32(NvRegMIIStatus);
+
+    // Clear latent registers
+    reg32(NvRegWakeUpFlags) = 0;
+    reg32(NvRegPollingControl) = 0;
+    reg32(NvRegTransmitPoll) = 0;
+    reg32(NvRegLinkSpeed) = 0;
+
+    // Reset local ring tracking variables
+    g_rxRingBeginIndex = 0;
+    g_txRingBeginIndex = 0;
+    g_txRingEndIndex = 0;
+    g_txRingDescriptorsInUseCount = 0;
+    g_rxCallbackEndIndex = 0;
+    RtlZeroMemory(tx_misc, sizeof(tx_misc));
+
+    // Setup the TX and RX ring descriptor pointers
+    g_rxRingDescriptors = (struct descriptor_t *)descriptors;
+    g_txRingDescriptors = (struct descriptor_t *)descriptors + RX_RING_SIZE;
+
+    // Remember the offset between virtual and physical address
+    g_rxRingBufferVtoP = ((uint32_t)g_rxRingBuffers) - (uint32_t)MmGetPhysicalAddress(g_rxRingBuffers);
+
+    // Setup some fixed registers for the NIC
+    reg32(NvRegMacAddrA) = (g_ethAddr[0] << 0) | (g_ethAddr[1] << 8) | (g_ethAddr[2] << 16) | (g_ethAddr[3] << 24);
+    reg32(NvRegMacAddrB) = (g_ethAddr[4] << 0) | (g_ethAddr[5] << 8);
+    reg32(NvRegMulticastAddrA) = NVREG_MCASTMASKA_NONE;
+    reg32(NvRegMulticastAddrB) = NVREG_MCASTMASKB_NONE;
+    reg32(NvRegMulticastMaskA) = NVREG_MCASTMASKA_NONE;
+    reg32(NvRegMulticastMaskB) = NVREG_MCASTMASKB_NONE;
+    reg32(NvRegOffloadConfig) = NVREG_OFFLOAD_NORMAL;
+    reg32(NvRegPacketFilterFlags) = NVREG_PFF_ALWAYS_MYADDR;
+    reg32(NvRegDuplexMode) = NVREG_DUPLEX_MODE_FORCEH;
+
+    //Pseudo random slot time to minimise collisions
+    reg32(NvRegSlotTime) = ((rand() % 0xFF) & NVREG_SLOTTIME_MASK) | NVREG_SLOTTIME_10_100_FULL;
+    reg32(NvRegTxDeferral) = NVREG_TX_DEFERRAL_RGMII_10_100;
+    reg32(NvRegRxDeferral) = NVREG_RX_DEFERRAL_DEFAULT;
+
+    // MS Dash does this and sets up both these registers with 0x300010)
+    reg32(NvRegUnknownSetupReg7) = NVREG_UNKSETUP7_VAL1; //RxWatermark?
+    reg32(NvRegTxWatermark) = NVREG_UNKSETUP7_VAL1;
+
+    // Point the NIC to our TX and RX ring buffers. NIC expects Ring size as size-1.
+    reg32(NvRegTxRingPhysAddr) = MmGetPhysicalAddress((void *)g_txRingDescriptors);
+    reg32(NvRegRxRingPhysAddr) = MmGetPhysicalAddress((void *)g_rxRingDescriptors);
+    reg32(NvRegRingSizes) = ((RX_RING_SIZE - 1) << NVREG_RINGSZ_RXSHIFT) |
+                            ((TX_RING_SIZE - 1) << NVREG_RINGSZ_TXSHIFT);
+
+    // Prepare for Phy Init
+    reg32(NvRegAdapterControl) = (1 << NVREG_ADAPTCTL_PHYSHIFT) | NVREG_ADAPTCTL_PHYVALID;
+    reg32(NvRegMIISpeed) = NVREG_MIISPEED_BIT8 | NVREG_MIIDELAY;
+    reg32(NvRegMIIMask) = NVREG_MII_LINKCHANGE;
+    KeDelayExecutionThread(KernelMode, FALSE, &fiftymicros);
+
+    // Initialise the transceiver
+    if (PhyInitialize(FALSE, NULL) != STATUS_SUCCESS) {
+        MmFreeContiguousMemory(descriptors);
+        MmFreeContiguousMemory(g_rxRingBuffers);
+        free(g_rxCallbackQueue);
+        return NVNET_PHY_ERR;
+    }
+
+    // Short delay to allow the phy to startup. MSDash delays 50us
+    reg32(NvRegAdapterControl) |= NVREG_ADAPTCTL_RUNNING;
+    KeDelayExecutionThread(KernelMode, FALSE, &fiftymicros);
+
+    // The NIC hardware IRQ queues a DPC. The DPC then sets g_irqEvent.
+    // g_irqEvent is monitored by irqthread to handle the IRQ
+    g_irq = HalGetInterruptVector(4, &g_irql);
+    KeInitializeInterrupt(&g_interrupt, &nvnetdrv_isr, NULL, g_irq, g_irql, LevelSensitive, TRUE);
+    KeInitializeDpc(&g_dpcObj, nvnetdrv_dpc, NULL);
+    KeInitializeEvent(&g_irqEvent, SynchronizationEvent, FALSE);
+
+    // We use semaphores to track the number of free TX and RX ring descriptors, the number of free RX buffers
+    // available to be queued in the RX ring and the number of pending rx callbacks.
+    KeInitializeSemaphore(&g_txRingFreeDescriptors, TX_RING_SIZE, TX_RING_SIZE);
+    KeInitializeSemaphore(&g_rxRingFreeDescriptors, RX_RING_SIZE, RX_RING_SIZE);
+    KeInitializeSemaphore(&g_rxFreeBuffers, 0, g_rxBuffCnt);
+    KeInitializeSemaphore(&g_rxCallbackQueued, 0, g_rxBuffCnt);
+
+    // Setup the push/pop stack for all our RX buffers. RX buffers are stored here until they can
+    // be pushed into the RX ring. We need to handle the case where the user supplies less buffers
+    // than can fit in the RX ring, also if excess (spare) buffers are supplied.
+    g_rxBuffPoolHead = -1;
+    RtlInitializeCriticalSection(&g_rxBuffPoolLock);
+    for (uint32_t i = 0; i < g_rxBuffCnt; i++) {
+        nvnetdrv_rx_push(g_rxRingBuffers + (i * NVNET_RX_BUFF_LEN));
+    }
+
+    // Fill our rx ring descriptor. g_rxBuffCnt may be less than the ring size, so only fill what we can.
+    for (uint32_t i = 0; i < NVNET_MIN(g_rxBuffCnt, RX_RING_SIZE); i++) {
+        KeWaitForSingleObject(&g_rxRingFreeDescriptors, Executive, KernelMode, FALSE, NULL);
+        nvnetdrv_rx_requeue(i);
+    }
+
+    // g_rxRingEndIndex stores the position in the RX ring that is empty or about to be empty on the next packet.
+    g_rxRingEndIndex = NVNET_MIN(g_rxBuffCnt, RX_RING_SIZE) % RX_RING_SIZE;
+
+    // Get link speed settings from Phy
+    nvnetdrv_handle_mii_irq(0, true);
+
+    // Set running flag. This needs to happen before we connect the irq and start threads.
+    bool prev_value = atomic_exchange(&g_running, true);
+    assert(!prev_value);
+
+    // Create a minimal stack, no TLS thread to handle NIC events
+    PsCreateSystemThreadEx(&g_irqThread, 0, 4096, 0, NULL, NULL, NULL, FALSE, FALSE, irq_thread);
+
+    // Create a minimal stack, no TLS thread to handle NIC RX ring buffer re-queing
+    PsCreateSystemThreadEx(&g_rxRingRequeueThread, 0, 4096, 0, NULL, NULL, NULL, FALSE, FALSE, rxrequeue_thread);
+
+    // Create a minimal stack, no TLS thread to handle NIC RX callbacks to user application
+    PsCreateSystemThreadEx(&g_rxCallbackThread, 0, 4096, 0, NULL, NULL, NULL, FALSE, FALSE, rxcallback_thread);
+
+    // Connect the NIC IRQ to the ISR
+    status = KeConnectInterrupt(&g_interrupt);
+    if (!NT_SUCCESS(status)) {
+        nvnetdrv_stop();
+        return NVNET_SYS_ERR;
+    }
+
+    // Start getting and sending data
+    nvnetdrv_irq_enable();
+    nvnetdrv_start_txrx();
+
+    return NVNET_OK;
+}
+
+void nvnetdrv_stop(void)
+{
+    assert(g_running);
+
+    KeDisconnectInterrupt(&g_interrupt);
+
+    // Disable DMA and wait for it to idle, re-checking every 50 microseconds
+    reg32(NvRegTxRxControl) = NVREG_TXRXCTL_DISABLE;
+    for (int i = 0; i < 10000; i++) {
+        if (reg32(NvRegTxRxControl) & NVREG_TXRXCTL_IDLE) {
+            break;
+        }
+        KeDelayExecutionThread(KernelMode, FALSE, &fiftymicros);
+    }
+
+    //Stop NIC processing rings
+    nvnetdrv_stop_txrx();
+
+    //Clear the nvnet running flag so threads know to end
+    bool prev_value = atomic_exchange(&g_running, false);
+    assert(prev_value);
+
+    // End the IRQ event-handling thread
+    KeSetEvent(&g_irqEvent, IO_NETWORK_INCREMENT, FALSE);
+    NtWaitForSingleObject(g_irqThread, FALSE, NULL);
+    NtClose(g_irqThread);
+
+    // Pass back all TX buffers to user.
+    for (int i = 0; i < TX_RING_SIZE; i++) {
+        if (tx_misc[i].callback) {
+            tx_misc[i].callback(tx_misc[i].userdata);
+        }
+    }
+
+    // Free all TX descriptors g_txRingFreeDescriptors so nvnetdrv_acquire_tx_descriptors will return.
+    KeReleaseSemaphore(&g_txRingFreeDescriptors, IO_NETWORK_INCREMENT, g_txRingDescriptorsInUseCount, NULL);
+
+    // End rxrequeue_thread
+    nvnetdrv_rx_push(g_rxRingBuffers); //Just push a buffer into stack so we dont get stuck waiting for one
+    KeReleaseSemaphore(&g_rxRingFreeDescriptors, IO_NETWORK_INCREMENT, 1, NULL);
+    NtWaitForSingleObject(g_rxRingRequeueThread, FALSE, NULL);
+    NtClose(g_rxRingRequeueThread);
+
+    // End rxcallback_thread
+    KeReleaseSemaphore(&g_rxCallbackQueued, IO_NETWORK_INCREMENT, 1, NULL);
+    NtWaitForSingleObject(g_rxCallbackThread, FALSE, NULL);
+    NtClose(g_rxCallbackThread);
+
+    // Reset TX & RX control
+    reg32(NvRegTxRxControl) = NVREG_TXRXCTL_DISABLE | NVREG_TXRXCTL_RESET;
+    KeDelayExecutionThread(KernelMode, FALSE, &tenmicros);
+    reg32(NvRegTxRxControl) = NVREG_TXRXCTL_DISABLE;
+
+    // Free all memory allocated by nvnetdrv
+    RtlDeleteCriticalSection(&g_rxBuffPoolLock);
+    MmFreeContiguousMemory((void *)g_rxRingDescriptors);
+    MmFreeContiguousMemory((void *)g_rxRingBuffers);
+    free(g_rxCallbackQueue);
+    free(g_rxBuffPool);
+}
+
+void nvnetdrv_start_txrx (void)
+{
+    reg32(NvRegLinkSpeed) = g_linkSpeed | NVREG_LINKSPEED_FORCE;
+    reg32(NvRegTransmitterControl) |= NVREG_XMITCTL_START;
+    reg32(NvRegReceiverControl) |= NVREG_RCVCTL_START;
+    reg32(NvRegTxRxControl) = NVREG_TXRXCTL_KICK | NVREG_TXRXCTL_GET;
+}
+
+void nvnetdrv_stop_txrx (void)
+{
+    reg32(NvRegReceiverControl) &= ~NVREG_RCVCTL_START;
+    reg32(NvRegTransmitterControl) &= ~NVREG_XMITCTL_START;
+
+    //Wait for active TX and RX descriptors to finish
+    for (int i = 0; i < 50000; i++) {
+        if (!((reg32(NvRegReceiverStatus) & NVREG_RCVSTAT_BUSY) ||
+              (reg32(NvRegTransmitterStatus) & NVREG_XMITSTAT_BUSY))) {
+            break;
+        }
+        KeDelayExecutionThread(KernelMode, FALSE, &tenmicros);
+    }
+
+    reg32(NvRegLinkSpeed) = 0;
+    reg32(NvRegTransmitPoll) = 0;
+}
+
+int nvnetdrv_acquire_tx_descriptors (size_t count)
+{
+    NTSTATUS status;
+
+    // Sanity check
+    assert(count > 0);
+    // Avoid excessive requests
+    assert(count <= 4);
+
+    if (!g_running)
+        return false;
+
+    while (true) {
+        // Wait for TX descriptors to become available
+        KeWaitForSingleObject(&g_txRingFreeDescriptors, Executive, KernelMode, FALSE, NULL);
+
+        if (!g_running) return false;
+
+        // We want to try claim all tx descriptors at once without sleeping.
+        size_t i = 0;
+        for (i = 0; i < count - 1; i++) {
+            // Try to acquire remaining descriptors without sleeping
+            status = KeWaitForSingleObject(&g_txRingFreeDescriptors, Executive, KernelMode, FALSE, &no_sleep);
+            if (!NT_SUCCESS(status) || status == STATUS_TIMEOUT) {
+                // Couldn't acquire all at once, back off
+                KeReleaseSemaphore(&g_txRingFreeDescriptors, IO_NETWORK_INCREMENT, i + 1, NULL);
+                if (status == STATUS_TIMEOUT) {
+                    // Sleep for 10 microseconds to avoid immediate re-locking
+                    KeDelayExecutionThread(UserMode, FALSE, &tenmicros);
+                    // Retry
+                    break;
+                } else {
+                    return false;
+                }
+            }
+        }
+
+        if (!g_running) return false;
+
+        //If we have claimed all the tx descriptors. We are done.
+        if (i == (count - 1))
+            break;
+    }
+    return true;
+}
+
+void nvnetdrv_submit_tx_descriptors (nvnetdrv_descriptor_t *buffers, size_t count)
+{
+    // Sanity check
+    assert(count > 0);
+    // Avoid excessive requests
+    assert(count <= 4);
+
+    if (!g_running)
+        return;
+
+    // Check that no buffer crosses a page boundary
+    for (size_t i = 0; i < count; i++) {
+        // For 4KiB pages, the least significant 12 bits are intra-page offsets, so shift them away and compare the rest
+        assert(((uint32_t)buffers[i].addr >> 12) == (((uint32_t)buffers[i].addr + buffers[i].length - 1) >> 12));
+    }
+
+    // We don't check for buffer overrun here, because the Semaphore already protects us
+    size_t descriptors_index = g_txRingEndIndex;
+    while (!atomic_compare_exchange_weak(&g_txRingEndIndex, &descriptors_index,
+                                         (descriptors_index + count) % TX_RING_SIZE));
+
+    for (size_t i = 0; i < count; i++) {
+        size_t current_descriptor_index = (descriptors_index + i) % TX_RING_SIZE;
+
+        tx_misc[current_descriptor_index].bufAddr = buffers[i].addr;
+        tx_misc[current_descriptor_index].length = buffers[i].length;
+        tx_misc[current_descriptor_index].userdata = buffers[i].userdata;
+        tx_misc[current_descriptor_index].callback = buffers[i].callback;
+
+        // Buffers get locked before sending and unlocked after sending
+        MmLockUnlockBufferPages(buffers[i].addr, buffers[i].length, FALSE);
+        g_txRingDescriptors[current_descriptor_index].paddr = MmGetPhysicalAddress(buffers[i].addr);
+        g_txRingDescriptors[current_descriptor_index].length = buffers[i].length - 1;
+        g_txRingDescriptors[current_descriptor_index].flags = (i != 0 ? NV_TX_VALID : 0);
+    }
+
+    // Terminate descriptor chain
+    g_txRingDescriptors[(descriptors_index + count - 1) % TX_RING_SIZE].flags |= NV_TX_LASTPACKET;
+
+    // Enable first descriptor last to keep the NIC from sending incomplete packets
+    g_txRingDescriptors[descriptors_index].flags |= NV_TX_VALID;
+
+    // Keep track of how many descriptors are in use
+    g_txRingDescriptorsInUseCount += count;
+
+    // Inform that NIC that we have TX packet waiting
+    reg32(NvRegTxRxControl) = NVREG_TXRXCTL_KICK;
+}
+
+void nvnetdrv_rx_release (void *buffer_virt)
+{
+    assert(buffer_virt != NULL);
+
+    if (!g_running)
+        return;
+
+    nvnetdrv_rx_push(buffer_virt);
+}

--- a/lib/net/nvnetdrv/nvnetdrv.h
+++ b/lib/net/nvnetdrv/nvnetdrv.h
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2022 Ryan Wendland
+
+#ifndef __NVNETDRV_H__
+#define __NVNETDRV_H__
+
+#include <stddef.h>
+#include <stdint.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+#ifndef RX_RING_SIZE
+#define RX_RING_SIZE 64
+#endif
+#ifndef TX_RING_SIZE
+#define TX_RING_SIZE 64
+#endif
+
+// Must be greated than max thernet frame size. A multiple of page size prevents page boundary crossing
+#define NVNET_RX_BUFF_LEN (PAGE_SIZE / 2)
+
+// NVNET error codes
+#define NVNET_OK 0
+#define NVNET_NO_MEM -1
+#define NVNET_NO_MAC -2
+#define NVNET_PHY_ERR -3
+#define NVNET_SYS_ERR -4
+
+typedef void (*nvnetdrv_rx_callback_t) (void *buffer, uint16_t length);
+typedef void (*nvnetdrv_tx_callback_t) (void *userdata);
+
+typedef struct _nvnetdrv_descriptor_t
+{
+    void *addr;
+    size_t length;
+    nvnetdrv_tx_callback_t callback;
+    void *userdata;
+} nvnetdrv_descriptor_t;
+
+/**
+ * Temporarily stop sending and receiving ethernet packets. TX packets will be held. RX packets will be dropped.
+ */
+void nvnetdrv_stop_txrx (void);
+
+/**
+ * Resume sending and receiving ethernet packets after nvnetdrv_stop_txrx();
+ */
+void nvnetdrv_start_txrx (void);
+
+/**
+ * Initialised the low level NIC hardware.
+ * @param rx_buffer_count The number of receive buffers to reserve. This should be atleast two.
+ * Recommend this this equal to or greater than RX_RING_SIZE.
+ * @param rx_callback. Pointer to a callback function that is called when a new packet is received by the NIC.
+ * @return NVNET_OK or the error.
+ */
+int nvnetdrv_init (size_t rx_buffer_count, nvnetdrv_rx_callback_t rx_callback);
+
+/**
+ * Stop the low level NIC hardware. Should be called after nvnetdrv_init() to shutdown the NIC hardware.
+ */
+void nvnetdrv_stop (void);
+
+/**
+ * Returns the ethernet MAC Address.
+ * @return A pointer to an array containing the 6 byte ethernet MAC address.
+ */
+const uint8_t *nvnetdrv_get_ethernet_addr ();
+
+/**
+ * Reserves 1-4 descriptors. If the requested number is not immediately available,
+ * this function will block until the request can be satisfied. This should be called prior to nvnetdrv_submit_tx_descriptors
+ * This function is thread-safe.
+ * @param count The number of descriptors to reserve
+ * @return Zero if the reservation failed, non-zero if it succeeded.
+ */
+int nvnetdrv_acquire_tx_descriptors (size_t count);
+
+/**
+ * Queues a packet, which consists of 1-4 buffers, for sending. The descriptors for this
+ * need to be allocated beforehand using nvnetdrv_acquire_tx_descriptors()/
+ * This function is thread-safe.
+ * @param buffers Pointer to an array of buffers which will be queued for sending as a packet
+ * @param count The number of buffers to queue
+ */
+void nvnetdrv_submit_tx_descriptors (nvnetdrv_descriptor_t *buffers, size_t count);
+
+/**
+ * Releases an RX buffer given out by nvnetdrv. All RX buffers need to be
+ * released eventually, or the NIC will run out of buffers to use.
+ * This function is thread-safe.
+ * @param buffer_virt Pointer to the buffer given out by nvnetdrv.
+ */
+void nvnetdrv_rx_release(void *buffer_virt);
+
+#endif

--- a/lib/net/nvnetdrv/nvnetdrv_lwip.c
+++ b/lib/net/nvnetdrv/nvnetdrv_lwip.c
@@ -1,0 +1,276 @@
+// SPDX-License-Identifier: BSD
+
+// SPDX-FileCopyrightText: 2001-2004 Swedish Institute of Computer Science.
+// SPDX-FileCopyrightText: 2015 Matt Borgerson
+// SPDX-FileCopyrightText: 2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2022 Ryan Wendland
+
+#include "lwip/opt.h"
+#include "lwip/def.h"
+#include "lwip/mem.h"
+#include "lwip/pbuf.h"
+#include "lwip/stats.h"
+#include "lwip/sys.h"
+#include "lwip/snmp.h"
+#include "lwip/ethip6.h"
+#include "lwip/mld6.h"
+#include "netif/etharp.h"
+#include "netif/ppp/pppoe.h"
+#include "nvnetdrv.h"
+#include <xboxkrnl/xboxkrnl.h>
+#include <assert.h>
+
+/* Define those to better describe your network interface. */
+#define IFNAME0 'x'
+#define IFNAME1 'b'
+#define RX_BUFF_CNT (RX_RING_SIZE)
+
+
+#define LINK_SPEED_OF_YOUR_NETIF_IN_BPS 100 * 1000 * 1000 /* 100 Mbps */
+
+static struct netif *g_pnetif;
+/**
+ * Helper struct to hold private data used to operate your ethernet interface.
+ * Keeping the ethernet address of the MAC in this struct is not necessary
+ * as it is already kept in the struct netif.
+ * But this is only an example, anyway...
+ */
+struct nforceif
+{
+    struct eth_addr *ethaddr;
+    /* Add whatever per-interface state that is needed here. */
+};
+
+/**
+ * Create a memory pool of rx pbufs
+ * RX buffers are linked to a custom pbuf during its lifecycle in lwip stack.
+ * When the user has finished with the pbuf, it is freed by custom_free_function to allow the NIC to reuse the buffer
+ * This is entirely zero-copy.
+ * */
+typedef struct
+{
+    struct pbuf_custom p;
+    void *buff;
+} rx_pbuf_t;
+
+LWIP_MEMPOOL_DECLARE(RX_POOL, RX_BUFF_CNT, sizeof(rx_pbuf_t), "Zero-copy RX PBUF pool");
+void rx_pbuf_free_callback(struct pbuf *p)
+{
+    rx_pbuf_t *rx_pbuf = (rx_pbuf_t *)p;
+    nvnetdrv_rx_release(rx_pbuf->buff);
+    LWIP_MEMPOOL_FREE(RX_POOL, rx_pbuf);
+}
+
+void rx_callback(void *buffer, uint16_t length)
+{
+    rx_pbuf_t *rx_pbuf = (rx_pbuf_t *)LWIP_MEMPOOL_ALLOC(RX_POOL);
+    LWIP_ASSERT("RX_POOL full\n", rx_pbuf != NULL);
+    rx_pbuf->p.custom_free_function = rx_pbuf_free_callback;
+    rx_pbuf->buff = buffer;
+    struct pbuf *p = pbuf_alloced_custom(PBUF_RAW,
+                                        length + ETH_PAD_SIZE,
+                                        PBUF_REF,
+                                        &rx_pbuf->p,
+                                        buffer - ETH_PAD_SIZE,
+                                        NVNET_RX_BUFF_LEN - ETH_PAD_SIZE);
+
+    if (g_pnetif->input(p, g_pnetif) != ERR_OK) {
+        pbuf_free(p);
+        nvnetdrv_rx_release(buffer);
+    }
+}
+
+/**
+ * In this function, the hardware should be initialized.
+ * Called from nforceif_init().
+ *
+ * @param netif the already initialized lwip network interface structure
+ * for this nforceif
+ */
+static void low_level_init(struct netif *netif)
+{
+    if (nvnetdrv_init(RX_BUFF_CNT, rx_callback) < 0) {
+        abort();
+    }
+
+    /* set MAC hardware address length */
+    netif->hwaddr_len = ETHARP_HWADDR_LEN;
+
+    /* set MAC hardware address */
+    memcpy(netif->hwaddr, nvnetdrv_get_ethernet_addr(), 6);
+
+    /* maximum transfer unit */
+    netif->mtu = 1500;
+
+    /* device capabilities */
+    /* don't set NETIF_FLAG_ETHARP if this device is not an ethernet one */
+    netif->flags = NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_LINK_UP;
+
+#if LWIP_IPV6 && LWIP_IPV6_MLD
+    /*
+     * For hardware/netifs that implement MAC filtering.
+     * All-nodes link-local is handled by default, so we must let the hardware know
+     * to allow multicast packets in.
+     * Should set mld_mac_filter previously. */
+    if (netif->mld_mac_filter != NULL)
+    {
+        ip6_addr_t ip6_allnodes_ll;
+        ip6_addr_set_allnodes_linklocal(&ip6_allnodes_ll);
+        netif->mld_mac_filter(netif, &ip6_allnodes_ll, NETIF_ADD_MAC_FILTER);
+    }
+#endif /* LWIP_IPV6 && LWIP_IPV6_MLD */
+    g_pnetif = netif;
+}
+
+/**
+ * This function gets registered as callback function to free pbufs after the
+ * NIC driver is done sending their contents.
+ *
+ * @param userdata the pbuf address, supplied by low_level_output
+ */
+void tx_pbuf_free_callback(void *userdata)
+{
+    struct pbuf *p = (struct pbuf *)userdata;
+    pbuf_free(p);
+}
+
+/**
+ * This function should do the actual transmission of the packet. The packet is
+ * contained in the pbuf that is passed to the function. This pbuf
+ * might be chained.
+ *
+ * @param netif the lwip network interface structure for this nforceif
+ * @param p the MAC packet to send (e.g. IP packet including MAC addresses and type)
+ * @return ERR_OK if the packet could be sent
+ *                 an err_t value if the packet couldn't be sent
+ *
+ * @note Returning ERR_MEM here if a DMA queue of your MAC is full can lead to
+ *             strange results. You might consider waiting for space in the DMA queue
+ *             to become available since the stack doesn't retry to send a packet
+ *             dropped because of memory failure (except for the TCP timers).
+ */
+
+static err_t low_level_output(struct netif *netif, struct pbuf *p)
+{
+#if ETH_PAD_SIZE
+    pbuf_header(p, -ETH_PAD_SIZE); /* drop the padding word */
+#endif
+
+    nvnetdrv_descriptor_t descriptors[4];
+    size_t pbufCount = 0;
+    for (struct pbuf *q = p; q != NULL; q = q->next)
+    {
+        assert(p->len < 4096);
+        descriptors[pbufCount].addr = q->payload;
+        descriptors[pbufCount].length = q->len;
+        descriptors[pbufCount].callback = NULL;
+
+        pbufCount++;
+        if (pbufCount > 4)
+            return ERR_MEM;
+
+        const uint32_t addr_start = (uint32_t)q->payload;
+        const uint32_t addr_end = ((uint32_t)q->payload + q->len);
+        if (addr_start >> 12 != addr_end >> 12) {
+            // Buffer crosses a page boundary
+            const uint32_t addr_boundary = (addr_end & 0xFFFFF000);
+            const uint32_t length_a = addr_boundary - addr_start;
+            const uint32_t length_b = addr_end - addr_boundary;
+
+            // Buffer ends right at page boundary, so no problem
+            if (length_b == 0)
+                continue;
+
+            // Fixup the descriptor
+            descriptors[pbufCount - 1].length = length_a;
+
+            // Queue another descriptor for the remainder
+            descriptors[pbufCount].addr = (void *)addr_boundary;
+            descriptors[pbufCount].length = length_b;
+            descriptors[pbufCount].callback = NULL;
+
+            pbufCount++;
+            if (pbufCount > 4)
+                return ERR_MEM;
+        }
+    }
+
+    // Last descriptor gets the callback to free the pbufs
+    descriptors[pbufCount - 1].userdata = (void *)p;
+    descriptors[pbufCount - 1].callback = tx_pbuf_free_callback;
+
+    int r = nvnetdrv_acquire_tx_descriptors(pbufCount);
+    if (!r) {
+        return ERR_MEM;
+    }
+
+#if ETH_PAD_SIZE
+    pbuf_header(p, ETH_PAD_SIZE); /* reclaim the padding word */
+#endif
+
+    // Increase pbuf refcount so they don't get freed while the NIC requires them
+    pbuf_ref(p);
+
+    nvnetdrv_submit_tx_descriptors(descriptors, pbufCount);
+
+    LINK_STATS_INC(link.xmit);
+
+    return ERR_OK;
+}
+
+/**
+ * Should be called at the beginning of the program to set up the
+ * network interface. It calls the function low_level_init() to do the
+ * actual setup of the hardware.
+ *
+ * This function should be passed as a parameter to netif_add().
+ *
+ * @param netif the lwip network interface structure for this nforceif
+ * @return ERR_OK if the loopif is initialized
+ *                 ERR_MEM if private data couldn't be allocated
+ *                 any other err_t on error
+ */
+err_t nvnetif_init(struct netif *netif)
+{
+    struct nforceif *nforceif;
+
+    LWIP_ASSERT("netif != NULL", (netif != NULL));
+
+    nforceif = mem_malloc(sizeof(struct nforceif));
+    if (nforceif == NULL) {
+        LWIP_DEBUGF(NETIF_DEBUG, ("nforceif_init: out of memory\n"));
+        return ERR_MEM;
+    }
+
+#if LWIP_NETIF_HOSTNAME
+    /* Initialize interface hostname */
+    netif->hostname = "lwip";
+#endif /* LWIP_NETIF_HOSTNAME */
+
+    /*
+     * Initialize the snmp variables and counters inside the struct netif.
+     * The last argument should be replaced with your link speed, in units
+     * of bits per second.
+     */
+    MIB2_INIT_NETIF(netif, snmp_ifType_ethernet_csmacd, LINK_SPEED_OF_YOUR_NETIF_IN_BPS);
+
+    netif->state = nforceif;
+    netif->name[0] = IFNAME0;
+    netif->name[1] = IFNAME1;
+    /* We directly use etharp_output() here to save a function call.
+     * You can instead declare your own function an call etharp_output()
+     * from it if you have to do some checks before sending (e.g. if link
+     * is available...) */
+    netif->output = etharp_output;
+#if LWIP_IPV6
+    netif->output_ip6 = ethip6_output;
+#endif /* LWIP_IPV6 */
+    netif->linkoutput = low_level_output;
+
+    nforceif->ethaddr = (struct eth_addr *)&(netif->hwaddr[0]);
+
+    /* initialize the hardware */
+    low_level_init(netif);
+
+    return ERR_OK;
+}

--- a/lib/net/nvnetdrv/nvnetdrv_regs.h
+++ b/lib/net/nvnetdrv/nvnetdrv_regs.h
@@ -1,0 +1,205 @@
+enum {
+    NvRegIrqStatus = 0x000,
+    NvRegIrqMask = 0x004,
+#define NVREG_IRQ_RX_ERROR       0x0001
+#define NVREG_IRQ_RX             0x0002
+#define NVREG_IRQ_RX_NOBUF       0x0004
+#define NVREG_IRQ_TX_ERROR       0x0008
+#define NVREG_IRQ_TX_OK          0x0010
+#define NVREG_IRQ_TIMER          0x0020
+#define NVREG_IRQ_LINK           0x0040
+#define NVREG_IRQ_RX_FORCED      0x0080
+#define NVREG_IRQ_TX_FORCED      0x0100
+#define NVREG_IRQMASK_THROUGHPUT (NVREG_IRQ_RX_ERROR | NVREG_IRQ_RX | NVREG_IRQ_RX_NOBUF | \
+                                  NVREG_IRQ_TX_ERROR | NVREG_IRQ_TX_OK | NVREG_IRQ_LINK | NVREG_IRQ_RX_FORCED)
+#define NVREG_IRQMASK_CPU        (NVREG_IRQ_TIMER | NVREG_IRQ_LINK)
+#define NVREG_IRQ_TX_ALL         (NVREG_IRQ_TX_ERROR | NVREG_IRQ_TX_OK | NVREG_IRQ_TX_FORCED)
+#define NVREG_IRQ_RX_ALL         (NVREG_IRQ_RX_ERROR | NVREG_IRQ_RX | NVREG_IRQ_RX_NOBUF | NVREG_IRQ_RX_FORCED)
+#define NVREG_IRQ_OTHER          (NVREG_IRQ_TIMER | NVREG_IRQ_LINK)
+#define NVREG_IRQ_MASK           0x1FF
+
+    NvRegPollingControl = 0x008,
+#define NVREG_POLL_ENABLED 3
+#define NVREG_POLL_DISABLED 0
+
+/*
+ * NVREG_POLL_DEFAULT is the interval length of the timer source on the nic
+ * NVREG_POLL_DEFAULT=97 would result in an interval length of 1 ms
+ */
+    NvRegPollingInterval = 0x00c,
+#define NVREG_POLL_DEFAULT_THROUGHPUT 970
+#define NVREG_POLL_DEFAULT_CPU        013
+
+    NvRegDuplexMode = 0x080,
+#define NVREG_DUPLEX_MODE_HDFLAG 0x00000002
+#define NVREG_DUPLEX_MODE_FORCEF 0x003B0F3C
+#define NVREG_DUPLEX_MODE_FORCEH 0x003B0F3E
+#define NVREG_DUPLEX_MODE_FDMASK 0xFFFFFFFD
+
+    NvRegTransmitterControl = 0x084,
+#define NVREG_XMITCTL_START 0x01
+
+    NvRegTransmitterStatus = 0x088,
+#define NVREG_XMITSTAT_BUSY 0x01
+
+// FIXME:  This could use some investigating
+    NvRegPacketFilterFlags = 0x08c,
+#define NVREG_PFF_ALWAYS        0x7F0008
+#define NVREG_PFF_PROMISC       0x000080
+#define NVREG_PFF_MYADDR        0x000020
+#define NVREG_PFF_ALWAYS_MYADDR 0x7F0020
+
+// FIXME: xnic disagrees?
+    NvRegOffloadConfig = 0x090,
+#define NVREG_OFFLOAD_HOMEPHY 0x601
+#define NVREG_OFFLOAD_NORMAL  0x5EE
+
+    NvRegReceiverControl = 0x094,
+#define NVREG_RCVCTL_START 0x01
+
+    NvRegReceiverStatus = 0x098,
+#define NVREG_RCVSTAT_BUSY 0x01
+
+// FIXME: check if better data available
+	NvRegSlotTime = 0x9c,
+#define NVREG_SLOTTIME_LEGBF_ENABLED 0x80000000
+#define NVREG_SLOTTIME_10_100_FULL   0x00007f00
+#define NVREG_SLOTTIME_1000_FULL     0x0003ff00
+#define NVREG_SLOTTIME_HALF          0x0000ff00
+#define NVREG_SLOTTIME_DEFAULT       0x00007f00
+#define NVREG_SLOTTIME_MASK          0x000000ff
+
+    NvRegTxDeferral = 0x0A0,
+#define NVREG_TX_DEFERRAL_RGMII_10_100 0x16070F
+
+    NvRegRxDeferral = 0x0A4,
+#define NVREG_RX_DEFERRAL_DEFAULT 0x16
+
+    NvRegMacAddrA = 0x0A8,
+    NvRegMacAddrB = 0x0AC,
+    NvRegMulticastAddrA = 0x0B0,
+#define NVREG_MCASTADDRA_FORCE 0x01
+    NvRegMulticastAddrB = 0x0B4,
+    NvRegMulticastMaskA = 0x0B8,
+#define NVREG_MCASTMASKA_NONE 0xffffffff
+    NvRegMulticastMaskB = 0x0BC,
+#define NVREG_MCASTMASKB_NONE 0xffff
+
+    NvRegPhyInterface = 0x0C0,
+#define PHY_RGMII 0x10000000
+
+    NvRegTxRingPhysAddr = 0x100,
+    NvRegRxRingPhysAddr = 0x104,
+    NvRegRingSizes = 0x108, // NOTE: these are size-1!
+#define NVREG_RINGSZ_TXSHIFT 0
+#define NVREG_RINGSZ_RXSHIFT 16
+
+    NvRegTransmitPoll = 0x10c,
+#define NVREG_TRANSMITPOLL_MAC_ADDR_REV	0x00008000
+
+    NvRegLinkSpeed = 0x110,
+#define NVREG_LINKSPEED_FORCE    0x10000
+#define NVREG_LINKSPEED_10MBPS   1000
+#define NVREG_LINKSPEED_100MBPS  100
+#define NVREG_LINKSPEED_1000MBPS 50
+#define NVREG_LINKSPEED_MASK     0xFFF
+
+    NvRegUnknownSetupReg5 = 0x130,
+#define NVREG_UNKSETUP5_BIT31 (1 << 31)
+
+    NvRegTxWatermark = 0x13c,
+#define NVREG_TX_WM_DESC1_DEFAULT	0x0200010
+#define NVREG_TX_WM_DESC2_3_DEFAULT	0x1e08000
+#define NVREG_TX_WM_DESC2_3_1000	0xfe08000
+
+// FIXME: used in pktdrv, but not forcedeth
+    NvRegUnknownSetupReg7 = 0x140,
+#define NVREG_UNKSETUP7_VAL1 0x300010
+
+    NvRegTxRxControl = 0x144,
+#define NVREG_TXRXCTL_KICK      0x0001
+#define NVREG_TXRXCTL_GET       0x0002 // NOTE: changed it
+#define NVREG_TXRXCTL_DISABLE   0x0004 // NOTE: changed it
+#define NVREG_TXRXCTL_IDLE      0x0008
+#define NVREG_TXRXCTL_RESET     0x0010
+#define NVREG_TXRXCTL_RXCHECK   0x0400
+#define NVREG_TXRXCTL_DESC_1    0x0000
+#define NVREG_TXRXCTL_DESC_2    0x2100
+#define NVREG_TXRXCTL_DESC_3    0x2200
+#define NVREG_TXRXCTL_VLANSTRIP 0x0040
+#define NVREG_TXRXCTL_VLANINS   0x0080
+
+    NvRegMIIStatus          = 0x180,
+#define NVREG_MIISTAT_ERROR      0x0001
+#define NVREG_MIISTAT_LINKCHANGE 0x0008
+#define NVREG_MIISTAT_MASK       0x000F
+#define NVREG_MIISTAT_MASK2      0x000F
+
+    NvRegMIIMask = 0x184,
+#define NVREG_MII_LINKCHANGE 0x0008
+
+    NvRegAdapterControl = 0x188,
+#define NVREG_ADAPTCTL_START    0x02
+#define NVREG_ADAPTCTL_LINKUP   0x04
+#define NVREG_ADAPTCTL_PHYVALID 0x40000
+#define NVREG_ADAPTCTL_RUNNING  0x100000
+#define NVREG_ADAPTCTL_PHYSHIFT 24
+
+    NvRegMIISpeed = 0x18c,
+#define NVREG_MIISPEED_BIT8 (1 << 8)
+#define NVREG_MIIDELAY 5
+    NvRegMIIControl = 0x190,
+#define NVREG_MIICTL_INUSE     0x08000
+#define NVREG_MIICTL_WRITE     0x00400
+#define NVREG_MIICTL_ADDRSHIFT 5
+    NvRegMIIData = 0x194,
+
+    NvRegWakeUpFlags = 0x200,
+#define NVREG_WAKEUPFLAGS_VAL               0x7770
+#define NVREG_WAKEUPFLAGS_BUSYSHIFT         24
+#define NVREG_WAKEUPFLAGS_ENABLESHIFT       16
+#define NVREG_WAKEUPFLAGS_D3SHIFT           12
+#define NVREG_WAKEUPFLAGS_D2SHIFT           8
+#define NVREG_WAKEUPFLAGS_D1SHIFT           4
+#define NVREG_WAKEUPFLAGS_D0SHIFT           0
+#define NVREG_WAKEUPFLAGS_ACCEPT_MAGPAT     0x01
+#define NVREG_WAKEUPFLAGS_ACCEPT_WAKEUPPAT  0x02
+#define NVREG_WAKEUPFLAGS_ACCEPT_LINKCHANGE 0x04
+#define NVREG_WAKEUPFLAGS_ENABLE            0x1111
+
+    NvRegPatternCRC = 0x204,
+    NvRegPatternMask = 0x208,
+
+    //Additional NVRegs obtained from monitoring Xbox HW:
+    NvRegTxCount        = 0x114, //Counts up with transmits?
+    NvRegRxCount        = 0x118, //Counts up with receives
+    NvRegCurrentTxRdesc = 0x11C, //Pointer to the current TX ring descriptor (struct descriptor_t)
+    NvRegCurrentRxRdesc = 0x120, //Pointer to the current RX ring descriptor (struct descriptor_t)
+    NvRegCurrentTxBuff  = 0x124, //Pointer to the current TX data buffer.
+    NvRegCurrentRxBuff  = 0x12C, //Pointer to the current RX data buffer.
+    NvRegNextTxRdesc    = 0x134, //Pointer to the next TX ring descriptor (struct descriptor_t)
+    NvRegNextRxRdesc    = 0x138, //Pointer to the next RX ring descriptor (struct descriptor_t)
+};
+
+#define NV_TX_LASTPACKET       (1 <<  0)
+#define NV_TX_RETRYERROR       (1 <<  3)
+#define NV_TX_FORCED_INTERRUPT (1 <<  8)
+#define NV_TX_DEFERRED         (1 << 10)
+#define NV_TX_CARRIERLOST      (1 << 11)
+#define NV_TX_LATECOLLISION    (1 << 12)
+#define NV_TX_UNDERFLOW        (1 << 13)
+#define NV_TX_ERROR            (1 << 14)
+#define NV_TX_VALID            (1 << 15)
+
+#define NV_RX_DESCRIPTORVALID (1 <<  0)
+#define NV_RX_MISSEDFRAME     (1 <<  1)
+#define NV_RX_SUBTRACT1       (1 <<  2)
+#define NV_RX_ERROR1          (1 <<  7)
+#define NV_RX_ERROR2          (1 <<  8)
+#define NV_RX_ERROR3          (1 <<  9)
+#define NV_RX_ERROR4          (1 << 10)
+#define NV_RX_CRCERR          (1 << 11)
+#define NV_RX_OVERFLOW        (1 << 12)
+#define NV_RX_FRAMINGERR      (1 << 13)
+#define NV_RX_ERROR           (1 << 14)
+#define NV_RX_AVAIL           (1 << 15)

--- a/lib/nxdk/net.c
+++ b/lib/nxdk/net.c
@@ -15,11 +15,10 @@
 #include <lwip/netifapi.h>
 #include <lwip/tcpip.h>
 #include <lwip/timeouts.h>
-#include <pktdrv.h>
 #include <xboxkrnl/xboxkrnl.h>
 
 
-err_t nforceif_init(struct netif *netif);
+err_t nvnetif_init(struct netif *netif);
 
 struct netif *g_pnetif;
 static struct netif nforce_netif;
@@ -28,13 +27,6 @@ static void tcpip_init_done(void *arg)
 {
     KEVENT *init_complete = arg;
     KeSetEvent(init_complete, IO_NO_INCREMENT, FALSE);
-}
-
-static void packet_timer(void *arg)
-{
-    LWIP_UNUSED_ARG(arg);
-    Pktdrv_ReceivePackets();
-    sys_timeout(5 /* ms */, packet_timer, NULL);
 }
 
 int nxNetInit(const nx_net_parameters_t *parameters)
@@ -114,7 +106,7 @@ int nxNetInit(const nx_net_parameters_t *parameters)
     KeWaitForSingleObject(&tcpip_init_complete, Executive, KernelMode, FALSE, NULL);
 
     g_pnetif = &nforce_netif;
-    err_t err = netifapi_netif_add(&nforce_netif, &ipaddr, &netmask, &gateway, NULL, nforceif_init, tcpip_input);
+    err_t err = netifapi_netif_add(&nforce_netif, &ipaddr, &netmask, &gateway, NULL, nvnetif_init, tcpip_input);
     if (err != ERR_OK) {
         debugPrint("netif_add failed\n");
         return -1;
@@ -122,8 +114,6 @@ int nxNetInit(const nx_net_parameters_t *parameters)
 
     netifapi_netif_set_default(&nforce_netif);
     netifapi_netif_set_up(&nforce_netif);
-
-    packet_timer(NULL);
 
     if (ipv4_dhcp) {
         netifapi_dhcp_start(&nforce_netif);

--- a/lib/nxdk/net.c
+++ b/lib/nxdk/net.c
@@ -114,7 +114,7 @@ int nxNetInit(const nx_net_parameters_t *parameters)
     KeWaitForSingleObject(&tcpip_init_complete, Executive, KernelMode, FALSE, NULL);
 
     g_pnetif = &nforce_netif;
-    err_t err = netifapi_netif_add(&nforce_netif, &ipaddr, &netmask, &gateway, NULL, nforceif_init, ethernet_input);
+    err_t err = netifapi_netif_add(&nforce_netif, &ipaddr, &netmask, &gateway, NULL, nforceif_init, tcpip_input);
     if (err != ERR_OK) {
         debugPrint("netif_add failed\n");
         return -1;

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -2418,10 +2418,16 @@ XBAPI NTSTATUS NTAPI PhyInitialize
     PVOID param OPTIONAL
 );
 
+#define XNET_ETHERNET_LINK_ACTIVE 0x01
+#define XNET_ETHERNET_LINK_100MBPS 0x02
+#define XNET_ETHERNET_LINK_10MBPS 0x04
+#define XNET_ETHERNET_LINK_FULL_DUPLEX 0x08
+#define XNET_ETHERNET_LINK_HALF_DUPLEX 0x10
+
 /**
  * Returns link status information either from NIC registers or from the last value cached by the kernel
  * @param update If FALSE, the kernel returns the cached value, otherwise the hardware is polled and the cached value updated
- * @return Flags describing the status of the NIC
+ * @return Flags describing the status of the NIC. See XNET_ETHERNET_LINK bit masks.
  */
 XBAPI DWORD NTAPI PhyGetLinkState
 (


### PR DESCRIPTION
This is a replacement network driver that intends to improve network performance of nxdk and replace pktdrv. Will close https://github.com/XboxDev/nxdk/issues/460 and https://github.com/XboxDev/nxdk/issues/129.
This work was started by @thrimbor and I kind of took it over.

~Relies on https://github.com/XboxDev/nxdk/pull/610.~

It has a few key improvements over pktdrv:
* Zero-copy TX and RX transmission
* Automatic scatter gather of TX packets that cross page boundaries so the user doesnt need to worry about it (Up to one page crossing, which should cover all ethernet frame lengths required for 100Mbit)
* Multithreaded buffer manager
* Supports different ring sizes for TX and RX so you can optimise your application for specifc directions to reduce RAM usage. Defaults to 64/64 which seems like a reasonable all around mode even under heavy loads.

As a comparison running lwip iperf server on the same Xbox and PC network config:

Current master (rx then tx test):
```
[  4] local 192.168.1.115 port 52244 connected with 192.168.1.113 port 5001
[ ID] Interval       Transfer     Bandwidth
[  4]  0.0-10.0 sec  39.4 MBytes  33.0 Mbits/sec
[  4] local 192.168.1.115 port 5001 connected with 192.168.1.113 port 51705
[  4]  0.0-10.3 sec  25.2 KBytes  20.1 Kbits/sec
```

nvnetdrv (rx then tx test)::
```
[  4] local 192.168.1.115 port 51764 connected with 192.168.1.113 port 5001
[ ID] Interval       Transfer     Bandwidth
[  4]  0.0-10.0 sec   112 MBytes  94.2 Mbits/sec
[  4] local 192.168.1.115 port 5001 connected with 192.168.1.113 port 51715
[  4]  0.0-10.0 sec   111 MBytes  92.9 Mbits/sec
```

It also performs quite well in full duplex mode (tx/rx in parallel):
```
[  4] local 192.168.1.115 port 57034 connected with 192.168.1.113 port 5001
[  5] local 192.168.1.115 port 5001 connected with 192.168.1.113 port 51704
[ ID] Interval       Transfer     Bandwidth
[  4]  0.0-10.0 sec   108 MBytes  90.3 Mbits/sec
[  5]  0.0-10.0 sec   106 MBytes  88.9 Mbits/sec
```

Current PRd as draft mainly due to it being a fairly large change and subject to feedback. I have tested this quite extensively and currently use it on my homebrew [dashboard](https://github.com/Ryzee119/LithiumX) in the form of an FTP server.

The `lwipopt.h` tweak is as per https://lwip.fandom.com/wiki/Tuning_TCP, which improved tx speed from ~60mbits to 90+mbits in my test with nvnetdrv. It made little impact to pktdrv perf.
```
Send-buffer (TCP_SND_BUF):
... For maximum throughput, set this to the same value as TCP_WND
```

Also fixes a bug in our network init function. We should be using `tcpip_input` instead of `ethernet_input` for OS mode (threaded) operation. Ref https://www.nongnu.org/lwip/2_0_x/group__netif.html#gade5498543e74067f28cc6bef0209e3be