### PR TITLE
Relicense remaining OpenXDK code

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Copy one of the sample directories to get started. You can copy it anywhere you 
 
 Credits
 -------
-- [OpenXDK](https://web.archive.org/web/20170624051336/http://openxdk.sourceforge.net:80/) is the inspiration for nxdk, and large parts of it have been reused. (License: GPLv2)
+- [OpenXDK](https://web.archive.org/web/20170624051336/http://openxdk.sourceforge.net:80/) is the inspiration for nxdk, and large parts of it have been reused. (License: MIT)
 - Large parts of [pbkit](https://web.archive.org/web/20141024145308/http://forums.xbox-scene.com/index.php?/topic/573524-pbkit/), by openxdkman, are included, with modifications. (License: MIT)
 - A network stack is included based on [lwIP](http://savannah.nongnu.org/projects/lwip/) (License: Modified BSD)
 - A libc is included based on [PDCLib](https://github.com/DevSolar/pdclib) (License: CC0)

--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -1,3 +1,16 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2005 Robin Mulloy
+// SPDX-FileCopyrightText: 2006 Tom Burns
+// SPDX-FileCopyrightText: 2006 Guillaume Lamonoca
+// SPDX-FileCopyrightText: 2006 Richard Osborne
+// SPDX-FileCopyrightText: 2017-2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2019 Lucas Jansson
+// SPDX-FileCopyrightText: 2021 Kosmas Raptis
+// SPDX-FileCopyrightText: 2021 GXTX
+// SPDX-FileCopyrightText: 2021 Stefan Schmidt
+// SPDX-FileCopyrightText: 2022 Ryan Wendland
+
 #include <xboxkrnl/xboxkrnl.h>
 #include <hal/xbox.h>
 #include <hal/video.h>

--- a/lib/hal/video.h
+++ b/lib/hal/video.h
@@ -1,3 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2005 Robin Mulloy
+// SPDX-FileCopyrightText: 2006 Tom Burns
+// SPDX-FileCopyrightText: 2006 Richard Osborne
+// SPDX-FileCopyrightText: 2017-2021 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019 Lucas Jansson
+// SPDX-FileCopyrightText: 2020 Jannik Vogel
+// SPDX-FileCopyrightText: 2022 Ryan Wendland
+
 #ifndef HAL_VIDEO_H
 #define HAL_VIDEO_H
 

--- a/lib/hal/xbox.c
+++ b/lib/hal/xbox.c
@@ -1,3 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2004 Craig Edwards
+// SPDX-FileCopyrightText: 2006 Richard Osborne
+// SPDX-FileCopyrightText: 2017-2020 Stefan Schmidt
+// SPDX-FileCopyrightText: 2022 Erik Abair
+
 #include <string.h>
 // #include <xboxrt/stat.h>
 #include <hal/xbox.h>

--- a/lib/hal/xbox.h
+++ b/lib/hal/xbox.h
@@ -1,3 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2004 Craig Edwards
+// SPDX-FileCopyrightText: 2005 Robin Mulloy
+// SPDX-FileCopyrightText: 2005 Tom Burns
+// SPDX-FileCopyrightText: 2019-2021 Stefan Schmidt
+// SPDX-FileCopyrightText: 2022 Erik Abair
+
 #ifndef HAL_XBOX_H
 #define HAL_XBOX_H
 


### PR DESCRIPTION
This relicenses the remaining OpenXDK code.

This change was delayed because I haven't been able to contact one the contributors, Carcharius. After multiple unsuccessful attempts I looked closely at the code he contributed, and most of the changes are no longer part of the code as it is used in nxdk. The only remaining work contributed by him are some constants in the video mode table, which can be considered facts, and those are not copyrightable.