### PR TITLE
cmake: Set CMAKE_C_COMPILER_AR and CMAKE_C_COMPILER_RANLIB

### DIFF
--- a/share/toolchain-nxdk.cmake
+++ b/share/toolchain-nxdk.cmake
@@ -19,6 +19,8 @@ set(WIN32 1)
 set(NXDK 1)
 
 set(CMAKE_C_COMPILER "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-cc")
+set(CMAKE_C_COMPILER_AR "llvm-ar")
+set(CMAKE_C_COMPILER_RANLIB "llvm-ranlib")
 set(CMAKE_C_STANDARD_LIBRARIES "${NXDK_DIR}/lib/libwinapi.lib ${NXDK_DIR}/lib/xboxkrnl/libxboxkrnl.lib ${NXDK_DIR}/lib/libxboxrt.lib  ${NXDK_DIR}/lib/libpdclib.lib ${NXDK_DIR}/lib/libnxdk_hal.lib ${NXDK_DIR}/lib/libnxdk.lib ${NXDK_DIR}/lib/nxdk_usb.lib") #"${CMAKE_CXX_STANDARD_LIBRARIES_INIT}"
 set(CMAKE_C_LINK_EXECUTABLE "${NXDK_DIR}/bin/${TOOLCHAIN_PREFIX}-link <FLAGS> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -out:<TARGET> <LINK_LIBRARIES>")
 # Keep in sync with include paths in bin/nxdk-cc


### PR DESCRIPTION
It's a rather trivial change, but the latest mbedtls release needs these two set to build.