### PR TITLE
cxbe: Fix sprintf compiler warnings

### DIFF
--- a/tools/cxbe/Exe.cpp
+++ b/tools/cxbe/Exe.cpp
@@ -109,7 +109,7 @@ Exe::Exe(const char *x_szFilename)
             if(fread(&m_SectionHeader[v], sizeof(SectionHeader), 1, ExeFile) != 1)
             {
                 char buffer[255];
-                sprintf(buffer, "Could not read PE section header %d (%Xh)", v, v);
+                snprintf(buffer, sizeof(buffer), "Could not read PE section header %d (%Xh)", v, v);
                 SetError(buffer, true);
                 goto cleanup;
             }
@@ -148,7 +148,7 @@ Exe::Exe(const char *x_szFilename)
                 if(fread(m_bzSection[v], raw_size, 1, ExeFile) != 1)
                 {
                     char buffer[255];
-                    sprintf(buffer, "Could not read PE section %d (%Xh)", v, v);
+                    snprintf(buffer, sizeof(buffer), "Could not read PE section %d (%Xh)", v, v);
                     SetError(buffer, true);
                     goto cleanup;
                 }
@@ -267,7 +267,7 @@ void Exe::Export(const char *x_szExeFilename)
             if(fwrite(&m_SectionHeader[v], sizeof(SectionHeader), 1, ExeFile) != 1)
             {
                 char buffer[255];
-                sprintf(buffer, "Could not write PE section header %d (%Xh)", v, v);
+                snprintf(buffer, sizeof(buffer), "Could not write PE section header %d (%Xh)", v, v);
                 SetError(buffer, false);
                 goto cleanup;
             }
@@ -298,7 +298,7 @@ void Exe::Export(const char *x_szExeFilename)
             if(fwrite(m_bzSection[v], RawSize, 1, ExeFile) != 1)
             {
                 char buffer[255];
-                sprintf(buffer, "Could not write PE section %d (%Xh)", v, v);
+                snprintf(buffer, sizeof(buffer), "Could not write PE section %d (%Xh)", v, v);
                 SetError(buffer, false);
                 goto cleanup;
             }

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -115,7 +115,11 @@ Xbe::Xbe(const char *x_szFilename)
 
             if(fread(&m_SectionHeader[v], sizeof(*m_SectionHeader), 1, XbeFile) != 1)
             {
-                sprintf(szBuffer, "Unexpected end of file while reading Xbe Section Header %d (%Xh)", v, v);
+                snprintf(szBuffer,
+                         sizeof(szBuffer),
+                         "Unexpected end of file while reading Xbe Section Header %d (%Xh)",
+                         v,
+                         v);
                 SetError(szBuffer, true);
                 goto cleanup;
             }
@@ -167,7 +171,11 @@ Xbe::Xbe(const char *x_szFilename)
 
             if(fread(&m_LibraryVersion[v], sizeof(*m_LibraryVersion), 1, XbeFile) != 1)
             {
-                sprintf(szBuffer, "Unexpected end of file while reading Xbe Library Version %d (%Xh)", v, v);
+                snprintf(szBuffer,
+                         sizeof(szBuffer),
+                         "Unexpected end of file while reading Xbe Library Version %d (%Xh)",
+                         v,
+                         v);
                 SetError(szBuffer, true);
                 goto cleanup;
             }
@@ -249,7 +257,12 @@ Xbe::Xbe(const char *x_szFilename)
 
             if(fread(m_bzSection[v], RawSize, 1, XbeFile) != 1)
             {
-                sprintf(szBuffer, "Unexpected end of file while reading Xbe Section %d (%Xh) (%s)", v, v, m_szSectionName[v]);
+                snprintf(szBuffer,
+                         sizeof(szBuffer),
+                         "Unexpected end of file while reading Xbe Section %d (%Xh) (%s)",
+                         v,
+                         v,
+                         m_szSectionName[v]);
                 SetError(szBuffer, true);
                 goto cleanup;
             }
@@ -962,7 +975,11 @@ void Xbe::Export(const char *x_szXbeFilename)
 
             if(fwrite(&m_SectionHeader[v], sizeof(*m_SectionHeader), 1, XbeFile) != 1)
             {
-                sprintf(szBuffer, "Unexpected write error while writing Xbe Section %d (%Xh)", v, v);
+                snprintf(szBuffer,
+                         sizeof(szBuffer),
+                         "Unexpected write error while writing Xbe Section %d (%Xh)",
+                         v,
+                         v);
                 SetError(szBuffer, false);
                 goto cleanup;
             }
@@ -992,7 +1009,12 @@ void Xbe::Export(const char *x_szXbeFilename)
 
             if(fwrite(m_bzSection[v], RawSize, 1, XbeFile) != 1)
             {
-                sprintf(szBuffer, "Unexpected write error while writing Xbe Section %d (%Xh) (%s)", v, v, m_szSectionName[v]);
+                snprintf(szBuffer,
+                         sizeof(szBuffer),
+                         "Unexpected write error while writing Xbe Section %d (%Xh) (%s)",
+                         v,
+                         v,
+                         m_szSectionName[v]);
                 SetError(szBuffer, false);
                 goto cleanup;
             }


### PR DESCRIPTION
Switches use of sprintf to snprintf to prevent a bunch of clang deprecation warnings.