### PR TITLE
winapi: Implement SecureZeroMemory()

### DIFF
--- a/lib/winapi/winbase.h
+++ b/lib/winapi/winbase.h
@@ -140,6 +140,19 @@ BOOL IsBadWritePtr (LPVOID lp, UINT_PTR ucb);
 
 BOOL GetOverlappedResult (HANDLE hFile, LPOVERLAPPED lpOverlapped, LPDWORD lpNumberOfBytesTransferred, BOOL bWait);
 
+static inline PVOID SecureZeroMemory (PVOID ptr, SIZE_T cnt)
+{
+    volatile char *cur_ptr = (volatile char *)ptr;
+    volatile char *end_ptr = (volatile char *)ptr + cnt;
+
+    while (cur_ptr < end_ptr) {
+        *cur_ptr = 0;
+        cur_ptr++;
+    }
+
+    return ptr;
+}
+
 #ifndef UNICODE
 #define OutputDebugString OutputDebugStringA
 #else


### PR DESCRIPTION
The latest mbedtls release depends on this, and it was easy to implement.
It's basically just like a memset with zeroes or a call to ZeroMemory, but with volatile pointers to keep the compiler from optimizing it out, so it can be used for clearing memory that contained sensitive data.
On Windows this is implement in a header so the compiler can inline it, I did that as well.