### PR TITLE
CMake: Toolchain fixes

### DIFF
--- a/bin/nxdk-cc
+++ b/bin/nxdk-cc
@@ -17,6 +17,9 @@ clang \
     -I${NXDK_DIR}/lib/pdclib/platform/xbox/include \
     -I${NXDK_DIR}/lib/winapi \
     -I${NXDK_DIR}/lib/xboxrt/vcruntime \
+    -I${NXDK_DIR}/lib/net/lwip/src/include \
+    -I${NXDK_DIR}/lib/net/nforceif/include \
+    -I${NXDK_DIR}/lib/net/nvnetdrv \
     -DNXDK \
     -D__STDC__=1 \
     -U__STDC_NO_THREADS__ \

--- a/bin/nxdk-cxx
+++ b/bin/nxdk-cxx
@@ -18,6 +18,9 @@ clang \
     -I${NXDK_DIR}/lib/pdclib/platform/xbox/include \
     -I${NXDK_DIR}/lib/winapi \
     -I${NXDK_DIR}/lib/xboxrt/vcruntime \
+    -I${NXDK_DIR}/lib/net/lwip/src/include \
+    -I${NXDK_DIR}/lib/net/nforceif/include \
+    -I${NXDK_DIR}/lib/net/nvnetdrv \
     -DNXDK \
     -D__STDC__=1 \
     -U__STDC_NO_THREADS__ \

--- a/lib/pkgconfig/SDL2_image.pc
+++ b/lib/pkgconfig/SDL2_image.pc
@@ -2,5 +2,5 @@ Name: SDL2_image
 Description: image loading library for Simple DirectMedia Layer
 Version: 2.0.5
 Requires: sdl2 >= 2.0.9 libjpeg libpng
-Libs: ${NXDK_DIR}/lib/libSDL2_image.lib
+Libs: -l${NXDK_DIR}/lib/libSDL2_image.lib
 Cflags: -I${NXDK_DIR}/lib/sdl/SDL2_image

--- a/lib/pkgconfig/SDL2_ttf.pc
+++ b/lib/pkgconfig/SDL2_ttf.pc
@@ -2,5 +2,5 @@ Name: SDL2_ttf
 Description: ttf library for Simple DirectMedia Layer with FreeType 2 support
 Version: 2.0.14
 Requires: sdl2 >= 2.0.9
-Libs: ${NXDK_DIR}/lib/libSDL_ttf.lib ${NXDK_DIR}/lib/libfreetype.lib
+Libs: -l${NXDK_DIR}/lib/libSDL_ttf.lib -l${NXDK_DIR}/lib/libfreetype.lib
 Cflags: -I${NXDK_DIR}/lib/sdl -I${NXDK_DIR}/lib/sdl/SDL_ttf

--- a/lib/pkgconfig/libjpeg.pc
+++ b/lib/pkgconfig/libjpeg.pc
@@ -2,4 +2,4 @@ Name: libjpeg
 Description: A SIMD-accelerated JPEG codec that provides the libjpeg API
 Version: 2.0.4
 Libs: ${NXDK_DIR}/lib/libjpeg.lib
-Cflags: -I${NXDK_DIR}/lib/libjpeg/libjpeg-turbo -I$(NXDK_DIR)/lib/libjpeg
+Cflags: -I${NXDK_DIR}/lib/libjpeg/libjpeg-turbo -I${NXDK_DIR}/lib/libjpeg

--- a/lib/pkgconfig/libjpeg.pc
+++ b/lib/pkgconfig/libjpeg.pc
@@ -1,5 +1,5 @@
 Name: libjpeg
 Description: A SIMD-accelerated JPEG codec that provides the libjpeg API
 Version: 2.0.4
-Libs: ${NXDK_DIR}/lib/libjpeg.lib
+Libs: -l${NXDK_DIR}/lib/libjpeg.lib
 Cflags: -I${NXDK_DIR}/lib/libjpeg/libjpeg-turbo -I${NXDK_DIR}/lib/libjpeg

--- a/lib/pkgconfig/libpng.pc
+++ b/lib/pkgconfig/libpng.pc
@@ -2,5 +2,5 @@ Name: libpng
 Description: Loads and saves PNG files
 Version: 1.6.37
 Requires: zlib
-Libs: ${NXDK_DIR}/lib/libpng.lib
+Libs: -l${NXDK_DIR}/lib/libpng.lib
 Cflags: -I${NXDK_DIR}/lib/libpng -I${NXDK_DIR}/lib/libpng/libpng

--- a/lib/pkgconfig/sdl2.pc
+++ b/lib/pkgconfig/sdl2.pc
@@ -3,5 +3,5 @@ Description: Simple DirectMedia Layer is a cross-platform multimedia library des
 Version: 2.0.9
 Requires:
 Conflicts:
-Libs: ${NXDK_DIR}/lib/libSDL2.lib
+Libs: -l${NXDK_DIR}/lib/libSDL2.lib
 Cflags: -I${NXDK_DIR}/lib/sdl/SDL2/include -DXBOX

--- a/lib/pkgconfig/zlib.pc
+++ b/lib/pkgconfig/zlib.pc
@@ -3,5 +3,5 @@ Description: zlib compression library
 Version: 1.2.11
 
 Requires:
-Libs: ${NXDK_DIR}/lib/libzlib.lib
+Libs: -l${NXDK_DIR}/lib/libzlib.lib
 Cflags: -I${NXDK_DIR}/lib/zlib/zlib -DZ_SOLO

--- a/share/cmake/Modules/FindSDL2.cmake
+++ b/share/cmake/Modules/FindSDL2.cmake
@@ -1,0 +1,18 @@
+# FPHSA_NAME_MISMATCHED is require to suppress warning message 
+set(FPHSA_NAME_MISMATCHED TRUE)
+include(FindPkgConfig)
+pkg_check_modules(sdl2 REQUIRED sdl2)
+unset(FPHSA_NAME_MISMATCHED)
+
+add_library(SDL2::SDL2 INTERFACE IMPORTED)
+set(SDL2_INCLUDE_DIRS ${sdl2_INCLUDE_DIRS})
+set(SDL2_LIBRARIES ${sdl2_LIBRARIES})
+set(SDL2_LINK_LIBRARIES ${sdl2_LINK_LIBRARIES})
+set_target_properties(SDL2::SDL2 PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES "${SDL2_INCLUDE_DIRS}"
+  INTERFACE_LINK_LIBRARIES "${SDL2_LINK_LIBRARIES}"
+  # NOTE: pkg_check_modules' Cflags definition for "XBOX" did not get included and was passed to CFLAGS_OTHER for some reason... 
+  INTERFACE_COMPILE_OPTIONS "${sdl2_CFLAGS}"
+)
+set(SDL2_FOUND 1)
+add_library(SDL2 ALIAS SDL2::SDL2)

--- a/share/cmake/Modules/FindThreads.cmake
+++ b/share/cmake/Modules/FindThreads.cmake
@@ -1,0 +1,6 @@
+# NOTE: custom FindThreads module is a requirement due to CMake's FindThreads module is looking for pThreads.
+# nxdk's toolchain is using system named Generic instead of "Windows" which could had work but inaccurate name.
+# xboxkrnl and pdclib have C11 thread support out of the box
+set(CMAKE_HAVE_THREADS_LIBRARY 1)
+set(Threads_FOUND TRUE)
+add_library(Threads::Threads INTERFACE IMPORTED)

--- a/share/toolchain-nxdk.cmake
+++ b/share/toolchain-nxdk.cmake
@@ -19,7 +19,7 @@ set(WIN32 1)
 set(NXDK 1)
 
 set(CMAKE_C_COMPILER "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-cc")
-set(CMAKE_C_STANDARD_LIBRARIES "${NXDK_DIR}/lib/libwinapi.lib ${NXDK_DIR}/lib/xboxkrnl/libxboxkrnl.lib ${NXDK_DIR}/lib/libxboxrt.lib  ${NXDK_DIR}/lib/libpdclib.lib ${NXDK_DIR}/lib/libnxdk_hal.lib ${NXDK_DIR}/lib/libnxdk.lib ${NXDK_DIR}/lib/nxdk_usb.lib") #"${CMAKE_CXX_STANDARD_LIBRARIES_INIT}"
+set(CMAKE_C_STANDARD_LIBRARIES "${NXDK_DIR}/lib/libwinapi.lib ${NXDK_DIR}/lib/xboxkrnl/libxboxkrnl.lib ${NXDK_DIR}/lib/libxboxrt.lib  ${NXDK_DIR}/lib/libpdclib.lib ${NXDK_DIR}/lib/libnxdk_hal.lib ${NXDK_DIR}/lib/libnxdk.lib ${NXDK_DIR}/lib/nxdk_usb.lib ${NXDK_DIR}/lib/libnxdk_net.lib") #"${CMAKE_CXX_STANDARD_LIBRARIES_INIT}"
 set(CMAKE_C_LINK_EXECUTABLE "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-link <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -out:<TARGET> <LINK_LIBRARIES>")
 
 set(CMAKE_CXX_COMPILER "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-cxx")

--- a/share/toolchain-nxdk.cmake
+++ b/share/toolchain-nxdk.cmake
@@ -45,4 +45,7 @@ set(_CMAKE_C_IPO_SUPPORTED_BY_CMAKE YES)
 set(_CMAKE_C_IPO_MAY_BE_SUPPORTED_BY_COMPILER YES)
 set(CMAKE_C_COMPILE_OPTIONS_IPO -flto)
 
+# TODO: CMAKE_MODULE_PATH is intended for project level than toolchain,
+#       find out what's wrong with CMAKE_FIND_ROOT_PATH as it is not working for some reason?
+set(CMAKE_MODULE_PATH "${NXDK_DIR}/share/cmake/Modules")
 set(PKG_CONFIG_EXECUTABLE "${NXDK_DIR}/bin/nxdk-pkg-config" CACHE STRING "Path to pkg-config")


### PR DESCRIPTION
After some troubleshooting process to figure out what went wrong with docker image for cmake usage. I found out there are several both manually incorrect coded and missing some support.

- pkgconfig for libjpeg missed replacement of  round to parenthesis brackets
- Whole *.pc files were missing -l, lowercase L, before each library files in `Libs:` variable. I had confirmed the correction now appear in `<PREFIX>_LIBRARIES` and `<PREFIX>_LINK_LIBRARIES` from output message test in cmake.
- FindThreads.cmake module is a requirement due to stock module will try to find pthread instead and fail. Since `CMAKE_SYSTEM_NAME` variable is set to Generic instead of Windows which fall back to unix-like's search method.
- FindSDL2.cmake should be a requirement in anyway due to definitions does not get include and only be found in `<PREFIX>_CFLAGS_OTHER`. Although, it does show up in `<PREFIX>_CFLAGS` except got exclude at compile/link time for unknown reason.
- For unknown reason, find_package did not look in nxdk's directory therefore require manually add path into `CMAKE_MODULE_PATH`.
  **NOTE:** `CMAKE_MODULE_PATH` is document intended for project level than toolchain.
- Add xbe conversion and check if author want xiso generated after compilation completion.

The changes made were tested with experimental package published on GitHub to test with NevolutionX application using cmake. It is able to compile with nxdk and with linux libraries (require install sdl2 packages).