### PR TITLE
Add GetLocalTime function

### DIFF
--- a/lib/winapi/Makefile
+++ b/lib/winapi/Makefile
@@ -17,6 +17,7 @@ WINAPI_SRCS := \
 	$(NXDK_DIR)/lib/winapi/sync.c \
 	$(NXDK_DIR)/lib/winapi/sysinfo.c \
 	$(NXDK_DIR)/lib/winapi/thread.c \
+	${NXDK_DIR}/lib/winapi/timezoneapi.c \
 	$(NXDK_DIR)/lib/winapi/tls.c \
 	$(NXDK_DIR)/lib/winapi/winnt.c
 

--- a/lib/winapi/sysinfoapi.h
+++ b/lib/winapi/sysinfoapi.h
@@ -15,6 +15,7 @@ extern "C" {
 void GetSystemTime (LPSYSTEMTIME lpSystemTime);
 void GetSystemTimePreciseAsFileTime (LPFILETIME lpSystemTimeAsFileTime);
 DWORD GetTickCount (void);
+void GetLocalTime (LPSYSTEMTIME lpSystemTime);
 
 // Unprovided fields are intentionally disabled to catch code trying to access them
 typedef struct _SYSTEM_INFO

--- a/lib/winapi/timezoneapi.c
+++ b/lib/winapi/timezoneapi.c
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2023 Ryan Wendland
+
+#include <timezoneapi.h>
+#include <winbase.h>
+#include <assert.h>
+#include <xboxkrnl/xboxkrnl.h>
+#include <string.h>
+
+typedef struct
+{
+    UCHAR Month;     // 1-12, a 0 indicates there is no timezone information
+    UCHAR Day;       // 1 = 1st occurrence of DayOfWeek up to 5 (5th or last)
+    UCHAR DayOfWeek; // 0 = Sunday to 6 = Saturday
+    UCHAR Hour;
+} XBOX_TZ_STRUCT;
+
+// Determine the day of the week given a year, month and day
+// https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week#Methods_in_computer_code
+static UCHAR GetDayOfWeek (SHORT year, UCHAR month, UCHAR day)
+{
+    return (day += month < 3 ? year-- : year - 2, 23 *
+            month / 9 + day + 4 + year / 4 - year / 100 + year / 400) % 7;
+}
+
+static UCHAR GetDaysInMonth (SHORT year, UCHAR month)
+{
+    static const UCHAR daysPerMonth[] = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    UCHAR days;
+
+    assert(month >= 1);
+    assert(month <= 12);
+
+    if (month == 2) {
+        if ((year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)) {
+            days = 29;
+        } else {
+            days = 28;
+        }
+    } else {
+        days = daysPerMonth[month - 1];
+    }
+
+    return days;
+}
+
+// Given a year, month, day of the week, and the n-th occurrence this returns the day in the month
+// i.e The 2nd Wednesday in November 2023 is the 8th November. This function would return 8
+static UCHAR GetDayOfMonth (SHORT year, XBOX_TZ_STRUCT *tzInfo)
+{
+    UCHAR dayOfWeek = GetDayOfWeek(year, tzInfo->Month, 1);
+    UCHAR daysInMonth = GetDaysInMonth(year, tzInfo->Month);
+    UCHAR dayTargetCount = tzInfo->Day - 1;
+    UCHAR dayActual = 1;
+
+    // Find first occurrence of the weekday
+    dayActual += (tzInfo->DayOfWeek < dayOfWeek) ? (tzInfo->DayOfWeek + 7 - dayOfWeek) : (tzInfo->DayOfWeek - dayOfWeek);
+
+    // Add remaining weeks
+    dayActual += dayTargetCount * 7;
+
+    // If we overrun, go back to the last occurrence in the month
+    while (dayActual > daysInMonth) {
+        dayActual -= 7;
+    }
+    return dayActual;
+}
+
+static void XboxTimeZoneToSystemTime (LPSYSTEMTIME lpSystemTime, XBOX_TZ_STRUCT *tzInfo)
+{
+    lpSystemTime->wMonth = tzInfo->Month;
+    lpSystemTime->wDayOfWeek = tzInfo->DayOfWeek;
+    lpSystemTime->wDay = tzInfo->Day;
+    lpSystemTime->wHour = tzInfo->Hour;
+}
+
+static BOOL XboxTimeZoneValid (XBOX_TZ_STRUCT *tzInfo)
+{
+    if (tzInfo->Month > 12 || tzInfo->DayOfWeek > 6 || tzInfo->Hour > 23) {
+        return FALSE;
+    }
+    return TRUE;
+}
+
+DWORD GetTimeZoneInformation (LPTIME_ZONE_INFORMATION lpTimeZoneInformation)
+{
+    assert(lpTimeZoneInformation != NULL);
+
+    LONG timeZoneBias, daylightBias, standardBias, daylightDisableFlag;
+    LONG timeNow, daylightStart, daylightEnd;
+    XBOX_TZ_STRUCT daylightStartDate, daylightEndDate;
+    CHAR daylightName[4], standardName[4];
+    NTSTATUS queryStatus;
+    TIME_FIELDS dateNow;
+    LARGE_INTEGER kTime;
+    ULONG type;
+
+    memset(lpTimeZoneInformation, 0, sizeof(TIME_ZONE_INFORMATION));
+
+    queryStatus = ExQueryNonVolatileSetting(XC_TIMEZONE_BIAS, &type, &timeZoneBias, sizeof(timeZoneBias), NULL);
+    if (!NT_SUCCESS(queryStatus)) {
+        SetLastError(RtlNtStatusToDosError(queryStatus));
+        return TIME_ZONE_ID_INVALID;
+    }
+
+    lpTimeZoneInformation->Bias = timeZoneBias;
+
+    // Check if daylight savings time (DST) adjustment is enabled
+    queryStatus = ExQueryNonVolatileSetting(XC_MISC, &type, &daylightDisableFlag, sizeof(daylightDisableFlag), NULL);
+    if (!NT_SUCCESS(queryStatus)) {
+        SetLastError(RtlNtStatusToDosError(queryStatus));
+        return TIME_ZONE_ID_INVALID;
+    }
+
+    // DST adjustment is disabled
+    if (daylightDisableFlag & XC_MISC_FLAG_DISABLE_DST) {
+        return TIME_ZONE_ID_UNKNOWN;
+    }
+
+    // Query all DST info from EEPROM
+    // FIXME: One large EEPROM access could be better
+    queryStatus = ExQueryNonVolatileSetting(XC_TZ_DLT_DATE, &type, &daylightStartDate, sizeof(daylightStartDate), NULL);
+    if (!NT_SUCCESS(queryStatus)) {
+        SetLastError(RtlNtStatusToDosError(queryStatus));
+        return TIME_ZONE_ID_INVALID;
+    }
+    queryStatus = ExQueryNonVolatileSetting(XC_TZ_STD_DATE, &type, &daylightEndDate, sizeof(daylightEndDate), NULL);
+    if (!NT_SUCCESS(queryStatus)) {
+        SetLastError(RtlNtStatusToDosError(queryStatus));
+        return TIME_ZONE_ID_INVALID;
+    }
+    queryStatus = ExQueryNonVolatileSetting(XC_TZ_DLT_BIAS, &type, &daylightBias, sizeof(daylightBias), NULL);
+    if (!NT_SUCCESS(queryStatus)) {
+        SetLastError(RtlNtStatusToDosError(queryStatus));
+        return TIME_ZONE_ID_INVALID;
+    }
+    queryStatus = ExQueryNonVolatileSetting(XC_TZ_STD_BIAS, &type, &standardBias, sizeof(standardBias), NULL);
+    if (!NT_SUCCESS(queryStatus)) {
+        SetLastError(RtlNtStatusToDosError(queryStatus));
+        return TIME_ZONE_ID_INVALID;
+    }
+    queryStatus = ExQueryNonVolatileSetting(XC_TZ_DLT_NAME, &type, daylightName, sizeof(daylightName), NULL);
+    if (!NT_SUCCESS(queryStatus)) {
+        SetLastError(RtlNtStatusToDosError(queryStatus));
+        return TIME_ZONE_ID_INVALID;
+    }
+    queryStatus = ExQueryNonVolatileSetting(XC_TZ_STD_NAME, &type, standardName, sizeof(standardName), NULL);
+    if (!NT_SUCCESS(queryStatus)) {
+        SetLastError(RtlNtStatusToDosError(queryStatus));
+        return TIME_ZONE_ID_INVALID;
+    }
+
+    if ((XboxTimeZoneValid(&daylightStartDate) == FALSE) || (XboxTimeZoneValid(&daylightEndDate) == FALSE)) {
+        return TIME_ZONE_ID_INVALID;
+    }
+
+    // Xbox stores up to 4 characters here
+    for (UCHAR i = 0; i < 4; i++) {
+        lpTimeZoneInformation->StandardName[i] = standardName[i];
+        lpTimeZoneInformation->DaylightName[i] = daylightName[i];
+    }
+
+    // There was no DST info
+    if (daylightEndDate.Month == 0 || daylightStartDate.Month == 0) {
+        return TIME_ZONE_ID_UNKNOWN;
+    }
+
+    XboxTimeZoneToSystemTime(&lpTimeZoneInformation->DaylightDate, &daylightStartDate);
+    XboxTimeZoneToSystemTime(&lpTimeZoneInformation->StandardDate, &daylightEndDate);
+    lpTimeZoneInformation->DaylightBias = daylightBias;
+    lpTimeZoneInformation->StandardBias = standardBias;
+
+    // Now we need to determine if the current time is within the DST range
+    KeQuerySystemTime(&kTime);
+    RtlTimeToTimeFields(&kTime, &dateNow);
+
+    // Determine what day in the month DST starts and ends
+    UCHAR daylightStartDay = GetDayOfMonth(dateNow.Year, &daylightStartDate);
+    UCHAR daylightEndDay = GetDayOfMonth(dateNow.Year, &daylightEndDate);
+
+    // Fix month wrapping. i.e if DST is from Oct(10) to Feb(2) and the current month is Jan(1) we should be in DST
+    // Applying a simple check would result is 10 < 1 < 2 = false and incorrect
+    // To account for this, we offset the months in the following year by 12
+    // This results in the comparison 10 < 13(12+1) < 14(12+2) = true and is correct
+    if (daylightEndDate.Month < daylightStartDate.Month) {
+        if (dateNow.Month <= daylightEndDate.Month) {
+            dateNow.Month += 12;
+        }
+        daylightEndDate.Month += 12;
+    }
+
+    // Now that month wrapping is fixed, we convert the dates to minutes from the start of the year corresponding to daylightStartDate
+    // The conversion to minutes allows for easier comparison. The minute resolution allows for timezones with 0.5 hour offsets.
+    const LONG mpd = 24 * 60;  // Minutes per day
+    const LONG mpm = 31 * mpd; // Minutes per month. 31 is ok providing it's consistent
+    timeNow = (dateNow.Month * mpm) + (dateNow.Day * mpd) + (dateNow.Hour * 60) + dateNow.Minute;
+    // DST change overs happen in local time, so we need to add the respective biases too
+    daylightStart = (daylightStartDate.Month * mpm) + (daylightStartDay * mpd) + (daylightStartDate.Hour * 60) + timeZoneBias + standardBias;
+    daylightEnd = (daylightEndDate.Month * mpm) + (daylightEndDay * mpd) + (daylightEndDate.Hour * 60) + timeZoneBias + daylightBias;
+
+    if (timeNow >= daylightStart && timeNow < daylightEnd) {
+        return TIME_ZONE_ID_DAYLIGHT;
+    } else {
+        return TIME_ZONE_ID_STANDARD;
+    }
+}

--- a/lib/winapi/timezoneapi.h
+++ b/lib/winapi/timezoneapi.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2023 Ryan Wendland
+
+#ifndef __TIMEZONEAPI_H__
+#define __TIMEZONEAPI_H__
+
+#include <minwinbase.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define TIME_ZONE_ID_UNKNOWN 0
+#define TIME_ZONE_ID_STANDARD 1
+#define TIME_ZONE_ID_DAYLIGHT 2
+#define TIME_ZONE_ID_INVALID ((DWORD)0xFFFFFFFF)
+
+typedef struct _TIME_ZONE_INFORMATION {
+    LONG Bias;
+    WCHAR StandardName[32];
+    SYSTEMTIME StandardDate;
+    LONG StandardBias;
+    WCHAR DaylightName[32];
+    SYSTEMTIME DaylightDate;
+    LONG DaylightBias;
+} TIME_ZONE_INFORMATION, *PTIME_ZONE_INFORMATION, *LPTIME_ZONE_INFORMATION;
+
+DWORD GetTimeZoneInformation (LPTIME_ZONE_INFORMATION lpTimeZoneInformation);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/winapi/windows.h
+++ b/lib/winapi/windows.h
@@ -20,5 +20,6 @@
 #include <sysinfoapi.h>
 #include <winbase.h>
 #include <winerror.h>
+#include <timezoneapi.h>
 
 #endif

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -4216,6 +4216,9 @@ XBAPI OBJECT_TYPE ExSemaphoreObjectType;
 #define XC_ENCRYPTED_SECTION              0xFFFE
 #define XC_MAX_ALL                        0xFFFF
 
+// This bit is set in XC_MISC when automatic daylight savings time (DST) adjustment is disabled
+#define XC_MISC_FLAG_DISABLE_DST 0x02
+
 XBAPI NTSTATUS NTAPI ExSaveNonVolatileSetting
 (
     IN ULONG ValueIndex,


### PR DESCRIPTION
This PR adds [GetLocalTime](https://learn.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getlocaltime). This requires [GetTimeZoneInformation](https://learn.microsoft.com/en-us/windows/win32/api/timezoneapi/nf-timezoneapi-gettimezoneinformation) so is also added in this PR.

`GetTimeZoneInformation` reads the timezone biases, and daylight savings start/end times from the Xbox EEPROM and calculates whether the user is in DST or not and returns a TIME_ZONE_INFORMATION struct with all the timezone information. These EEPROM values are written by MSDash when you set your timezone.

This is used by `GetLocalTime` to determine the users current time based on the SystemTime.

DST is automatically adjusted for when the corresponding setting in MSDash is enabled (and your timezone supports it).

As this relies on hardcoded time info within MSDash that is ~20 years old some discrepencies exist with modern timezones and daylight savings. But I have ran this against about 10 timezones and the output matches what I expect given the inputs.

This is admittedly hard to test for all cases but to try get some edge cases I ran a loop that increments time by 30 minutes over a whole year over a few timezones to confirm the transitions to DST occur at the correct times which outputs as expected.

This simple test will print your current timezone info and localtime (Ran with `xemu.exe -device lpc47m157 -serial stdio` and tested on my 1.6 Xbox.)
```
const CHAR *tz_strs[] = {"TIME_ZONE_ID_UNKNOWN", "TIME_ZONE_ID_STANDARD", "TIME_ZONE_ID_DAYLIGHT"};

TIME_ZONE_INFORMATION tzInfo;
DWORD result = GetTimeZoneInformation(&tzInfo);
DbgPrint("TIMEZONE RESULT %s\n", tz_strs[result]);
DbgPrint("Time Zone Information:\n");
DbgPrint("Standard Name: %ls\n", tzInfo.StandardName);
DbgPrint("Daylight Name: %ls\n", tzInfo.DaylightName);
DbgPrint("Bias: %ld minutes\n", tzInfo.Bias);
DbgPrint("Standard Bias: %ld minutes\n", tzInfo.StandardBias);
DbgPrint("Daylight Bias: %ld minutes\n", tzInfo.DaylightBias);
DbgPrint("Standard Date: Month: %ld, Day: %ld, Time: %02ld:%02ld:%02ld\n",
       tzInfo.StandardDate.wMonth, tzInfo.StandardDate.wDay,
       tzInfo.StandardDate.wHour, tzInfo.StandardDate.wMinute, tzInfo.StandardDate.wSecond);
DbgPrint("Daylight Date: Month: %ld, Day: %ld, Time: %02ld:%02ld:%02ld\n",
       tzInfo.DaylightDate.wMonth, tzInfo.DaylightDate.wDay,
       tzInfo.DaylightDate.wHour, tzInfo.DaylightDate.wMinute, tzInfo.DaylightDate.wSecond);

SYSTEMTIME st;
GetLocalTime(&st);
DbgPrint("Local time %04d-%02d-%02d %02d:%02d:%02d\n",
    st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);
```

This should output something like this:
```
TIMEZONE RESULT TIME_ZONE_ID_STANDARD
Time Zone Information:
Standard Name: ACST
Daylight Name: ACDT
Bias: -570 minutes
Standard Bias: 0 minutes
Daylight Bias: -60 minutes
Standard Date: Month: 3, Day: 5, Time: 02:00:00
Daylight Date: Month: 10, Day: 5, Time: 02:00:00
Local time 2023-06-09 09:02:50
```