### PR TITLE
winapi: Refactor GetDayOfWeek function

### DIFF
--- a/lib/winapi/timezoneapi.c
+++ b/lib/winapi/timezoneapi.c
@@ -18,10 +18,15 @@ typedef struct
 
 // Determine the day of the week given a year, month and day
 // https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week#Methods_in_computer_code
-static UCHAR GetDayOfWeek (SHORT year, UCHAR month, UCHAR day)
+static UCHAR GetDayOfWeek (INT year, INT month, INT day)
 {
-    return (day += month < 3 ? year-- : year - 2, 23 *
-            month / 9 + day + 4 + year / 4 - year / 100 + year / 400) % 7;
+    if (month < 3) {
+        day += year;
+        year--;
+    } else {
+        day += year - 2;
+    }
+    return (day + 23 * month / 9 + 4 + year / 4 - year / 100 + year / 400) % 7;
 }
 
 static UCHAR GetDaysInMonth (SHORT year, UCHAR month)


### PR DESCRIPTION
As mentioned in https://github.com/XboxDev/nxdk/pull/670, GetDayOfWeek() function had an unusual code style and did not behave well with clang-format.

The notation for this function was originally a copy paste of the "Keith" method from https://en.wikipedia.org/wiki/Determination_of_the_day_of_the_week.

This PR refactors the function to a more standard format. The functionality has been verified against the original wiki implementation with the below code .

I changed the function inputs to INTs are that is what the alogirthm calls for. This was technically a bug.

```
#include <assert.h>
#include <windows.h>

static int keith (int y, int m, int d)
{
    return (d+=m<3 ? y-- : y-2,23*m/9+d+4+y/4-y/100+y/400) % 7;
}

static UCHAR GetDayOfWeek (INT year, INT month, INT day) {
    if (month < 3) {
        day += year;
        year--;
    } else {
        day += year - 2;
    }
    return (day + 23 * month / 9 + 4 + year / 4 - year / 100 + year / 400) % 7;
}

void test_me() {
  for (int year = 0; year < 9999; year++) {
      for(int month = 1; month <= 12; month++) {
          for(int day = 1; day <= 31; day++) {
              int dow = keith (year, month, day);
              UCHAR dow1 = GetDayOfWeek (year, month, day);
              assert(dow == dow1);
          }
      }
  }
}

int main()
{
  test_me();
  return 0;
}
  ```