### PR TITLE
cmake: Set STANDARD_INCLUDE_DIRECTORIES

### DIFF
--- a/share/toolchain-nxdk.cmake
+++ b/share/toolchain-nxdk.cmake
@@ -21,10 +21,29 @@ set(NXDK 1)
 set(CMAKE_C_COMPILER "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-cc")
 set(CMAKE_C_STANDARD_LIBRARIES "${NXDK_DIR}/lib/libwinapi.lib ${NXDK_DIR}/lib/xboxkrnl/libxboxkrnl.lib ${NXDK_DIR}/lib/libxboxrt.lib  ${NXDK_DIR}/lib/libpdclib.lib ${NXDK_DIR}/lib/libnxdk_hal.lib ${NXDK_DIR}/lib/libnxdk.lib ${NXDK_DIR}/lib/nxdk_usb.lib") #"${CMAKE_CXX_STANDARD_LIBRARIES_INIT}"
 set(CMAKE_C_LINK_EXECUTABLE "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-link <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -out:<TARGET> <LINK_LIBRARIES>")
+# Keep in sync with include paths in bin/nxdk-cc
+set(CMAKE_C_STANDARD_INCLUDE_DIRECTORIES
+        "${NXDK_DIR}/lib"
+        "${NXDK_DIR}/lib/xboxrt/libc_extensions"
+        "${NXDK_DIR}/lib/pdclib/include"
+        "${NXDK_DIR}/lib/pdclib/platform/xbox/include"
+        "${NXDK_DIR}/lib/winapi"
+        "${NXDK_DIR}/lib/xboxrt/vcruntime"
+)
 
 set(CMAKE_CXX_COMPILER "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-cxx")
 set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} ${NXDK_DIR}/lib/libc++.lib")
 set(CMAKE_CXX_LINK_EXECUTABLE "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-link <FLAGS> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -out:<TARGET> <LINK_LIBRARIES>")
+# Keep in sync with include paths in bin/nxdk-cxx
+set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
+        "${NXDK_DIR}/lib/libcxx/include"
+        "${NXDK_DIR}/lib"
+        "${NXDK_DIR}/lib/xboxrt/libc_extensions"
+        "${NXDK_DIR}/lib/pdclib/include"
+        "${NXDK_DIR}/lib/pdclib/platform/xbox/include"
+        "${NXDK_DIR}/lib/winapi"
+        "${NXDK_DIR}/lib/xboxrt/vcruntime"
+)
 
 set(CMAKE_STATIC_LIBRARY_SUFFIX ".lib")
 set(CMAKE_STATIC_LIBRARY_SUFFIX_C ".lib")


### PR DESCRIPTION
Sets CMAKE_<LANG>_STANDARD_INCLUDE_DIRECTORIES for cc and cxx compilers. This allows tools like CLion to properly index the cross-compiler headers.