### PR TITLE
xboxkrnl: add OBJECT_HEADER structure

### DIFF
--- a/lib/xboxkrnl/xboxdef.h
+++ b/lib/xboxkrnl/xboxdef.h
@@ -41,6 +41,8 @@ typedef unsigned int SIZE_T, *PSIZE_T;
 typedef int BOOL, *PBOOL;
 typedef const char *PCSZ, *PCSTR, *LPCSTR;
 
+typedef ULONGLONG QUAD;
+
 typedef ULONG ULONG_PTR;
 typedef LONG LONG_PTR;
 

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -891,6 +891,16 @@ typedef struct _OBJECT_TYPE
     ULONG PoolTag;
 } OBJECT_TYPE, *POBJECT_TYPE;
 
+typedef struct _OBJECT_HEADER {
+	LONG PointerCount;
+	LONG HandleCount;
+	POBJECT_TYPE Type;
+	ULONG Flags;
+	QUAD Body;
+} OBJECT_HEADER, *POBJECT_HEADER;
+
+#define OBJECT_TO_OBJECT_HEADER(Object) CONTAINING_RECORD(Object, OBJECT_HEADER, Body)
+
 typedef VOID (NTAPI *PKDEFERRED_ROUTINE) (
     IN PKDPC Dpc,
     IN PVOID DeferredContext,


### PR DESCRIPTION
Missing addition of OBJECT_HEADER in nxdk repo will allow me to prepare upload xbox_object_directory_list project on GitHub. Having access to OBJECT_HEADER allow me access to pointer of Type member variable to determine which type of object it is.