### PR TITLE
ci(trigger): fix ci triggers and concurrency

### DIFF
--- a/.github/workflows/build_docker_image.yml
+++ b/.github/workflows/build_docker_image.yml
@@ -1,6 +1,18 @@
 name: Build Docker image
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   main:

--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -1,6 +1,18 @@
 name: Build Samples
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   windows:


### PR DESCRIPTION
When working on this locally in my own branch, I noticed some issues with the workflows.

1. Duplicated jobs are run simultaneously due to accepting both `push` and `pull_request` events.
2. All types of pull_request events will trigger the workflow. This is generally not a good idea. For example, these workflows should not trigger if you label the workflow, or request a review. See: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
3. There is no concurrency control. Concurrency will allow you to cancel in process workflows in cases where a PR is updated again while the current workflows are running. See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs

This PR fixes all of the above issues.

Additionally, many of the actions are also using very outdated versions. Generally, I use @dependabot to keep these updated through automatic PRs, I'd be happy to add a secondary PR to add this in. Also works for git submodules, which is pretty nice.