### PR TITLE
docker: Only build once and push to repo registry

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -52,13 +52,14 @@ jobs:
 
       - name: Login to Docker Registry
         uses: docker/login-action@v2
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' && matrix.tag == 'latest'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Push Docker Image
         uses: docker/build-push-action@v3
+        if: github.ref == 'refs/heads/master' && matrix.tag == 'latest'
         with:
           push: true
           build-args: ${{ matrix.build-args }}


### PR DESCRIPTION
I got the feedback that it would be preferred to not push the debug and lto tags to the nxdk repo. This changes that. It also makes sure the push is only done for the master branch. Sorry about that one.