### PR TITLE
ci: Install lld explicitly on macOS

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -42,7 +42,7 @@ jobs:
           HOMEBREW_NO_ANALYTICS: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew install llvm coreutils
+          brew install lld llvm coreutils
       - name: Build
         run: ./.ci_build_samples.sh
   ubuntu:


### PR DESCRIPTION
The build for macOS is currently failing due to missing `lld` dependency.

Note: If it's preferable I can combine my PRs into one, although it's probably easier to review them separately. Just let me know whatever you prefer.