### PR TITLE
winapi: Add clang-format file

### DIFF
--- a/lib/winapi/.clang-format
+++ b/lib/winapi/.clang-format
@@ -1,0 +1,21 @@
+BasedOnStyle: Microsoft
+ColumnLimit: 0
+IndentCaseLabels: true
+AlignTrailingComments: true
+AlignConsecutiveMacros: true
+InsertBraces: true
+
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterFunctionDefinitionName: true
+  AfterFunctionDeclarationName: true
+
+BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterControlStatement: false
+  AfterExternBlock: false
+  BeforeElse: false
+  AfterUnion: true
+
+TypeNames: [VOID, PVOID, LPVOID]


### PR DESCRIPTION
Add a clang-format file specifcally to the winapi folder. The formatting across the `lib/` varies alot with formatting so this atleast targets this one folder that has bitten me a few times with formatting issues., although this also works pretty well for the `nxdk/` folder

This was based on the bare minimum custom options I could find whilst matching the existing format as best as I could.
This results in the following diff when ran against the winapi folder

~~https://github.com/XboxDev/nxdk/commit/2a2392ae51832295061856f5bf2e0779c88520b3~~ comments1
~~https://github.com/XboxDev/nxdk/commit/f22f6eef47f110caf1a733c1e338539b62f04381~~ comments2
~~https://github.com/XboxDev/nxdk/commit/1a2ab65e225508e3c97b6e9868ed7d974b7999fe~~ comments3
https://github.com/Ryzee119/nxdk/commit/0b314214961b8dec10bbc0b6af24096aac239a08

The majority of these diffs look like genuine formatting issues.

Unfortuntely it does not handle our calling conventions __cdecl or __stdcall and removes a space when it  shouldn't. I think it is related to this issue https://github.com/llvm/llvm-project/issues/34171 and nothing I could do seemed to bypass it.

Where there was a mix of formatting I went with the majority (ie `extern "c" {` vs `extern "c" \n {`

Also dont know if we want a `ColumnLimit` ?