### PR TITLE
pbkit: Set default PTIMER values without killing the system

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -2806,18 +2806,7 @@ int pb_init(void)
     odiv=1;
     pdiv=(VIDEOREG(NV_PRAMDAC_NVPLL_COEFF)&NV_PRAMDAC_NVPLL_COEFF_PDIV)>>16;
 
-    if (mdiv)
-    {
-        //Xtal in Xbox is at 16.666 Mhz but we want 31.25Mhz for GPU...
-        if (((DW_XTAL_16MHZ*ndiv)/(odiv<<pdiv))/mdiv!=233333324)
-        {
-            //This PLL configuration doesn't create a 233.33 Mhz freq from Xtal
-            //Have this issure reported so we can update source for that case
-            debugPrint("PLL=%lu\n",((DW_XTAL_16MHZ*ndiv)/(odiv<<pdiv))/mdiv);
-            return -5;
-        }
-    }
-    else
+    if (!mdiv)
     {
         pb_kill();
         return -5; //invalid GPU internal PLL (Phase Locked Loop=GPU freq generator)
@@ -2828,7 +2817,6 @@ int pb_init(void)
     VIDEOREG(NV_PTIMER_DENOMINATOR)=7629;
 
     VIDEOREG(NV_PTIMER_ALARM_0)=0xFFFFFFFF;
-
 
     //The Gpu instance memory is a special place in PRAMIN area (VRAM attached to RAM?)
     //Essential Gpu data will be stored there, for, I guess, top speed access.


### PR DESCRIPTION
2nd go at #585 

Fixes #536

~~Edit: Playing around with this, it seems like we can remove it. The kernel and applications *before* should already be properly setting up these 2 regs and they aren't reset during a launch. Thoughts on removing it completely? I tried testing with `abaire/nxdk_pgraph_tests` but their nxdk is out of date and refuses to build on my system.~~

The kernel sets these registers up before ever launching an application, so we don't need to be calculating them. Verified this on 3944 and some scene kernels.
