### PR TITLE
fix(cmake): ensure D is automounted when using toolchain

### DIFF
--- a/share/toolchain-nxdk.cmake
+++ b/share/toolchain-nxdk.cmake
@@ -65,3 +65,8 @@ set(_CMAKE_C_IPO_MAY_BE_SUPPORTED_BY_COMPILER YES)
 set(CMAKE_C_COMPILE_OPTIONS_IPO -flto)
 
 set(PKG_CONFIG_EXECUTABLE "${NXDK_DIR}/bin/nxdk-pkg-config" CACHE STRING "Path to pkg-config")
+
+# automount the D drive
+if(NOT DEFINED NXDK_DISABLE_AUTOMOUNT_D OR NOT NXDK_DISABLE_AUTOMOUNT_D STREQUAL "y")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -include:_automount_d_drive")
+endif()


### PR DESCRIPTION
When using the toolchain file, the "D" drive is not automounted as it is when using the Makefile options. This PR fixes that using the same conditions as the Makefile option.

Otherwise you must add extra bits to the code to automount, such as https://github.com/abaire/nxdk_pgraph_tests/blob/4b7934e6d612a6d17f9ec229a2d72601a5caefc4/src/main.cpp#L118-L122

This was discussed on the discord server here: https://discord.com/channels/428359196719972353/428399682239332354/1296626606688833617

It may be better to use a cmake "option" with the value set to `ON` by default, and `OFF` when it desired to disable. This would be more standard for CMake, just let me know which way is preferred.

Edit: converted to draft as during my first test I had not cleared the cmake cache, thus the toolchain was not fully reloaded. Need to fix some things.