### PR TITLE
kernel: fix ObReferenceObjectByHandle return type

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -2460,7 +2460,7 @@ XBAPI NTSTATUS NTAPI ObReferenceObjectByName
     OUT PVOID *Object
 );
 
-XBAPI BOOLEAN NTAPI ObReferenceObjectByHandle
+XBAPI NTSTATUS NTAPI ObReferenceObjectByHandle
 (
     IN HANDLE Handle,
     IN POBJECT_TYPE ObjectType OPTIONAL,


### PR DESCRIPTION
When I was troubleshooting an issue with Area 51 title in Cxbx-Reloaded for a false positive successful by handle given with -1 from ObReferenceObjectByHandle function. I decided to verify the test on hardware if there is such special case for -1 from embedded kernel. After test was made and receive result, I only got `0x8` and `0x24` instead of `0xc0000008` and `0xc0000024` status.

After a fix with return type from BOOL to NTSTATUS, it now receive `0xc0000008` and `0xc0000024` status properly. I also discover this issue could affect `/lib/winapi/thread.c` file as well.