### PR TITLE
winapi: Implement GetSystemTimeAsFileTime()

### DIFF
--- a/lib/winapi/sysinfo.c
+++ b/lib/winapi/sysinfo.c
@@ -28,6 +28,11 @@ void GetSystemTime (LPSYSTEMTIME lpSystemTime)
     lpSystemTime->wDayOfWeek = timeFields.Weekday;
 }
 
+void GetSystemTimeAsFileTime (LPFILETIME lpSystemTimeAsFileTime)
+{
+    GetSystemTimePreciseAsFileTime(lpSystemTimeAsFileTime);
+}
+
 void GetSystemTimePreciseAsFileTime (LPFILETIME lpSystemTimeAsFileTime)
 {
     assert(lpSystemTimeAsFileTime != NULL);

--- a/lib/winapi/sysinfoapi.h
+++ b/lib/winapi/sysinfoapi.h
@@ -13,6 +13,7 @@ extern "C" {
 #endif
 
 void GetSystemTime (LPSYSTEMTIME lpSystemTime);
+void GetSystemTimeAsFileTime (LPFILETIME lpSystemTimeAsFileTime);
 void GetSystemTimePreciseAsFileTime (LPFILETIME lpSystemTimeAsFileTime);
 DWORD GetTickCount (void);
 void GetLocalTime (LPSYSTEMTIME lpSystemTime);


### PR DESCRIPTION
The latest mbedtls release depends on this, and it was easy to implement, just forwards to `GetSystemTimePreciseAsFileTime` for now.