### PR TITLE
winapi: Add Event functions

### DIFF
--- a/lib/winapi/sync.c
+++ b/lib/winapi/sync.c
@@ -580,3 +580,80 @@ BOOL ReleaseMutex (HANDLE hMutex)
     SetLastError(RtlNtStatusToDosError(status));
     return FALSE;
 }
+
+HANDLE CreateEventA (LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState, LPCSTR lpName)
+{
+    NTSTATUS status;
+    HANDLE handle;
+    ANSI_STRING obj_name;
+    OBJECT_ATTRIBUTES obj_attributes;
+    POBJECT_ATTRIBUTES obj_attributes_ptr;
+    EVENT_TYPE event;
+
+    if (lpName) {
+        RtlInitAnsiString(&obj_name, lpName);
+        InitializeObjectAttributes(&obj_attributes, &obj_name, OBJ_OPENIF, ObWin32NamedObjectsDirectory(), NULL);
+        obj_attributes_ptr = &obj_attributes;
+    } else {
+        obj_attributes_ptr = NULL;
+    }
+
+    if (bManualReset) {
+        event = NotificationEvent;
+    } else {
+        event = SynchronizationEvent;
+    }
+
+    status = NtCreateEvent(&handle, obj_attributes_ptr, event, bInitialState);
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return NULL;
+    }
+
+    if (status == STATUS_OBJECT_NAME_EXISTS) {
+        SetLastError(ERROR_ALREADY_EXISTS);
+    } else {
+        SetLastError(0);
+    }
+
+    return handle;
+}
+
+BOOL SetEvent (HANDLE hEvent)
+{
+    NTSTATUS status;
+
+    status = NtSetEvent(hEvent, NULL);
+    if (NT_SUCCESS(status)) {
+        return TRUE;
+    }
+
+    SetLastError(RtlNtStatusToDosError(status));
+    return FALSE;
+}
+
+BOOL ResetEvent (HANDLE hEvent)
+{
+    NTSTATUS status;
+
+    status = NtClearEvent(hEvent);
+    if (NT_SUCCESS(status)) {
+        return TRUE;
+    }
+
+    SetLastError(RtlNtStatusToDosError(status));
+    return FALSE;
+}
+
+BOOL PulseEvent (HANDLE hEvent)
+{
+    NTSTATUS status;
+
+    status = NtPulseEvent(hEvent, NULL);
+    if (NT_SUCCESS(status)) {
+        return TRUE;
+    }
+
+    SetLastError(RtlNtStatusToDosError(status));
+    return FALSE;
+}

--- a/lib/winapi/synchapi.h
+++ b/lib/winapi/synchapi.h
@@ -67,8 +67,14 @@ BOOL ReleaseSemaphore (HANDLE hSemaphore, LONG lReleaseCount, LPLONG lpPreviousC
 HANDLE CreateMutexA (LPSECURITY_ATTRIBUTES lpMutexAttributes, BOOL bInitialOwner, LPCSTR lpName);
 BOOL ReleaseMutex (HANDLE hMutex);
 
+HANDLE CreateEventA (LPSECURITY_ATTRIBUTES lpEventAttributes, BOOL bManualReset, BOOL bInitialState, LPCSTR lpName);
+BOOL SetEvent (HANDLE hEvent);
+BOOL ResetEvent (HANDLE hEvent);
+BOOL PulseEvent (HANDLE hEvent);
+
 #ifndef UNICODE
 #define CreateMutex CreateMutexA
+#define CreateEvent CreateEventA
 #else
 #error nxdk does not support the Unicode API
 #endif


### PR DESCRIPTION
I need asynchronous File IO using overlapped functions which is [not currently supported](https://github.com/XboxDev/nxdk/blob/9daebb58281125c6e0b7be8ebd36e93be06db63f/lib/winapi/fileio.c#L107). Win32 uses  [Event Objects](https://learn.microsoft.com/en-us/windows/win32/sync/event-objects) to achieve this.

This is the first step to support overlapped IO.

Usage example below that simply has a sleeping thread wait for an event. Also tests some error scenarios.

<!-- JFR: added syntax-highlight to codeblock -->
```c
#include <windows.h>
#include <stdio.h>
#include <assert.h>
#include <hal/video.h>
#include <hal/debug.h>

static DWORD WINAPI EventThread(LPVOID lpParam)
{
    HANDLE hEvent = (HANDLE)lpParam;
    while (1) {
        if (WaitForSingleObject(hEvent, INFINITE) == WAIT_OBJECT_0) {
            debugPrint("Thread received the event!\n");
        }
    }
    return 0;
}

int main()
{
    HANDLE hEvent1, hEvent2, hMutex;

    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    // Create a named event. Then try create another event with the same name,
    // Also create a different object type with the same name and confirm errors match up
    hEvent1 = CreateEvent(NULL, FALSE, FALSE, "hello world");
    hEvent2 = CreateEvent(NULL, FALSE, FALSE, "hello world");
    assert(GetLastError() == ERROR_ALREADY_EXISTS);
    hMutex = CreateMutex(NULL, FALSE, "hello world");
    assert(GetLastError() == ERROR_INVALID_HANDLE);

    HANDLE hThread = CreateThread(NULL, 0, EventThread, hEvent1, 0, NULL);

    debugPrint("Setting the event in 2 seconds\n\n");
    Sleep(2000);
    assert(SetEvent(hEvent1) == TRUE);
    Sleep(500); //Manual Reset is FALSE, so make sure the thread isnt spamming while we sleep here.
    assert(ResetEvent(hEvent1) == TRUE);

    debugPrint("Pulsing the event 3 times in 2 seconds...\n\n");
    Sleep(2000);
    for (INT i = 0; i < 3; i++) {
        assert(PulseEvent(hEvent1) == TRUE);
        Sleep(100);
    }
    Sleep(100);
    debugPrint("Test Complete!\n");
    while(1) Sleep(1000);
}
```
 Ouputs below. I ran the same code natively on my windows PC and the output is the same.
![xemu-2023-06-24-13-14-23](https://github.com/XboxDev/nxdk/assets/21236406/f540c474-4a48-45b1-99aa-499cd5f963d2)

