### PR TITLE
nvnetdrv v2 part 2

### DIFF
--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -716,8 +716,7 @@ void nvnetdrv_stop_txrx (void)
         KeDelayExecutionThread(KernelMode, FALSE, FIFTY_MICRO);
     }
 
-    reg32(NvRegLinkSpeed) = 0;
-    reg32(NvRegTransmitPoll) = 0;
+    reg32(NvRegTxRxControl) = 0;
 }
 
 int nvnetdrv_acquire_tx_descriptors (size_t count)

--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -498,22 +498,20 @@ int nvnetdrv_init (size_t rx_buffer_count, nvnetdrv_rx_callback_t rx_callback, s
     KeDelayExecutionThread(KernelMode, FALSE, TEN_MICRO);
     reg32(NvRegTxRxControl) = 0;
     KeDelayExecutionThread(KernelMode, FALSE, TEN_MICRO);
-
-    // Disable interrupts while we initialise the NIC
-    reg32(NvRegIrqMask) = 0;
     reg32(NvRegMIIMask) = 0;
+    reg32(NvRegIrqMask) = 0;
+    reg32(NvRegWakeUpFlags) = 0;
+    reg32(NvRegPollingControl) = 0;
+    reg32(NvRegTxRingPhysAddr) = 0;
+    reg32(NvRegRxRingPhysAddr) = 0;
+    reg32(NvRegTransmitPoll) = 0;
+    reg32(NvRegLinkSpeed) = 0;
 
     // Acknowledge any existing interrupts status bits
     reg32(NvRegTransmitterStatus) = reg32(NvRegTransmitterStatus);
     reg32(NvRegReceiverStatus) = reg32(NvRegReceiverStatus);
     reg32(NvRegIrqStatus) = reg32(NvRegIrqStatus);
     reg32(NvRegMIIStatus) = reg32(NvRegMIIStatus);
-
-    // Clear latent registers
-    reg32(NvRegWakeUpFlags) = 0;
-    reg32(NvRegPollingControl) = 0;
-    reg32(NvRegTransmitPoll) = 0;
-    reg32(NvRegLinkSpeed) = 0;
 
     // Reset local ring tracking variables
     g_rxRingHead = 0;

--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -659,16 +659,16 @@ void nvnetdrv_stop (void)
     }
 
     // Free all TX descriptors g_txRingFreeCount so nvnetdrv_acquire_tx_descriptors will return.
-    KeReleaseSemaphore(&g_txRingFreeCount, IO_NETWORK_INCREMENT, g_txPendingCount, NULL);
+    KeReleaseSemaphore(&g_txRingFreeCount, IO_NETWORK_INCREMENT, g_txPendingCount, FALSE);
 
     // End rxrequeue_thread
     nvnetdrv_rx_push(g_rxRingUserBuffers); // Just push a buffer into stack so we dont get stuck waiting for one
-    KeReleaseSemaphore(&g_rxRingFreeDescriptors, IO_NETWORK_INCREMENT, 1, NULL);
+    KeReleaseSemaphore(&g_rxRingFreeDescriptors, IO_NETWORK_INCREMENT, 1, FALSE);
     NtWaitForSingleObject(g_rxRingRequeueThread, FALSE, NULL);
     NtClose(g_rxRingRequeueThread);
 
     // End rxcallback_thread
-    KeReleaseSemaphore(&g_rxPendingCount, IO_NETWORK_INCREMENT, 1, NULL);
+    KeReleaseSemaphore(&g_rxPendingCount, IO_NETWORK_INCREMENT, 1, FALSE);
     NtWaitForSingleObject(g_rxCallbackThread, FALSE, NULL);
     NtClose(g_rxCallbackThread);
 

--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -639,15 +639,6 @@ void nvnetdrv_stop (void)
 
     KeDisconnectInterrupt(&g_interrupt);
 
-    // Disable DMA and wait for it to idle, re-checking every 50 microseconds
-    reg32(NvRegTxRxControl) = NVREG_TXRXCTL_DISABLE;
-    for (int i = 0; i < 10000; i++) {
-        if (reg32(NvRegTxRxControl) & NVREG_TXRXCTL_IDLE) {
-            break;
-        }
-        KeDelayExecutionThread(KernelMode, FALSE, FIFTY_MICRO);
-    }
-
     // Stop NIC processing rings
     nvnetdrv_stop_txrx();
 
@@ -714,6 +705,15 @@ void nvnetdrv_stop_txrx (void)
             break;
         }
         KeDelayExecutionThread(KernelMode, FALSE, TEN_MICRO);
+    }
+
+    // Disable DMA and wait for it to idle, re-checking every 50 microseconds
+    reg32(NvRegTxRxControl) = NVREG_TXRXCTL_DISABLE;
+    for (int i = 0; i < 10000; i++) {
+        if (reg32(NvRegTxRxControl) & NVREG_TXRXCTL_IDLE) {
+            break;
+        }
+        KeDelayExecutionThread(KernelMode, FALSE, FIFTY_MICRO);
     }
 
     reg32(NvRegLinkSpeed) = 0;

--- a/lib/net/nvnetdrv/nvnetdrv.h
+++ b/lib/net/nvnetdrv/nvnetdrv.h
@@ -10,13 +10,6 @@
 #include <stdint.h>
 #include <xboxkrnl/xboxkrnl.h>
 
-#ifndef RX_RING_SIZE
-#define RX_RING_SIZE 64
-#endif
-#ifndef TX_RING_SIZE
-#define TX_RING_SIZE 64
-#endif
-
 // Must be greater than max ethernet frame size. A multiple of page size prevents page boundary crossing
 #define NVNET_RX_BUFF_LEN (PAGE_SIZE / 2)
 
@@ -50,12 +43,12 @@ void nvnetdrv_start_txrx (void);
 
 /**
  * Initialised the low level NIC hardware.
- * @param rx_buffer_count The number of receive buffers to reserve. This should be atleast two.
- * Recommend this this equal to or greater than RX_RING_SIZE.
+ * @param rx_buffer_count The number of receive buffers to reserve for network packets
  * @param rx_callback. Pointer to a callback function that is called when a new packet is received by the NIC.
+ * @param tx_queue_size. How many packets can be queued for transfer simultaneously.
  * @return NVNET_OK or the error.
  */
-int nvnetdrv_init (size_t rx_buffer_count, nvnetdrv_rx_callback_t rx_callback);
+int nvnetdrv_init (size_t rx_buffer_count, nvnetdrv_rx_callback_t rx_callback, size_t tx_queue_size);
 
 /**
  * Stop the low level NIC hardware. Should be called after nvnetdrv_init() to shutdown the NIC hardware.

--- a/lib/net/nvnetdrv/nvnetdrv_lwip.c
+++ b/lib/net/nvnetdrv/nvnetdrv_lwip.c
@@ -23,7 +23,9 @@
 /* Define those to better describe your network interface. */
 #define IFNAME0     'x'
 #define IFNAME1     'b'
-#define RX_BUFF_CNT (RX_RING_SIZE)
+#ifndef RX_BUFF_CNT
+#define RX_BUFF_CNT (64)
+#endif
 
 #define LINK_SPEED_OF_YOUR_NETIF_IN_BPS 100 * 1000 * 1000 /* 100 Mbps */
 
@@ -90,7 +92,7 @@ void rx_callback (void *buffer, uint16_t length)
  */
 static err_t low_level_init (struct netif *netif)
 {
-    if (nvnetdrv_init(RX_BUFF_CNT, rx_callback) < 0) {
+    if (nvnetdrv_init(RX_BUFF_CNT, rx_callback, PBUF_POOL_SIZE) < 0) {
         return ERR_IF;
     }
 


### PR DESCRIPTION
Continuation from https://github.com/XboxDev/nxdk/pull/686

Will likely end up in 3 parts.

Primary change here are to pass ring sizes to the init function instead of #defines. Previously we could have different hardware ring size and queue size. Its actually much simpler to just have the hardware ring size exactly the same size as the queue. It also works better with LWIP as we can create pbuf pools to exactly match our requirement.

Most other commits are just some minor bug fixes and house keeping.

This fixes a bug that on soft reset or coming from XDK app where the network would not retrieve an IP address in some cases.