### PR TITLE
pbkit: Enable flip stall; expose ramin, print_char, depth buffer internals

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1607,9 +1607,32 @@ static void pb_3D_init(void)
 #endif
 }
 
+DWORD pb_reserve_instance(DWORD size) {
+    DWORD ret = pb_FreeInst;
+    pb_FreeInst += (size>>4);
+    return ret;
+}
 
+void pb_create_gr_instance(int ChannelID,
+                           int Class,
+                           DWORD instance,
+                           DWORD flags,
+                           DWORD flags3D,
+                           struct s_CtxDma *pGrObject)
+{
+    DWORD offset = instance << 4;
+    VIDEOREG(NV_PRAMIN + offset + 0x00) = flags;
+    VIDEOREG(NV_PRAMIN + offset + 0x04) = flags3D;
+    VIDEOREG(NV_PRAMIN + offset + 0x08) = 0;
+    VIDEOREG(NV_PRAMIN + offset + 0x0C) = 0;
 
+    memset(pGrObject,0,sizeof(struct s_CtxDma));
 
+    pGrObject->ChannelID = ChannelID;
+    pGrObject->Class = Class;
+    pGrObject->isGr = 1;
+    pGrObject->Inst = instance;
+}
 
 void pb_create_gr_ctx(   int ChannelID,
                 int Class,
@@ -1643,14 +1666,13 @@ void pb_create_gr_ctx(   int ChannelID,
         }
     }
 
-    Inst=pb_FreeInst; pb_FreeInst+=(size>>4);
+    Inst = pb_reserve_instance(size);
 
     if (flags3D)
     {
         pb_3DGrCtxInst[pb_FifoChannelID]=Inst;
         pb_3D_init();
     }
-
 
     flags=Class&0x000000FF;
     flags3D=0x00000000;
@@ -1659,18 +1681,7 @@ void pb_create_gr_ctx(   int ChannelID,
 
     if (Class==GR_CLASS_97) flags3D=0x00000A00;
 
-    VIDEOREG(NV_PRAMIN+(Inst<<4)+0x00)=flags;
-    VIDEOREG(NV_PRAMIN+(Inst<<4)+0x04)=flags3D;
-    VIDEOREG(NV_PRAMIN+(Inst<<4)+0x08)=0;
-    VIDEOREG(NV_PRAMIN+(Inst<<4)+0x0C)=0;
-
-
-    memset(pGrObject,0,sizeof(struct s_CtxDma));
-
-    pGrObject->ChannelID=ChannelID;
-    pGrObject->Class=Class;
-    pGrObject->isGr=1;
-    pGrObject->Inst=Inst;
+    pb_create_gr_instance(ChannelID, Class, Inst, flags, flags3D, pGrObject);
 }
 
 

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -370,7 +370,7 @@ static void pb_scrollup(void)
     memset(&pb_text_screen[ROWS-1][0],0,COLS);
 }
 
-static void pb_print_char(char c)
+void pb_print_char(char c)
 {
     if (c=='\n')
     {

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -18,6 +18,7 @@
 #include <hal/debug.h>
 #include <stdbool.h>
 #include <assert.h>
+#include <winapi/synchapi.h>
 
 #include "pbkit.h"
 #include "outer.h"
@@ -673,7 +674,9 @@ static DWORD pb_gr_handler(void)
 
                             //calling XReboot() from here doesn't work well.
 
-                            while(1) {};
+                            while(1) {
+                              Sleep(2000);
+                            };
                         }
                     }
                 }

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -1331,11 +1331,11 @@ static void pb_prepare_tiles(void)
 
 
 
-void pb_create_dma_ctx(  DWORD ChannelID,
+void pb_create_dma_ctx(DWORD ChannelID,
                 DWORD Class,
                 DWORD Base,
                 DWORD Limit,
-                struct s_CtxDma *pDmaObject )
+                struct s_CtxDma *pDmaObject)
 {
     DWORD           Addr;
     DWORD           AddrSpace;
@@ -1611,7 +1611,8 @@ static void pb_3D_init(void)
 #endif
 }
 
-DWORD pb_reserve_instance(DWORD size) {
+DWORD pb_reserve_instance(DWORD size)
+{
     DWORD ret = pb_FreeInst;
     pb_FreeInst += (size>>4);
     return ret;
@@ -2626,12 +2627,14 @@ void pb_kill(void)
 }
 
 
-void pb_set_color_format(unsigned int fmt, bool swizzled) {
+void pb_set_color_format(unsigned int fmt, bool swizzled)
+{
     pb_ColorFmt = fmt;
     assert(swizzled == false);
 }
 
-void pb_set_fb_size_multiplier(unsigned int multiplier) {
+void pb_set_fb_size_multiplier(unsigned int multiplier)
+{
     assert(multiplier > 0);
     pb_FBSizeMultiplier = multiplier;
 }
@@ -3737,10 +3740,12 @@ uint8_t* pb_depth_stencil_buffer()
   return (uint8_t*)pb_DepthStencilAddr;
 }
 
-DWORD pb_depth_stencil_pitch() {
+DWORD pb_depth_stencil_pitch()
+{
   return pb_DepthStencilPitch;
 }
 
-DWORD pb_depth_stencil_size() {
+DWORD pb_depth_stencil_size()
+{
   return pb_DSSize;
 }

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -149,6 +149,7 @@ static  DWORD           pb_FBVFlag;
 static  DWORD           pb_GPUFrameBuffersFormat;//encoded format for GPU
 static  DWORD           pb_EXAddr[8];       //extra buffers addresses
 static  DWORD           pb_ExtraBuffersCount=0;
+static  DWORD           pb_FBSizeMultiplier = 1;
 
 static  DWORD           pb_DepthStencilAddr;
 static  DWORD           pb_DepthStencilPitch;
@@ -2630,6 +2631,11 @@ void pb_set_color_format(unsigned int fmt, bool swizzled) {
     assert(swizzled == false);
 }
 
+void pb_set_fb_size_multiplier(unsigned int multiplier) {
+    assert(multiplier > 0);
+    pb_FBSizeMultiplier = multiplier;
+}
+
 int pb_init(void)
 {
     DWORD           old;
@@ -2738,7 +2744,6 @@ int pb_init(void)
     pb_PutRunSize=0;
 
     pb_FrameBuffersAddr=0;
-
 
     pb_DmaBuffer8=MmAllocateContiguousMemoryEx(32,0,MAXRAM,0,4);
     pb_DmaBuffer2=MmAllocateContiguousMemoryEx(32,0,MAXRAM,0,4);
@@ -3391,7 +3396,7 @@ int pb_init(void)
         }
     }
 
-    Size=Pitch*VSize;
+    Size=Pitch*VSize*pb_FBSizeMultiplier;
 
     //verify 64 bytes alignment for size of a frame buffer
     if (Size&(64-1)) debugPrint("pb_init: FBSize is not well aligned.\n");
@@ -3464,7 +3469,7 @@ int pb_init(void)
         }
     }
 
-    Size=Pitch*VSize;
+    Size=Pitch*VSize*pb_FBSizeMultiplier;
 
     //verify 64 bytes alignment for size of a frame buffer
     if (Size&(64-1)) debugPrint("pb_init: DSSize is not well aligned.\n");
@@ -3518,7 +3523,7 @@ int pb_init(void)
             }
         }
 
-        Size=Pitch*VSize;
+        Size=Pitch*VSize*pb_FBSizeMultiplier;
 
         //verify 64 bytes alignment for size of a frame buffer
         if (Size&(64-1)) debugPrint("pb_init: EXSize is not well aligned.\n");

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -3712,3 +3712,16 @@ static NTAPI VOID pb_shutdown_notification_routine (PHAL_SHUTDOWN_REGISTRATION S
 {
 	pb_kill();
 }
+
+uint8_t* pb_depth_stencil_buffer()
+{
+  return (uint8_t*)pb_DepthStencilAddr;
+}
+
+DWORD pb_depth_stencil_pitch() {
+  return pb_DepthStencilPitch;
+}
+
+DWORD pb_depth_stencil_size() {
+  return pb_DSSize;
+}

--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -2468,7 +2468,7 @@ int pb_finished(void)
     p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_WAIT_MAKESPACE,0); //wait/makespace (obtains null status)
     p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_PARAMETER_A,pb_back_index); //set param=back buffer index to show up
     p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_FIRE_INTERRUPT,PB_FINISHED); //subprogID PB_FINISHED: gets frame ready to show up soon
-//  p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STALL_PIPELINE,0); //stall gpu pipeline (not sure it's needed in triple buffering technic)
+    p=pb_push1(p,NV20_TCL_PRIMITIVE_3D_STALL_PIPELINE,0); //stall gpu pipeline (not sure it's needed in triple buffering technic)
     pb_end(p);
 
     //insert in push buffer the commands to trigger selection of next back buffer

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -156,6 +156,10 @@ void pb_create_gr_instance(int ChannelID,
                         DWORD flags,
                         DWORD flags3D,
                         struct s_CtxDma *pGrObject);
+
+// Exposed so pb_print can be overridden using a version of vsprintf that
+// supports floats.
+void pb_print_char(char c);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -132,6 +132,8 @@ void    pb_fill(int x,int y,int w,int h, DWORD color);  //rectangle fill
 
 void    pb_set_viewport(int dwx,int dwy,int width,int height,float zmin,float zmax);
 
+void    pb_set_fb_size_multiplier(unsigned int multiplier);
+
 int pb_busy(void);
 
 

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -141,10 +141,10 @@ void pb_create_dma_ctx(DWORD ChannelID,
                        DWORD Class,
                        DWORD Base,
                        DWORD Limit,
-                       struct s_CtxDma *pDmaObject );
-void pb_create_gr_ctx(   int ChannelID,
+                       struct s_CtxDma *pDmaObject);
+void pb_create_gr_ctx(int ChannelID,
                       int Class,
-                      struct s_CtxDma *pGrObject  );
+                      struct s_CtxDma *pGrObject);
 void pb_bind_channel(struct s_CtxDma *pCtxDmaObject);
 
 uint8_t *pb_depth_stencil_buffer();
@@ -159,8 +159,6 @@ void pb_create_gr_instance(int ChannelID,
                         DWORD flags3D,
                         struct s_CtxDma *pGrObject);
 
-// Exposed so pb_print can be overridden using a version of vsprintf that
-// supports floats.
 void pb_print_char(char c);
 #ifdef __cplusplus
 }

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -51,6 +51,24 @@ extern "C"
 #define SUBCH_3                 3
 #define SUBCH_4                 4
 
+//DMA and graphics classes
+#define DMA_CLASS_2                 0x02
+#define DMA_CLASS_3                 0x03
+#define DMA_CLASS_3D                0x3D
+#define GR_CLASS_19                 0x19
+#define GR_CLASS_30                 0x30
+#define GR_CLASS_39                 0x39
+#define GR_CLASS_62                 0x62
+#define GR_CLASS_97                 0x97
+#define GR_CLASS_9F                 0x9F
+
+struct s_CtxDma
+{
+  DWORD               ChannelID;
+  DWORD               Inst;   //Addr in PRAMIN area, unit=16 bytes blocks, baseaddr=VIDEO_BASE+NV_PRAMIN
+  DWORD               Class;
+  DWORD               isGr;
+};
 
 void    pb_show_front_screen(void); //shows scene (allows VBL synced screen swapping)
 void    pb_show_debug_screen(void); //shows debug screen (default openxdk+SDL buffer)
@@ -115,6 +133,16 @@ void    pb_set_viewport(int dwx,int dwy,int width,int height,float zmin,float zm
 
 int pb_busy(void);
 
+
+void pb_create_dma_ctx(DWORD ChannelID,
+                       DWORD Class,
+                       DWORD Base,
+                       DWORD Limit,
+                       struct s_CtxDma *pDmaObject );
+void pb_create_gr_ctx(   int ChannelID,
+                      int Class,
+                      struct s_CtxDma *pGrObject  );
+void pb_bind_channel(struct s_CtxDma *pCtxDmaObject);
 
 #ifdef __cplusplus
 }

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -50,6 +50,7 @@ extern "C"
 #define SUBCH_2                 2
 #define SUBCH_3                 3
 #define SUBCH_4                 4
+#define NEXT_SUBCH              5
 
 //DMA and graphics classes
 #define DMA_CLASS_2                 0x02
@@ -148,6 +149,13 @@ uint8_t *pb_depth_stencil_buffer();
 DWORD pb_depth_stencil_pitch();
 DWORD pb_depth_stencil_size();
 
+DWORD pb_reserve_instance(DWORD size);
+void pb_create_gr_instance(int ChannelID,
+                        int Class,
+                        DWORD instance,
+                        DWORD flags,
+                        DWORD flags3D,
+                        struct s_CtxDma *pGrObject);
 #ifdef __cplusplus
 }
 #endif

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -144,6 +144,10 @@ void pb_create_gr_ctx(   int ChannelID,
                       struct s_CtxDma *pGrObject  );
 void pb_bind_channel(struct s_CtxDma *pCtxDmaObject);
 
+uint8_t *pb_depth_stencil_buffer();
+DWORD pb_depth_stencil_pitch();
+DWORD pb_depth_stencil_size();
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This PR upstreams the pbkit changes required by the [pgraph test suite](https://github.com/abaire/nxdk_pgraph_tests).

They are all combined into one PR, but can be split it if preferred.
CC: @abaire 