### PR TITLE
build: Fix finding LLVM on macOS on ARM64

### DIFF
--- a/bin/activate
+++ b/bin/activate
@@ -8,7 +8,7 @@
 readlink_cmd="readlink"
 
 if [ $(uname -s) = 'Darwin' ]; then
-    export PATH=/usr/local/opt/llvm/bin/:$PATH
+    export PATH=/opt/homebrew/opt/llvm/bin/:/usr/local/opt/llvm/bin/:$PATH
     readlink_cmd="greadlink"
 fi
 


### PR DESCRIPTION
This fixes the macOS CI failure on the newer ARM64 runners, caused by homebrew using a different installation path there.