### PR TITLE
usb: Support maximum endpoints per interface specified by USB spec

### DIFF
--- a/lib/usb/libusbohci_xbox/usbh_config_xbox.h
+++ b/lib/usb/libusbohci_xbox/usbh_config_xbox.h
@@ -45,7 +45,7 @@
 #define MAX_ALT_PER_IFACE      12      /*!< maximum number of alternative interfaces per interface    */
 #endif
 #ifndef MAX_EP_PER_IFACE
-#define MAX_EP_PER_IFACE       8       /*!< maximum number of endpoints per interface                 */
+#define MAX_EP_PER_IFACE       15      /*!< maximum number of endpoints per interface                 */
 #endif
 #ifndef MAX_HUB_DEVICE
 #define MAX_HUB_DEVICE         8       /*!< Maximum number of hub devices                             */


### PR DESCRIPTION
The USB spec specifies a maximum of 15 endpoints per interface (excluding the control endpoint), this change makes us support that.

Fixes https://github.com/XboxDev/nxdk/issues/675

libusbohci preallocates a lot of stuff, so this increases memory usage per device by about 1KiB.