### PR TITLE
Add overlapped (asynchronous file read/writes) to WinAPI

### DIFF
--- a/lib/winapi/Makefile
+++ b/lib/winapi/Makefile
@@ -10,6 +10,7 @@ WINAPI_SRCS := \
 	$(NXDK_DIR)/lib/winapi/filemanip.c \
 	$(NXDK_DIR)/lib/winapi/findfile.c \
 	$(NXDK_DIR)/lib/winapi/handleapi.c \
+	$(NXDK_DIR)/lib/winapi/ioapi.c \
 	$(NXDK_DIR)/lib/winapi/memory.c \
 	$(NXDK_DIR)/lib/winapi/libloaderapi.c \
 	$(NXDK_DIR)/lib/winapi/profiling.c \

--- a/lib/winapi/ioapi.c
+++ b/lib/winapi/ioapi.c
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+
+// SPDX-FileCopyrightText: 2023 Ryan Wendland
+
+#include <synchapi.h>
+#include <winbase.h>
+#include <winerror.h>
+#include <xboxkrnl/xboxkrnl.h>
+
+BOOL GetOverlappedResult (HANDLE hFile, LPOVERLAPPED lpOverlapped, LPDWORD lpNumberOfBytesTransferred, BOOL bWait)
+{
+    DWORD status;
+    HANDLE waitHandle;
+
+    status = (DWORD)lpOverlapped->Internal;
+
+    if (status == STATUS_PENDING && bWait == FALSE) {
+        SetLastError(ERROR_IO_INCOMPLETE);
+        return FALSE;
+    }
+
+    // If the hEvent member of the OVERLAPPED structure is NULL, the system
+    // uses the state of the hFile handle to signal when the operation has been completed
+    if (lpOverlapped->hEvent == NULL) {
+        waitHandle = hFile;
+    } else {
+        waitHandle = lpOverlapped->hEvent;
+    }
+
+    if (status == STATUS_PENDING) {
+        if (WaitForSingleObject(waitHandle, INFINITE) != WAIT_OBJECT_0) {
+            SetLastError(ERROR_IO_INCOMPLETE);
+            return FALSE;
+        }
+        // Get final status of the transfer
+        status = (DWORD)lpOverlapped->Internal;
+    }
+
+    // InternalHigh contains the actual number of bytes transferred for the I/O request
+    *lpNumberOfBytesTransferred = (DWORD)lpOverlapped->InternalHigh;
+
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return FALSE;
+    }
+    return TRUE;
+}

--- a/lib/winapi/winbase.h
+++ b/lib/winapi/winbase.h
@@ -134,6 +134,8 @@ void WINAPI OutputDebugStringA (LPCTSTR lpOutputString);
 
 BOOL IsBadWritePtr (LPVOID lp, UINT_PTR ucb);
 
+BOOL GetOverlappedResult (HANDLE hFile, LPOVERLAPPED lpOverlapped, LPDWORD lpNumberOfBytesTransferred, BOOL bWait);
+
 #ifndef UNICODE
 #define OutputDebugString OutputDebugStringA
 #else


### PR DESCRIPTION
Asynchronous fileio has some limitations ref
https://learn.microsoft.com/en-US/previous-versions/troubleshoot/windows/win32/asynchronous-disk-io-synchronous and 
https://github.com/JayFoxRox/nxdk/pull/45

Asynchronous file read/writes have these requirements generally:
* They must use FILE_FLAG_NO_BUFFERING which has size and alignemnt requirements of the buffer (DWORD alignment and multiple of sector size)
* Writes that increase the file size must preallocate the space.

If these are not met the request will either fail or complete synchronously

Overlapped structure members seemed a bit odd to me when I initially looked at this but this was my reference
https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-overlapped



Some test code below which demonstrates async read and write as per win32 docs
```
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>
#include <nxdk/mount.h>
#include <assert.h>

// Async buffer should be DWORD aligned and a multiple of the sector size (512 bytes for HDD, 2048 bytes for DVD normally)
__attribute__((aligned(sizeof(DWORD)))) CHAR buffer[32 * 1024 * 1024];

int main(void)
{
    CONST CHAR *lpFileName = "E:\\test.bin";
    DWORD lpNumberOfBytesTransferred;
    HANDLE hFile;

    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
    nxMountDrive('E', "\\Device\\Harddisk0\\Partition1\\");

    OVERLAPPED overlapped = {
        .Offset = 0,
        .OffsetHigh = 0,
        .hEvent = CreateEvent(NULL, TRUE, FALSE, NULL)};

    /* ASYNC WRITE */
    hFile = CreateFile(lpFileName, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_FLAG_OVERLAPPED | FILE_FLAG_NO_BUFFERING, NULL);
    assert(hFile != INVALID_HANDLE_VALUE);

    // Any write operation to a file that extends its length will be synchronous, so pre-allocate its length to ensure it is asynchronous
    assert(SetFilePointer(hFile, sizeof(buffer), NULL, FILE_BEGIN) != INVALID_SET_FILE_POINTER);
    assert(SetEndOfFile(hFile));
    assert(SetFilePointer(hFile, 0, NULL, FILE_BEGIN) != INVALID_SET_FILE_POINTER);

    // An asynchronous write will return false, but the error code will be ERROR_IO_PENDING.
    assert(WriteFile(hFile, (LPCVOID)buffer, sizeof(buffer), NULL, &overlapped) == FALSE);
    assert(GetLastError() == ERROR_IO_PENDING);
    debugPrint("Async write started to %s\n", lpFileName);

    // Wait for the write to complete asynchronously
    assert(GetOverlappedResult(hFile, &overlapped, &lpNumberOfBytesTransferred, TRUE));
    debugPrint("WriteFile completed successfully. Wrote %lu bytes\n", lpNumberOfBytesTransferred);

    CloseHandle(hFile);

    /* ASYNC READ */
    hFile = CreateFile(lpFileName, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_FLAG_OVERLAPPED | FILE_FLAG_NO_BUFFERING, NULL);
    assert(hFile != INVALID_HANDLE_VALUE);

    // An asynchronous read will return false, but the error code will be ERROR_IO_PENDING.
    assert(ReadFile(hFile, (LPVOID)buffer, sizeof(buffer), NULL, &overlapped) == FALSE);
    assert(GetLastError() == ERROR_IO_PENDING);
    debugPrint("Async read started to %s\n", lpFileName);

    // Wait for the read to complete asynchronously
    assert(GetOverlappedResult(hFile, &overlapped, &lpNumberOfBytesTransferred, TRUE));
    debugPrint("ReadFile completed successfully. Read %lu bytes\n", lpNumberOfBytesTransferred);

    while (1)
    {
        Sleep(2000);
    }

    return 0;
}
```
![image](https://github.com/XboxDev/nxdk/assets/21236406/39906881-086e-4fd7-babe-4c607a48ae08)
