### PR TITLE
net: Allow for initialization to gracefully fail

### DIFF
--- a/lib/net/nvnetdrv/nvnetdrv_lwip.c
+++ b/lib/net/nvnetdrv/nvnetdrv_lwip.c
@@ -86,11 +86,13 @@ void rx_callback(void *buffer, uint16_t length)
  *
  * @param netif the already initialized lwip network interface structure
  * for this nforceif
+ * @return ERR_OK if low level initiliazation succeeds
+ *         ERR_IF if any failure
  */
-static void low_level_init(struct netif *netif)
+static err_t low_level_init(struct netif *netif)
 {
     if (nvnetdrv_init(RX_BUFF_CNT, rx_callback) < 0) {
-        abort();
+        return ERR_IF;
     }
 
     /* set MAC hardware address length */
@@ -120,6 +122,8 @@ static void low_level_init(struct netif *netif)
     }
 #endif /* LWIP_IPV6 && LWIP_IPV6_MLD */
     g_pnetif = netif;
+
+    return ERR_OK;
 }
 
 /**
@@ -270,7 +274,5 @@ err_t nvnetif_init(struct netif *netif)
     nforceif->ethaddr = (struct eth_addr *)&(netif->hwaddr[0]);
 
     /* initialize the hardware */
-    low_level_init(netif);
-
-    return ERR_OK;
+    return low_level_init(netif);
 }


### PR DESCRIPTION
This PR modifies the return type of ``low_level_init()`` inside of nvnet to allow it to pass an error back to ``nvnetif_init()`` on failure to initialize. 

With a retail kernel, calls to ``ExQueryNonVolatileSetting`` can fail if the EEPROM is corrupt. In its current state, nxdk, will bail via ``abort()`` after the call [here](https://github.com/XboxDev/nxdk/blob/4070510f2916745e1794050a101b9e7b4acf465a/lib/net/nvnetdrv/nvnetdrv.c#L406) to ``ExQueryNonVolatileSetting``.

This PR addresses the above-mentioned issue and allows for the application to handle if nvnet was successful, or not, in initialization.