### PR TITLE
cxbe: Fix oob section reads

### DIFF
--- a/tools/cxbe/Exe.cpp
+++ b/tools/cxbe/Exe.cpp
@@ -7,6 +7,7 @@
 
 #include "Exe.h"
 
+#include <algorithm>
 #include <memory.h>
 #include <stdio.h>
 
@@ -130,10 +131,12 @@ Exe::Exe(const char *x_szFilename)
 
             uint32 raw_size = m_SectionHeader[v].m_sizeof_raw;
             uint32 raw_addr = m_SectionHeader[v].m_raw_addr;
+            uint32 virt_size = m_SectionHeader[v].m_virtual_size;
+            uint32 max_size = std::max(virt_size, raw_size);
 
-            m_bzSection[v] = new uint08[raw_size];
+            m_bzSection[v] = new uint08[max_size];
 
-            memset(m_bzSection[v], 0, raw_size);
+            memset(m_bzSection[v], 0, max_size);
 
             if(raw_size == 0)
             {

--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -9,6 +9,7 @@
 #include "Xbe.h"
 #include "Exe.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <locale.h>
@@ -513,8 +514,12 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vec
                 printf("Xbe::Xbe: Generating Section %.04X...", v);
 
                 uint32 RawSize = m_SectionHeader[v].dwSizeofRaw;
+                uint32 VirtSize = m_SectionHeader[v].dwVirtualSize;
+                uint32 maxSize = std::max(VirtSize, RawSize);
 
-                m_bzSection[v] = new uint08[RawSize];
+                m_bzSection[v] = new uint08[maxSize];
+
+                memset(m_bzSection[v], 0, maxSize);
 
                 memcpy(m_bzSection[v], x_Exe->m_bzSection[v], RawSize);
 


### PR DESCRIPTION
Fixes regression introduced by https://github.com/XboxDev/nxdk/commit/d6f0f3a24b35f086889c8d8c2c591656e759fdbb.

The underlying issue is that trailing null bytes are not stored in the exe and thus are not part of `dwSizeofRaw`, causing the null terminator of the `xboxkrnl.exe`-string to get cut off resulting in an oob-read and invalid string comparison, which ultimately produces an xbe with an incorrect import directory (the `hello` sample can be used to test this).

I've changed the exe loader and xbe constructor to instead keep the full section in memory so that valid reads from sections can no longer be out of bounds. This slightly increases memory consumption during the conversion, but that shouldn't be an issue.