### PR TITLE
net: Whitespace and macro cleanup in cc.h

### DIFF
--- a/lib/net/nforceif/include/arch/cc.h
+++ b/lib/net/nforceif/include/arch/cc.h
@@ -1,9 +1,9 @@
 /*
  * Copyright (c) 2001-2003 Swedish Institute of Computer Science.
  * Copyright (c) 2015 Matt Borgerson
- * All rights reserved. 
- * 
- * Redistribution and use in source and binary forms, with or without modification, 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
@@ -12,21 +12,21 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  * 3. The name of the author may not be used to endorse or promote products
- *    derived from this software without specific prior written permission. 
+ *    derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED 
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
- * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  *
  * This file is part of the lwIP TCP/IP stack.
- * 
+ *
  * Author: Adam Dunkels <adam@sics.se>
  * Xbox Support: Matt Borgerson
  *
@@ -40,7 +40,7 @@
 #include <windows.h>
 
 #define printf debugPrint
-#define fflush(...) 
+#define fflush(...)
 void abort(void);
 
 //#define MEM_ALIGNMENT 4

--- a/lib/net/nforceif/include/arch/cc.h
+++ b/lib/net/nforceif/include/arch/cc.h
@@ -35,20 +35,16 @@
 #define LWIP_ARCH_CC_H
 
 /* Include some files for defining library routines */
+#include <assert.h>
+#include <stdlib.h>
 #include <string.h>
 #include <hal/debug.h>
 #include <windows.h>
 
-#define printf debugPrint
-#define fflush(...)
-void abort(void);
-
 //#define MEM_ALIGNMENT 4
 
 /* Define platform endianness */
-//#ifndef BYTE_ORDER
 #define BYTE_ORDER LITTLE_ENDIAN
-//#endif /* BYTE_ORDER */
 
 /* Define generic types used in lwIP */
 typedef unsigned   char    u8_t;
@@ -70,11 +66,7 @@ typedef unsigned long mem_ptr_t;
 #define X32_F "x"
 
 /* If only we could use C99 and get %zu */
-#if defined(__x86_64__)
-#define SZT_F "lu"
-#else
 #define SZT_F "u"
-#endif
 
 /* Compiler hints for packing structures */
 #define PACK_STRUCT_FIELD(x) x
@@ -83,14 +75,9 @@ typedef unsigned long mem_ptr_t;
 #define PACK_STRUCT_END
 
 /* Plaform specific diagnostic output */
-#define LWIP_PLATFORM_DIAG(x)	do {printf x;} while(0)
+#define LWIP_PLATFORM_DIAG(x)	do {debugPrint x;} while(0)
 
-#ifdef LWIP_UNIX_EMPTY_ASSERT
-#define LWIP_PLATFORM_ASSERT(x)
-#else
-#define LWIP_PLATFORM_ASSERT(x) do {printf("Assertion \"%s\" failed at line %d in %s\n", \
-                                     x, __LINE__, __FILE__); fflush(NULL); abort();} while(0)
-#endif
+#define LWIP_PLATFORM_ASSERT(x) do {assert(x);} while(0)
 
 #define LWIP_RAND() ((u32_t)GetTickCount()) /* Not really random... */
 


### PR DESCRIPTION
This removes a few bits of unnecessary preprocessor stuff and whitespaces, and removes the redefinition of `fflush` and `printf` that could cause some issues with header include order.