### PR TITLE
docker: Set lto and debug tags for correct containers

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -17,10 +17,10 @@ jobs:
             tag: latest
           - image-name: nxdk-debug
             build-args: buildparams=DEBUG=y
-            tag: lto
+            tag: debug
           - image-name: nxdk-lto
             build-args: buildparams=LTO=y CFLAGS=-O2 CXXFLAGS=-O2
-            tag: debug
+            tag: lto
     steps:
       - name: Clone Tree
         uses: actions/checkout@v3


### PR DESCRIPTION
I accidentally put them to wrong way around. This fixes that.