### PR TITLE
lwip: Use modulo operator for mbox

### DIFF
--- a/lib/net/nforceif/src/sys_arch.c
+++ b/lib/net/nforceif/src/sys_arch.c
@@ -202,7 +202,7 @@ sys_mbox_post(struct sys_mbox **mb, void *msg)
     sys_arch_sem_wait(&mbox->write_sem, 0);
 
     sys_arch_sem_wait(&mbox->mutex, 0);
-    mbox->msgs[mbox->last & SYS_MBOX_SIZE] = msg;
+    mbox->msgs[mbox->last % SYS_MBOX_SIZE] = msg;
     mbox->last++;
     sys_sem_signal(&mbox->mutex);
 


### PR DESCRIPTION
Was getting some corruption in the lwip mboxes. This is a bug and the code should be the modulo operator not bitwise AND.

The below code demonstrates the issue
```
static void my_tcpip_callback1(void *param){
    DbgPrint("I work\n"):
} 

static void my_tcpip_callback2(void *param){
    DbgPrint("I don't work\n"):
}

nxNetInit(NULL);
tcpip_callback(my_tcpip_callback1, NULL); // This works by chance as mbox position is zero.
tcpip_callback(my_tcpip_callback2, NULL); // This doesnt work
```