### PR TITLE
Some warning fixes

### DIFF
--- a/bin/nxdk-cc
+++ b/bin/nxdk-cc
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: CC0-1.0
 
-# SPDX-FileCopyrightText: 2021-2022 Stefan Schmidt
+# SPDX-FileCopyrightText: 2021-2024 Stefan Schmidt
 
 clang \
     -target i386-pc-win32 \
@@ -17,6 +17,7 @@ clang \
     -I${NXDK_DIR}/lib/pdclib/platform/xbox/include \
     -I${NXDK_DIR}/lib/winapi \
     -I${NXDK_DIR}/lib/xboxrt/vcruntime \
+    -Wno-builtin-macro-redefined \
     -DNXDK \
     -D__STDC__=1 \
     -U__STDC_NO_THREADS__ \

--- a/bin/nxdk-cxx
+++ b/bin/nxdk-cxx
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: CC0-1.0
 
-# SPDX-FileCopyrightText: 2021-2022 Stefan Schmidt
+# SPDX-FileCopyrightText: 2021-2024 Stefan Schmidt
 
 clang \
     -target i386-pc-win32 \
@@ -18,6 +18,7 @@ clang \
     -I${NXDK_DIR}/lib/pdclib/platform/xbox/include \
     -I${NXDK_DIR}/lib/winapi \
     -I${NXDK_DIR}/lib/xboxrt/vcruntime \
+    -Wno-builtin-macro-redefined \
     -DNXDK \
     -D__STDC__=1 \
     -U__STDC_NO_THREADS__ \

--- a/lib/winapi/winnt.h
+++ b/lib/winapi/winnt.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 // SPDX-FileCopyrightText: 2019 Jannik Vogel
-// SPDX-FileCopyrightText: 2019-2022 Stefan Schmidt
+// SPDX-FileCopyrightText: 2019-2024 Stefan Schmidt
 // SPDX-FileCopyrightText: 2021 Lucas Jansson
 
 #ifndef __WINNT_H__
@@ -13,7 +13,10 @@ typedef LONG HRESULT;
 
 typedef CHAR *LPSTR;
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wlanguage-extension-token"
 typedef signed __int64 LONG64, *PLONG64;
+#pragma clang diagnostic pop
 
 LONG64 InterlockedExchange64 (LONG64 volatile *Target, LONG64 Value);
 PVOID InterlockedExchangePointer (PVOID volatile *Target, PVOID Value);


### PR DESCRIPTION
Fixes https://github.com/XboxDev/nxdk/issues/547
Also fixes the `undefining builtin macro` warnings caused by us undefining `__STDC_NO_THREADS__`.