### PR TITLE
hal: Relicense fileio code to MIT

### DIFF
--- a/lib/hal/fileio.c
+++ b/lib/hal/fileio.c
@@ -1,3 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2004 Craig Edwards
+// SPDX-FileCopyrightText: 2006 Richard Osborne
+// SPDX-FileCopyrightText: 2017-2020 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019 Lucas Jansson
+// SPDX-FileCopyrightText: 2019 Jannik Vogel
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/lib/hal/fileio.h
+++ b/lib/hal/fileio.h
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2004 Craig Edwards
+// SPDX-FileCopyrightText: 2017-2020 Stefan Schmidt
+
 #ifndef HAL_FILEIO_H
 #define HAL_FILEIO_H
 


### PR DESCRIPTION
I got the original authors' permission to relicense this code under the MIT license. I can share proof of this on Discord on request, and have already shown it to @Ryzee119.

There was a commit by Carcharius, who I haven't been able to contact yet, but it only touched code that we already removed.