### PR TITLE
Fix macOS build

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -69,11 +69,11 @@ jobs:
           submodules: recursive
       - name: Install Dependencies
         env:
+          HOMEBREW_NO_AUTO_UPDATE: 1
           HOMEBREW_NO_ANALYTICS: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew doctor || true
-          brew update-reset && brew install llvm coreutils
+          brew install llvm coreutils
       - name: Build
         run: ./.ci_build_samples.sh
   ubuntu:

--- a/tools/cxbe/Exe.cpp
+++ b/tools/cxbe/Exe.cpp
@@ -180,8 +180,8 @@ cleanup:
 // constructor initialization
 void Exe::ConstructorInit()
 {
-    m_SectionHeader = nullptr;
-    m_bzSection     = nullptr;
+    m_SectionHeader = NULL;
+    m_bzSection     = NULL;
 }
 
 // deconstructor
@@ -342,5 +342,5 @@ uint08 *Exe::GetAddr(uint32 x_dwVirtualAddress)
             return &m_bzSection[v][x_dwVirtualAddress - virt_addr];
     }
 
-    return nullptr;
+    return NULL;
 }


### PR DESCRIPTION
The wonderful Homebrew package manager exits with an error code after refusing to remove symlinks from older versions of packages when updating packages during an install of a new package. Just remove the brew update to avoid the issue. We don't need bleeding edge llvm and will get updates periodically with runner updates anyway.

Replaces newly added `nullptr` usage with `NULL` for older C++ compiler standard compat.