### PR TITLE
Add XBE->Exe Functionality

### DIFF
--- a/tools/cxbe/Exe.cpp
+++ b/tools/cxbe/Exe.cpp
@@ -6,9 +6,14 @@
 // SPDX-FileCopyrightText: 2021 Stefan Schmidt
 
 #include "Exe.h"
+#include "Xbe.h"
 
-#include <stdio.h>
 #include <memory.h>
+#include <locale.h>
+#include <stdlib.h>
+#include <time.h>
+#include <cstring>
+#include <cstdio>
 
 // construct via Exe file
 Exe::Exe(const char *x_szFilename)
@@ -176,6 +181,39 @@ cleanup:
 
     return;
 }
+
+Exe(class Xbe *x_Xbe, const char *x_szTitle, bool x_bRetail) {
+    
+    ConstructorInit();
+
+    time_t CurrentTime;
+
+    time(&CurrentTime);
+
+    printf("Exe::Exe: Pass 1 (Simple Pass)...");
+    
+    //pass 1
+    {
+        //standard Pe magic Number
+        m_Header.m_magic = *(uint32 *)"PE\0\0";
+        //m_Header.dwBaseAddr = 0x00010000;
+        //we want the same number of sections as our xbe file
+        m_Header.m_sections= x_Xbe->dwSections; 
+        //copies of various same header values
+        {
+            m_Header.m_OptionalHeader.m_sizeof_stack_reserve = x_Xbe->dwPeStackCommit;
+            m_Header.m_OptionalHeader.m_sizeof_heap_reserve= x_Xbe->dwPeHeapReserve;
+            m_OptionalHeader.m_sizeof_heap_commit= x_Xbe->dwPeHeapCommit;
+            m_OptionalHeader.m_sizeof_image= x_Xbe-> dwPeSizeofImage;
+            //dwPeChecksum    Is this needed?
+            m_Header.m_timedate=X_Xbe->dwPeTimeDate;
+        }
+            
+        
+    }
+    
+}
+
 
 // constructor initialization
 void Exe::ConstructorInit()

--- a/tools/cxbe/Exe.h
+++ b/tools/cxbe/Exe.h
@@ -15,6 +15,9 @@ class Exe : public Error
     public:
         // construct via Exe file
         Exe(const char *x_szFilename);
+        
+        // Construct via Xbe file
+        Exe(class Xbe *x_Xbe, const char *x_szTitle, bool x_bRetail);
 
         // deconstructor
        ~Exe();


### PR DESCRIPTION
There are numerous analysis tools which are compatible with Windows PE files, but do not work with XBE files even though they are functionally compatible. Adding this functionality would allow for the conversion of Xbe files to a dummy Exe file allowing for the use of these tools. There is no need in needing these exe files to be executable or even functionally correct, as long as the correct header information is maintained between both files. 

Overall, the produced Exe file is not meant to be executed on actual systems, but only meant as a way to further additional analysis.