### PR TITLE
Added various features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,6 @@ else
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
 	$(VE) $(LD) $(NXDK_LDFLAGS) $(LDFLAGS) -out:'$@' $^
-	$(VE) objcopy --rename-section 'XTIMAGE=$$$$XTIMAGE' --rename-section 'XSIMAGE=$$$$XSIMAGE' $@ || exit 0
 endif
 
 %.lib:

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,6 @@ endif
 ifeq ($(XBE_TITLE),)
 XBE_TITLE = nxdk_app
 endif
-ifeq ($(XBE_TITLEID),)
-XBE_TITLEID = FFFF0002
-endif
 
 ifeq ($(OUTPUT_DIR),)
 OUTPUT_DIR = bin

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ endif
 ifeq ($(XBE_TITLE),)
 XBE_TITLE = nxdk_app
 endif
+ifeq ($(XBE_TITLEID),)
+XBE_TITLEID = FFFF0002
+endif
 
 ifeq ($(OUTPUT_DIR),)
 OUTPUT_DIR = bin
@@ -98,7 +101,8 @@ DEPS += $(filter %.cpp.d, $(SRCS:.cpp=.cpp.d))
 
 $(OUTPUT_DIR)/default.xbe: main.exe $(OUTPUT_DIR) $(CXBE)
 	@echo "[ CXBE     ] $@"
-	$(VE)$(CXBE) -OUT:$@ -TITLE:$(XBE_TITLE) $< $(QUIET)
+	$(VE)$(CXBE) -OUT:$@ -TITLE:$(XBE_TITLE) -TITLEID:$(XBE_TITLEID) \
+	    -REGION:$(XBE_REGION) -VERSION:$(XBE_VERSION) $< $(QUIET)
 
 $(OUTPUT_DIR):
 	@mkdir -p $(OUTPUT_DIR);
@@ -118,6 +122,7 @@ else
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"
 	$(VE) $(LD) $(NXDK_LDFLAGS) $(LDFLAGS) -out:'$@' $^
+	$(VE) objcopy --rename-section 'XTIMAGE=$$$$XTIMAGE' --rename-section 'XSIMAGE=$$$$XSIMAGE' $@ || exit 0
 endif
 
 %.lib:

--- a/tools/cxbe/Exe.cpp
+++ b/tools/cxbe/Exe.cpp
@@ -122,8 +122,10 @@ Exe::Exe(const char *x_szFilename)
                 for(uint32 i = 1; i < 8; ++i)
                 {
                     char c = m_SectionHeader[v].m_name[i];
-                    if(c < '0' || c > '9')
+                    if(!c)
                         break;
+                    if(c < '0' || c > '9') // not a long section after all?
+                        goto notlong;
                     m_SectionHeader_longname[v].m_offset *= 10;
                     m_SectionHeader_longname[v].m_offset += c - '0';
                 }
@@ -133,14 +135,13 @@ Exe::Exe(const char *x_szFilename)
                 fseek(ExeFile, m_Header.m_symbol_table_addr + m_SectionHeader_longname[v].m_offset,
                       SEEK_SET);
 
-                uint32 i = 0;
-                while(i < 255)
+                uint32 i;
+                for(i = 0; i < 255; ++i)
                 {
                     int c = fgetc(ExeFile);
                     if(!c || c == EOF)
                         break;
                     m_SectionHeader_longname[v].m_longname[i] = c;
-                    ++i;
                 }
                 m_SectionHeader_longname[v].m_longname[i] = 0;
 
@@ -150,6 +151,7 @@ Exe::Exe(const char *x_szFilename)
             }
             else
             {
+            notlong:;
                 m_SectionHeader_longname[v].m_longname = NULL;
             }
 

--- a/tools/cxbe/Exe.cpp
+++ b/tools/cxbe/Exe.cpp
@@ -146,16 +146,15 @@ Exe::Exe(const char *x_szFilename)
                 m_SectionHeader_longname[v].m_longname[i] = 0;
 
                 fseek(ExeFile, tmppos, SEEK_SET);
-                printf(" (long: offset=%u name=%s) ", m_SectionHeader_longname[v].m_offset,
+                printf("OK %d (long)\n", v, m_SectionHeader_longname[v].m_offset,
                        m_SectionHeader_longname[v].m_longname);
             }
             else
             {
             notlong:;
                 m_SectionHeader_longname[v].m_longname = NULL;
+                printf("OK %d\n", v);
             }
-
-            printf("OK %d\n", v);
         }
     }
 

--- a/tools/cxbe/Exe.h
+++ b/tools/cxbe/Exe.h
@@ -127,6 +127,13 @@ class Exe : public Error
         uint32 m_characteristics;  // characteristics for this segment
     } __attribute((packed)) * m_SectionHeader;
 
+    // array to store long section names
+    struct SectionHeader_longname
+    {
+        char *m_longname;
+        uint32 m_offset;
+    } __attribute((packed)) * m_SectionHeader_longname;
+
     // array of section data
     uint08 **m_bzSection;
 

--- a/tools/cxbe/Main.cpp
+++ b/tools/cxbe/Main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     char szLogo[OPTION_LEN + 1] = "";
 
     bool bRetail;
-    uint32 dwTitleId = 0x4358270F; // CX-9999
+    uint32 dwTitleId = 0xFFFF0002;
     uint32 dwRegions;
     uint32 dwVersion;
 
@@ -87,8 +87,8 @@ int main(int argc, char *argv[])
         }
         else
         {
-            char titlechar[2] = { 'C', 'X' };
-            unsigned titleno = 9999;
+            char titlechar[2] = { (char)0xFF, (char)0xFF };
+            unsigned titleno = 0x0002;
             sscanf(szXbeTitleID, "%c%c-%u", &titlechar[0], &titlechar[1], &titleno);
             if(titleno > 0xFFFF)
             {

--- a/tools/cxbe/Main.cpp
+++ b/tools/cxbe/Main.cpp
@@ -9,6 +9,7 @@
 #include "Exe.h"
 #include "Xbe.h"
 
+#include <stdlib.h>
 #include <string.h>
 
 // program entry point
@@ -21,12 +22,14 @@ int main(int argc, char *argv[])
     char szXbeTitle[OPTION_LEN + 1] = "Untitled";
     char szXbeTitleID[OPTION_LEN + 1] = "";
     char szXbeRegions[OPTION_LEN + 1] = "";
+    char szXbeVersion[OPTION_LEN + 1] = "";
     char szMode[OPTION_LEN + 1] = "retail";
     char szLogo[OPTION_LEN + 1] = "";
 
     bool bRetail;
     uint32 dwTitleId = 0x4358270F; // CX-9999
     uint32 dwRegions;
+    uint32 dwVersion;
 
     const char *program = argv[0];
     const char *program_desc = "CXBE EXE to XBE (win32 to Xbox) Relinker (Version: " VERSION ")";
@@ -39,6 +42,7 @@ int main(int argc, char *argv[])
         { szXbeRegions, "REGION",
           "{-|[n][j][w][m]|a}\n"
           "    -=none, n=North America, j=Japan, w=world, m=manufacturing, a=njwm" },
+        { szXbeVersion, "VERSION", "version" },
         { szMode, "MODE", "{debug|retail}" },
         { szLogo, "LOGO", "filename" },
         { NULL }
@@ -136,6 +140,16 @@ int main(int argc, char *argv[])
                     XBEIMAGE_GAME_REGION_RESTOFWORLD | XBEIMAGE_GAME_REGION_MANUFACTURING;
     }
 
+    // interpret version
+    if(szXbeVersion[0])
+    {
+        dwVersion = strtoul(szXbeVersion, NULL, 0);
+    }
+    else
+    {
+        dwVersion = 0;
+    }
+
     // verify we received the required parameters
     if(szExeFilename[0] == '\0')
     {
@@ -172,7 +186,8 @@ int main(int argc, char *argv[])
             LogoPtr = &logo;
         }
 
-        Xbe *XbeFile = new Xbe(ExeFile, szXbeTitle, dwTitleId, dwRegions, bRetail, LogoPtr);
+        Xbe *XbeFile =
+            new Xbe(ExeFile, szXbeTitle, dwTitleId, dwRegions, dwVersion, bRetail, LogoPtr);
 
         if(XbeFile->GetError() != 0)
         {

--- a/tools/cxbe/Main.cpp
+++ b/tools/cxbe/Main.cpp
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
 
     bool bRetail;
     uint32 dwTitleId = 0xFFFF0002;
-    uint32 dwRegions;
+    uint32 dwRegions = XBEIMAGE_GAME_REGION_NA | XBEIMAGE_GAME_REGION_JAPAN | XBEIMAGE_GAME_REGION_RESTOFWORLD | XBEIMAGE_GAME_REGION_MANUFACTURING;;
     uint32 dwVersion;
 
     const char *program = argv[0];
@@ -87,9 +87,13 @@ int main(int argc, char *argv[])
         }
         else
         {
-            char titlechar[2] = { (char)0xFF, (char)0xFF };
-            unsigned titleno = 0x0002;
-            sscanf(szXbeTitleID, "%c%c-%u", &titlechar[0], &titlechar[1], &titleno);
+            char titlechar[2];
+            unsigned titleno;
+            if (sscanf(szXbeTitleID, "%c%c-%u", &titlechar[0], &titlechar[1], &titleno) != 3)
+            {
+                strncpy(szErrorMessage, "invalid TITLEID", ERROR_LEN);
+                goto cleanup;
+            }
             if(titleno > 0xFFFF)
             {
                 printf("WARNING: Title ID number too high (max is 65535)\n");
@@ -102,6 +106,7 @@ int main(int argc, char *argv[])
     // interpret region flags
     if(szXbeRegions[0])
     {
+        dwRegions = 0;
         char c;
         for(int i = 0; (c = szXbeRegions[i]); ++i)
         {
@@ -109,11 +114,6 @@ int main(int argc, char *argv[])
             {
                 case '-':;
                     dwRegions = 0;
-                    goto breakfor;
-                case 'a':;
-                    dwRegions = XBEIMAGE_GAME_REGION_NA | XBEIMAGE_GAME_REGION_JAPAN |
-                                XBEIMAGE_GAME_REGION_RESTOFWORLD |
-                                XBEIMAGE_GAME_REGION_MANUFACTURING;
                     goto breakfor;
                 case 'n':;
                     dwRegions |= XBEIMAGE_GAME_REGION_NA;
@@ -133,11 +133,6 @@ int main(int argc, char *argv[])
             }
         }
     breakfor:;
-    }
-    else
-    {
-        dwRegions = XBEIMAGE_GAME_REGION_NA | XBEIMAGE_GAME_REGION_JAPAN |
-                    XBEIMAGE_GAME_REGION_RESTOFWORLD | XBEIMAGE_GAME_REGION_MANUFACTURING;
     }
 
     // interpret version

--- a/tools/cxbe/Main.cpp
+++ b/tools/cxbe/Main.cpp
@@ -40,8 +40,8 @@ int main(int argc, char *argv[])
         { szXbeTitle, "TITLE", "title" },
         { szXbeTitleID, "TITLEID", "{%c%c-%u|%x}" },
         { szXbeRegions, "REGION",
-          "{-|[n][j][w][m]|a}\n"
-          "    -=none, n=North America, j=Japan, w=world, m=manufacturing, a=njwm" },
+          "{-|[n][j][w][m]}\n"
+          "    -=none, n=North America, j=Japan, w=world, m=manufacturing" },
         { szXbeVersion, "VERSION", "version" },
         { szMode, "MODE", "{debug|retail}" },
         { szLogo, "LOGO", "filename" },

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -357,14 +357,27 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, uint32 x_d
 
                 memset(&m_SectionHeader[v].dwFlags, 0, sizeof(m_SectionHeader->dwFlags));
 
-                if(characteristics & IMAGE_SCN_MEM_WRITE)
-                    m_SectionHeader[v].dwFlags.bWritable = true;
+                // check for $$XTIMAGE or $$XSIMAGE and set the correct flags
+                if(x_Exe->m_SectionHeader_longname[v].m_longname &&
+                   (!strcmp(x_Exe->m_SectionHeader_longname[v].m_longname, "$$XTIMAGE") ||
+                    !strcmp(x_Exe->m_SectionHeader_longname[v].m_longname, "$$XSIMAGE")))
+                {
+                    m_SectionHeader[v].dwFlags.bInsertedFile = true;
+                    m_SectionHeader[v].dwFlags.bHeadPageRO = true;
+                    m_SectionHeader[v].dwFlags.bTailPageRO = true;
+                }
+                else
+                {
+                    if(characteristics & IMAGE_SCN_MEM_WRITE)
+                        m_SectionHeader[v].dwFlags.bWritable = true;
 
-                if((characteristics & IMAGE_SCN_MEM_EXECUTE) ||
-                   (characteristics & IMAGE_SCN_CNT_CODE))
-                    m_SectionHeader[v].dwFlags.bExecutable = true;
+                    if((characteristics & IMAGE_SCN_MEM_EXECUTE) ||
+                       (characteristics & IMAGE_SCN_CNT_CODE))
+                        m_SectionHeader[v].dwFlags.bExecutable = true;
 
-                m_SectionHeader[v].dwFlags.bPreload = true;
+                    m_SectionHeader[v].dwFlags.bPreload = true;
+                }
+
                 m_SectionHeader[v].dwVirtualAddr =
                     x_Exe->m_SectionHeader[v].m_virtual_addr + m_Header.dwPeBaseAddr;
 

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -20,8 +20,8 @@ static const char kKernelImageName[] = "xboxkrnl.exe";
 static uint32 CountNonKernelImportTableEntries(class Exe *x_Exe, uint32_t *extra_bytes);
 
 // construct via Exe file object
-Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, bool x_bRetail,
-         const std::vector<uint08> *logo)
+Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, uint32 x_dwRegions,
+         bool x_bRetail, const std::vector<uint08> *logo)
 {
     ConstructorInit();
 
@@ -285,10 +285,7 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, bool x_bRe
                 XBEIMAGE_MEDIA_TYPE_MEDIA_BOARD | XBEIMAGE_MEDIA_TYPE_NONSECURE_HARD_DISK |
                 XBEIMAGE_MEDIA_TYPE_NONSECURE_MODE;
 
-            // TODO: allow configuration
-            m_Certificate.dwGameRegion = XBEIMAGE_GAME_REGION_MANUFACTURING |
-                                         XBEIMAGE_GAME_REGION_NA | XBEIMAGE_GAME_REGION_JAPAN |
-                                         XBEIMAGE_GAME_REGION_RESTOFWORLD;
+            m_Certificate.dwGameRegion = x_dwRegions;
 
             // TODO: allow configuration
             m_Certificate.dwGameRatings = 0xFFFFFFFF;

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -20,7 +20,8 @@ static const char kKernelImageName[] = "xboxkrnl.exe";
 static uint32 CountNonKernelImportTableEntries(class Exe *x_Exe, uint32_t *extra_bytes);
 
 // construct via Exe file object
-Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vector<uint08> *logo)
+Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, bool x_bRetail,
+         const std::vector<uint08> *logo)
 {
     ConstructorInit();
 
@@ -259,8 +260,7 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vec
 
             m_Certificate.dwTimeDate = CurrentTime;
 
-            // TODO: generate in the form CX-9999
-            m_Certificate.dwTitleId = 0xFFFF0002;
+            m_Certificate.dwTitleId = x_dwTitleID;
 
             // title name
             memset(m_Certificate.wszTitleName, 0, sizeof(m_Certificate.wszTitleName));

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -21,7 +21,7 @@ static uint32 CountNonKernelImportTableEntries(class Exe *x_Exe, uint32_t *extra
 
 // construct via Exe file object
 Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, uint32 x_dwRegions,
-         bool x_bRetail, const std::vector<uint08> *logo)
+         uint32 x_dwVersion, bool x_bRetail, const std::vector<uint08> *logo)
 {
     ConstructorInit();
 
@@ -293,8 +293,7 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, uint32 x_d
             // always disk 0, AFAIK
             m_Certificate.dwDiskNumber = 0;
 
-            // TODO: allow configuration
-            m_Certificate.dwVersion = 0;
+            m_Certificate.dwVersion = x_dwVersion;
 
             // generate blank LAN, signature, and alternate signature keys
             {

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -375,7 +375,11 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, uint32 x_d
                        (characteristics & IMAGE_SCN_CNT_CODE))
                         m_SectionHeader[v].dwFlags.bExecutable = true;
 
-                    m_SectionHeader[v].dwFlags.bPreload = true;
+                    char *name = (x_Exe->m_SectionHeader_longname[v].m_longname)
+                                     ? x_Exe->m_SectionHeader_longname[v].m_longname
+                                     : (char *)x_Exe->m_SectionHeader[v].m_name;
+                    m_SectionHeader[v].dwFlags.bPreload =
+                        (strcmp(name, ".debug") && strncmp(name, ".debug_", 7));
                 }
 
                 m_SectionHeader[v].dwVirtualAddr =

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -111,8 +111,16 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vec
             {
                 uint32 s = 0;
 
-                while(s < 8 && x_Exe->m_SectionHeader[v].m_name[s] != '\0')
-                    s++;
+                if(x_Exe->m_SectionHeader_longname[v].m_longname)
+                {
+                    while(s < 255 && x_Exe->m_SectionHeader_longname[v].m_longname[s] != '\0')
+                        s++;
+                }
+                else
+                {
+                    while(s < 8 && x_Exe->m_SectionHeader[v].m_name[s] != '\0')
+                        s++;
+                }
 
                 mrc += s + 1;
             }
@@ -325,7 +333,7 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vec
 
         // write section headers / section names
         {
-            m_szSectionName = new char[m_Header.dwSections][9];
+            m_szSectionName = new char[m_Header.dwSections][256];
 
             m_SectionHeader = new SectionHeader[m_Header.dwSections];
 
@@ -411,10 +419,21 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vec
                     memset(secn, 0, 8);
 
                     m_SectionHeader[v].dwSectionNameAddr = hwc_secn;
-                    while(s < 8 && x_Exe->m_SectionHeader[v].m_name[s] != '\0')
+                    if(x_Exe->m_SectionHeader_longname[v].m_longname)
                     {
-                        m_szSectionName[v][s] = secn[s] = x_Exe->m_SectionHeader[v].m_name[s];
-                        s++;
+                        while(s < 255 && x_Exe->m_SectionHeader_longname[v].m_longname[s] != '\0')
+                        {
+                            m_szSectionName[v][s] = secn[s] = x_Exe->m_SectionHeader_longname[v].m_longname[s];
+                            s++;
+                        }
+                    }
+                    else
+                    {
+                        while(s < 8 && x_Exe->m_SectionHeader[v].m_name[s] != '\0')
+                        {
+                            m_szSectionName[v][s] = secn[s] = x_Exe->m_SectionHeader[v].m_name[s];
+                            s++;
+                        }
                     }
 
                     m_szSectionName[v][s] = '\0';

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -533,7 +533,8 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vec
 
                 uint32 RawSize = m_SectionHeader[v].dwSizeofRaw;
 
-                m_bzSection[v] = new uint08[RawSize];
+                m_bzSection[v] = new uint08[RawSize + 1];
+                m_bzSection[v][RawSize] = 0;
 
                 memcpy(m_bzSection[v], x_Exe->m_bzSection[v], RawSize);
 

--- a/tools/cxbe/Xbe.h
+++ b/tools/cxbe/Xbe.h
@@ -26,8 +26,8 @@ class Xbe : public Error
 {
   public:
     // construct via Exe file object
-    Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, bool x_bRetail,
-        const std::vector<uint08> *logo = nullptr);
+    Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, uint32 x_dwRegions,
+        bool x_bRetail, const std::vector<uint08> *logo = nullptr);
 
     // deconstructor
     ~Xbe();

--- a/tools/cxbe/Xbe.h
+++ b/tools/cxbe/Xbe.h
@@ -27,7 +27,7 @@ class Xbe : public Error
   public:
     // construct via Exe file object
     Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, uint32 x_dwRegions,
-        bool x_bRetail, const std::vector<uint08> *logo = nullptr);
+        uint32 x_dwVersion, bool x_bRetail, const std::vector<uint08> *logo = nullptr);
 
     // deconstructor
     ~Xbe();

--- a/tools/cxbe/Xbe.h
+++ b/tools/cxbe/Xbe.h
@@ -26,7 +26,7 @@ class Xbe : public Error
 {
   public:
     // construct via Exe file object
-    Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail,
+    Xbe(class Exe *x_Exe, const char *x_szTitle, uint32 x_dwTitleID, bool x_bRetail,
         const std::vector<uint08> *logo = nullptr);
 
     // deconstructor

--- a/tools/cxbe/Xbe.h
+++ b/tools/cxbe/Xbe.h
@@ -172,8 +172,6 @@ class Xbe : public Error
     } __attribute((packed)) * m_TLS;
 
     // Xbe section names, each 255 bytes max and null terminated
-    // Old value was 8 which caused problems
-    // For example, $$XTIMAGE and $$XSIMAGE are 9 bytes long not including null
     char (*m_szSectionName)[256];
 
     // Xbe sections

--- a/tools/cxbe/Xbe.h
+++ b/tools/cxbe/Xbe.h
@@ -171,8 +171,10 @@ class Xbe : public Error
         uint32 dwCharacteristics; // characteristics
     } __attribute((packed)) * m_TLS;
 
-    // Xbe section names, each 8 bytes max and null terminated
-    char (*m_szSectionName)[9];
+    // Xbe section names, each 255 bytes max and null terminated
+    // Old value was 8 which caused problems
+    // For example, $$XTIMAGE and $$XSIMAGE are 9 bytes long not including null
+    char (*m_szSectionName)[256];
 
     // Xbe sections
     uint08 **m_bzSection;


### PR DESCRIPTION
`tools/cxbe`:
- Added the ability to handle long section names (moved the limit from 8 chars to 255)
- Added an option to set the XBE's title ID to either a hex code (like `FFFF0002`) or a human-readable code (like `CX-9999`)
- Added an option to set the XBE's region flags
- Added an option to set the XBE's version (can be dec, hex, or oct)

`Makefile`:
- Added `XBE_TITLEID` to define a title ID (goes to cxbe as `-TITLEID:$(XBE_TITLEID)`)
- Added `XBE_REGION` to define a title ID (goes to cxbe as `-REGION:$(XBE_REGION)`)
- Added `XBE_VERSION` to define a title ID (goes to cxbe as `-VERSION:$(XBE_VERSION)`)