### PR TITLE
feat: Add video mode sample

### DIFF
--- a/samples/set_best_video_mode/Makefile
+++ b/samples/set_best_video_mode/Makefile
@@ -1,0 +1,7 @@
+XBE_TITLE = nxdk\ sample\ -\ set_best_video_mode
+GEN_XISO = $(XBE_TITLE).iso
+SRCS = $(CURDIR)/main.cpp
+NXDK_DIR ?= $(CURDIR)/../..
+NXDK_CXX = y
+
+include $(NXDK_DIR)/Makefile

--- a/samples/set_best_video_mode/main.cpp
+++ b/samples/set_best_video_mode/main.cpp
@@ -1,0 +1,70 @@
+#include <hal/debug.h>
+#include <hal/video.h>
+#include <windows.h>
+#include <vector>
+
+// Screen dimension globals
+static int SCREEN_WIDTH = 640;
+static int SCREEN_HEIGHT = 480;
+
+int main(void)
+{
+    // set the default video mode
+    XVideoSetMode(SCREEN_WIDTH, SCREEN_HEIGHT, 32, REFRESH_DEFAULT);
+
+    // create an empty list for the available video modes
+    std::vector<VIDEO_MODE> availableVideoModes;
+
+    // save the best video mode here
+    VIDEO_MODE bestVideoMode = {0, 0, 0, 0};
+
+    VIDEO_MODE vm;
+    int bpp = 32;  // Bits per pixel
+    void *p = NULL;  // Initialize to NULL for the first call
+
+    // get the available video modes
+    while (XVideoListModes(&vm, bpp, REFRESH_DEFAULT, &p)) {
+        availableVideoModes.push_back(vm);
+
+        // ensure height is equal to or better than the current best video mode
+        if (vm.height < bestVideoMode.height) {
+            continue;
+        }
+
+        // ensure width is equal to or better than the current best video mode
+        if (vm.width < bestVideoMode.width) {
+            continue;
+        }
+
+        // ensure bpp is equal to or better than the current best video mode
+        if (vm.bpp < bestVideoMode.bpp) {
+            continue;
+        }
+
+        // ensure refresh is equal to or better than the current best video mode
+        if (vm.refresh < bestVideoMode.refresh) {
+            continue;
+        }
+
+        // save the best video mode
+        bestVideoMode = vm;
+    }
+
+    debugPrint("Available video modes:\n");
+    for (VIDEO_MODE vm : availableVideoModes) {
+        debugPrint("Width: %d, Height: %d, BPP: %d, Refresh: %d\n", vm.width, vm.height, vm.bpp, vm.refresh);
+    }
+    Sleep(2000);
+
+    // set the best video mode
+    XVideoSetMode(bestVideoMode.width, bestVideoMode.height, bestVideoMode.bpp, bestVideoMode.refresh);
+
+    debugPrint("Best video mode:\n");
+    debugPrint("Width: %d, Height: %d, BPP: %d, Refresh: %d\n", bestVideoMode.width, bestVideoMode.height, bestVideoMode.bpp, bestVideoMode.refresh);
+
+    while (1) {
+        Sleep(1000);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds a new sample that sets the Xbox to the "best" video mode available.

It was not abundantly clear to me if `XVideoListModes` will loop through in any specific order... if it does perhaps this can be simplified.

I tested this in Xemu, but only get two possible video modes so testing was not extensive.

Note: I'm quite new to nxdk so there may be better ways to accomplish this. I did find one other similar example (https://github.com/Ryzee119/LithiumX/blob/f4471d287d44abc84803d3b901bd4aa7ed459689/src/platform/xbox/platform.c#L99-L123) after I already wrote this, but feel my code is better for selecting the highest resolution available.