### PR TITLE
Fix typo in RemoveHeadList macro

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -113,7 +113,7 @@ typedef CONST UNICODE_STRING *PCUNICODE_STRING;
 
 #define IsListEmpty(ListHead) ((ListHead)->Flink == (ListHead))
 
-#define RemoveHeadList(Listhead) (ListHead)->Flink;{RemoveEntryList((ListHead)->Flink)}
+#define RemoveHeadList(ListHead) (ListHead)->Flink;{RemoveEntryList((ListHead)->Flink)}
 
 #define RemoveTailList(ListHead) (ListHead)->Blink;{RemoveEntryList((ListHead)->Blink)}
 


### PR DESCRIPTION
Nothing much to say. Just a simple typo fix.

Fixed typo in RemoveHeadList macro variable name.