### PR TITLE
vcruntime: Fix crashes in SEH handling when enabling optimizations

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: CC0-1.0
 
-// SPDX-FileCopyrightText: 2017-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2017-2023 Stefan Schmidt
 // SPDX-FileCopyrightText: 2018-2021 Jannik Vogel
 // SPDX-FileCopyrightText: 2018 Sean Koppenhafer
 // SPDX-FileCopyrightText: 2022 Erik Abair
@@ -1844,6 +1844,14 @@ XBAPI WCHAR NTAPI RtlUpcaseUnicodeChar
     WCHAR SourceCharacter
 );
 
+/**
+ * Initiates an unwind of procedure call frames
+ * THIS FUNCTION IS NOT SAFE TO CALL FROM C CODE! It does not follow the stdcall convention and trashes registers that are supposed to be callee-saved.
+ * @param TargetFrame A pointer to the call frame that is the target of the unwind. If this parameter is NULL, the function performs an exit unwind.
+ * @param TargetIp The continuation address of the unwind. If NULL, the function will return normally. This parameter is ignored if TargetFrame is NULL.
+ * @param ExceptionRecord A pointer to an EXCEPTION_RECORD structure.
+ * @param ReturnValue A value to be placed in the integer function return register before continuing execution.
+ */
 XBAPI VOID NTAPI RtlUnwind
 (
     IN PVOID TargetFrame OPTIONAL,


### PR DESCRIPTION
This is the problem that has been causing issues for https://github.com/insignia-live/xblunblock
It was caused by `RtlUnwind` not following the stdcall calling convention and overwriting values in registers that are supposed to be callee-saved. This didn't cause any problems when building without optimizations, but adding `-O2` and trying to catch exceptions made this problem appear due to the compiler inlining `_global_unwind2`, resulting in a jump to a null pointer.

The solution here is to add all registers (except `eax`, which is used for pushing the parameter) to the clobber list, making the compiler save the registers that are still needed.

Some other minor changes are also included, like making sure the compiler doesn't reorder memory accesses across `cld` and marking the exception pointer storing as volatile.

/edit:
This is the code I used to demonstrate and debug the issue (make sure to compile all of nxdk with `make CFLAGS=-O2 CXXFLAGS=-O2` to make the issue appear)
```c
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>

void innerfunc ()
{
    volatile int *t = 0x10;
    debugPrint("%x\n", *t);
}

void outerfunc ()
{
    DbgPrint("%s: %d\n", __FUNCTION__, __LINE__);
    __try
    {
        DbgPrint("%s: %d\n", __FUNCTION__, __LINE__);
        innerfunc();
    }
    __except (GetExceptionCode() == EXCEPTION_ACCESS_VIOLATION ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH)
    {
        DbgPrint("%s: %d\n", __FUNCTION__, __LINE__);
    }
    DbgPrint("%s: %d\n", __FUNCTION__, __LINE__);
}

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    DbgPrint("%s: %d\n", __FUNCTION__, __LINE__);
    outerfunc();
    DbgPrint("%s: %d\n", __FUNCTION__, __LINE__);

    debugPrint("Hello nxdk!\n");

    while(1) {
        Sleep(2000);
    }

    return 0;
}
``` 