### PR TITLE
winapi: Implement Suspend/Resume Thread

### DIFF
--- a/lib/winapi/processthreadsapi.h
+++ b/lib/winapi/processthreadsapi.h
@@ -23,6 +23,8 @@ DWORD GetThreadId (HANDLE Thread);
 BOOL SwitchToThread (VOID);
 
 BOOL SetThreadPriority (HANDLE hThread, int nPriority);
+DWORD SuspendThread (HANDLE hThread);
+DWORD ResumeThread (HANDLE hThread);
 
 DWORD TlsAlloc (void);
 BOOL TlsFree (DWORD dwTlsIndex);

--- a/lib/winapi/thread.c
+++ b/lib/winapi/thread.c
@@ -172,3 +172,31 @@ BOOL SetThreadPriority (HANDLE hThread, int nPriority)
     ObfDereferenceObject(thread);
     return TRUE;
 }
+
+DWORD SuspendThread (HANDLE hThread)
+{
+    ULONG PreviousSuspendCount;
+    NTSTATUS status;
+
+    status = NtSuspendThread(hThread, &PreviousSuspendCount);
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return -1;
+    }
+
+    return PreviousSuspendCount;
+}
+
+DWORD ResumeThread (HANDLE hThread)
+{
+    ULONG PreviousResumeCount;
+    NTSTATUS status;
+
+    status = NtResumeThread(hThread, &PreviousResumeCount);
+    if (!NT_SUCCESS(status)) {
+        SetLastError(RtlNtStatusToDosError(status));
+        return -1;
+    }
+
+    return PreviousResumeCount;
+}


### PR DESCRIPTION
Needed these, realised we had no winapi wrapper. Tested on xemu and hw with the below code:

```
#include <hal/debug.h>
#include <hal/video.h>
#include <windows.h>
#include <assert.h>

DWORD WINAPI ThreadProc(LPVOID lpParameter)
{
    while (1)
    {
        debugPrint("Worker thread is running...\n");
        Sleep(250);
    }
    return 0;
}

int main(void)
{
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    HANDLE hThread = CreateThread(NULL, 0, ThreadProc, NULL, 0, NULL);

    // Let thread work for a while
    Sleep(1000);

    // Suspend the thread 3 times to test count
    SuspendThread(hThread);
    SuspendThread(hThread);
    DWORD dwPreviousCount = SuspendThread(hThread);

    // If the function succeeds, the return value is the thread's previous suspend count
    assert(dwPreviousCount == 2);

    // Ensure thread is suspended
    debugPrint("Thread is suspended\n");
    Sleep(1000);

    DWORD dwResumeCount = ResumeThread(hThread);

    // If the function succeeds, the return value is the thread's previous suspend count.
    // We suspend the thread 3 times, so we need to resume 3 times
    assert(dwResumeCount == 3);
    ResumeThread(hThread);

    // Ensure thread still isn't resumed yet
    Sleep(1000);

    // Okay, this should actually resume the thread
    ResumeThread(hThread);
    debugPrint("Thread is resumed\n");

    // Let thread work for a while
    Sleep(3000);

    return 0;
}
```