### PR TITLE
cxbe: Fix broken XBE sections sizes

### DIFF
--- a/tools/cxbe/Xbe.cpp
+++ b/tools/cxbe/Xbe.cpp
@@ -384,14 +384,6 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vec
                 m_SectionHeader[v].dwVirtualAddr =
                     x_Exe->m_SectionHeader[v].m_virtual_addr + m_Header.dwPeBaseAddr;
 
-                if(v < m_Header.dwSections - 1)
-                    m_SectionHeader[v].dwVirtualSize =
-                        x_Exe->m_SectionHeader[v + 1].m_virtual_addr -
-                        x_Exe->m_SectionHeader[v].m_virtual_addr;
-                else
-                    m_SectionHeader[v].dwVirtualSize =
-                        RoundUp(x_Exe->m_SectionHeader[v].m_virtual_size, 4);
-
                 m_SectionHeader[v].dwRawAddr = SectionCursor;
 
                 // calculate sizeof_raw by locating the last non-zero value in the raw section data
@@ -409,6 +401,20 @@ Xbe::Xbe(class Exe *x_Exe, const char *x_szTitle, bool x_bRetail, const std::vec
 
                     // word aligned
                     m_SectionHeader[v].dwSizeofRaw = RoundUp(r + 2, 4);
+                }
+
+                // calculate virtual size
+                if(v < m_Header.dwSections - 1)
+                    m_SectionHeader[v].dwVirtualSize =
+                        x_Exe->m_SectionHeader[v + 1].m_virtual_addr -
+                        x_Exe->m_SectionHeader[v].m_virtual_addr;
+                else {
+                    m_SectionHeader[v].dwVirtualSize =
+                        RoundUp(x_Exe->m_SectionHeader[v].m_virtual_size, 4);
+
+                    // force virtual size to be at least as large as the raw size
+                    m_SectionHeader[v].dwVirtualSize = std::max(m_SectionHeader[v].dwSizeofRaw,
+                        m_SectionHeader[v].dwVirtualSize);
                 }
 
                 SectionCursor += RoundUp(m_SectionHeader[v].dwSizeofRaw, 0x1000);


### PR DESCRIPTION
A simple test with the hello world example is enough to generate an XBE with an invalid header.

```c
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>

__attribute__((section("TEST")))
void test() {
    Sleep(1000);
}

int main(void) {
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    while(1) {
        debugPrint("Hello nxdk!\n");
        Sleep(2000);
    }

    return 0;
}
```

This results in the final section, ``TEST``, being generated with a physical section size greater than the virtual size.

![image](https://github.com/XboxDev/nxdk/assets/1701315/b428691f-f5b3-4fd7-92e9-52f4dace8cc5)

The physical size is calculated [here](https://github.com/XboxDev/nxdk/blob/ed21e83da43b8b8da14a9a78cf2528d9b5df86a7/tools/cxbe/Xbe.cpp#L397). The calculated physical size is 512 bytes in this case since the code section is filled with 0xCC. 

Since this is the last section in the PE, the virtual size is pulled from the PE directly. [here](https://github.com/XboxDev/nxdk/blob/ed21e83da43b8b8da14a9a78cf2528d9b5df86a7/tools/cxbe/Xbe.cpp#L392).

---

Calculating the physical size from the last zero-byte makes sense since the Xbox kernel will set the memory tail end of the section to zero based on the difference between physical and virtual size.

This PR attempts to fix this issue by ensuring the section's virtual size is at least as large as the physical size.