### PR TITLE
Docker & Actions updates

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -22,7 +22,7 @@ jobs:
             build-args: buildparams=LTO=y CFLAGS=-O2 CXXFLAGS=-O2
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Generate timestamp
@@ -38,20 +38,20 @@ jobs:
           TAGS="$TAGS,ghcr.io/${DOCKER_IMAGE}:git-${GITHUB_SHA::8}"
           echo ::set-output name=tags::${TAGS}
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -19,7 +19,7 @@ jobs:
             build-args: buildparams=LTO=y CFLAGS=-O2 CXXFLAGS=-O2
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Build Docker image
@@ -42,7 +42,7 @@ jobs:
       POWERSHELL_TELEMETRY_OPTOUT: 1
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install MSYS2 & Dependencies
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install Dependencies
@@ -82,7 +82,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Clone Tree
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
       - name: Install Dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # SPDX-FileCopyrightText: 2020-2022 Stefan Schmidt
 
-FROM ghcr.io/xboxdev/nxdk-buildbase:git-2c3115b1 AS builder
+FROM ghcr.io/xboxdev/nxdk-buildbase:git-7c4eb218 AS builder
 
 COPY ./ /usr/src/nxdk/
 ENV NXDK_DIR=/usr/src/nxdk
@@ -11,7 +11,7 @@ ARG buildparams
 RUN eval $(./usr/src/nxdk/bin/activate -s); cd /usr/src/nxdk && make NXDK_ONLY=y $buildparams -j`nproc`
 
 
-FROM ghcr.io/xboxdev/nxdk-runbase:git-2c3115b1
+FROM ghcr.io/xboxdev/nxdk-runbase:git-7c4eb218
 
 COPY --from=builder /usr/src/nxdk/ /usr/src/nxdk/
 ENV NXDK_DIR=/usr/src/nxdk


### PR DESCRIPTION
Our previous base image (Alpine 3.13, LLVM 10) seemed to cause broken builds in some cases (`xblunblock` is impacted by this). The newer image is based on Alpine 3.17 with LLVM 15, which worked better in my testing.

I took the chance to also update the Actions we're using (and slightly modify the token usage), since the old versions cause warnings now due to being based on node.js 12.

/edit: This is necessary to fix `xblunblock`'s CI, so I might self-merge in a few days.