### PR TITLE
cxbe: Support non-kernel imports

### DIFF
--- a/tools/cxbe/Exe.cpp
+++ b/tools/cxbe/Exe.cpp
@@ -180,8 +180,8 @@ cleanup:
 // constructor initialization
 void Exe::ConstructorInit()
 {
-    m_SectionHeader = 0;
-    m_bzSection     = 0;
+    m_SectionHeader = nullptr;
+    m_bzSection     = nullptr;
 }
 
 // deconstructor
@@ -326,6 +326,10 @@ cleanup:
     return;
 }
 
+const uint08 *Exe::ReadAddr(uint32 x_dwVirtualAddress) const {
+    return const_cast<Exe*>(this)->GetAddr(x_dwVirtualAddress);
+}
+
 // return a modifiable pointer inside this structure that corresponds to a virtual address
 uint08 *Exe::GetAddr(uint32 x_dwVirtualAddress)
 {
@@ -338,5 +342,5 @@ uint08 *Exe::GetAddr(uint32 x_dwVirtualAddress)
             return &m_bzSection[v][x_dwVirtualAddress - virt_addr];
     }
 
-    return 0;
+    return nullptr;
 }

--- a/tools/cxbe/Exe.h
+++ b/tools/cxbe/Exe.h
@@ -9,6 +9,18 @@
 
 #include "Error.h"
 
+typedef struct IMAGE_IMPORT_DESCRIPTOR
+{
+    union {
+        uint32 Characteristics;
+        uint32 OriginalFirstThunk;
+    } DUMMYUNIONNAME;
+    uint32 TimeDateStamp;
+    uint32 ForwarderChain;
+    uint32 Name;
+    uint32 FirstThunk;
+} IMAGE_IMPORT_DESCRIPTOR;
+
 // Exe (PE) file object
 class Exe : public Error
 {
@@ -126,6 +138,9 @@ class Exe : public Error
 
         // array of section data
         uint08 **m_bzSection;
+
+        // return a const pointer inside this structure that corresponds to a virtual address
+        const uint08 *ReadAddr(uint32 x_dwVirtualAddress) const;
 
     protected:
         // protected default constructor

--- a/tools/cxbe/Xbe.h
+++ b/tools/cxbe/Xbe.h
@@ -15,6 +15,12 @@
 
 static const int XBE_UNCOMPRESSED_LOGO_SIZE = 100*17;
 
+typedef struct XBE_IMAGE_IMPORT_DESCRIPTOR
+{
+    uint32 FirstThunk;
+    uint32 WideCharName;
+} __attribute((packed)) XBE_IMAGE_IMPORT_DESCRIPTOR;
+
 // Xbe (Xbox Executable) file object
 class Xbe : public Error
 {
@@ -189,6 +195,9 @@ class Xbe : public Error
         // Xbe ascii title, translated from certificate title
         char m_szAsciiTitle[40+1];
 
+        // addr of area reserved for import table names converted from ASCII to wide characters.
+        uint32 m_ImportNameAddr;
+
         // retrieve thread local storage data address
         uint08 *GetTLSData() { if(m_TLS == 0) return 0; else return GetAddr(m_TLS->dwDataStartAddr); }
 
@@ -204,6 +213,9 @@ class Xbe : public Error
 
         // return a modifiable pointer to logo bitmap data
         uint08 *GetLogoBitmap(uint32 x_dwSize);
+
+        // sets the dwKernelImageThunkAddr and dwNonKernelImportDirAddr fields from the given Exe.
+        bool ProcessImportTable(class Exe *x_Exe, bool x_bRetail);
 
         // used to encode/decode logo bitmap data
         union LogoRLE


### PR DESCRIPTION
This implements handling for `dwNonKernelImportDirAddr` in DEBUG mode, allowing nxdk-based XBEs to make use of `xbdm.dll` and other non-kernel imports.