### PR TITLE
debug: Handle carriage return

### DIFF
--- a/lib/hal/debug.c
+++ b/lib/hal/debug.c
@@ -200,6 +200,10 @@ void debugPrint(const char *format, ...)
 			nextRow += FONT_HEIGHT+1;
 			nextCol = MARGIN;
 		}
+		else if (*s == '\r')
+		{
+			nextCol = MARGIN;
+		}
 		else
 		{
 			drawChar( *s, nextCol, nextRow, fgColour, bgColour );


### PR DESCRIPTION
Prevents CR characters being printed like below and is just generally useful to handle CR correctly.

![image](https://github.com/user-attachments/assets/75bf5167-8b53-4a26-8ed7-86ef65b9be92)