### PR TITLE
docker: Fix missing authorization when pushing image

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Login to Docker Registry
         uses: docker/login-action@v2
-        if: github.ref == 'refs/heads/master' && matrix.tag == 'latest'
+        if: github.ref == 'refs/heads/master'
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
Current nxdk master fails because the login action isn't always executed.