### PR TITLE
Pkgconfig CMake compatibility & switch to pkgconf

### DIFF
--- a/.github/workflows/build_samples.yml
+++ b/.github/workflows/build_samples.yml
@@ -42,7 +42,7 @@ jobs:
           HOMEBREW_NO_ANALYTICS: 1
           HOMEBREW_NO_INSTALL_CLEANUP: 1
         run: |
-          brew install lld llvm coreutils
+          brew install lld llvm coreutils pkgconf
       - name: Build
         run: ./.ci_build_samples.sh
   ubuntu:
@@ -57,6 +57,6 @@ jobs:
       - name: Install Dependencies
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install llvm lld
+          sudo apt-get -y install llvm lld pkgconf
       - name: Build
         run: ./.ci_build_samples.sh

--- a/bin/activate
+++ b/bin/activate
@@ -19,7 +19,7 @@ CLANG_VERSION=$(clang --version | grep version | grep -o -m 1 "[0-9]\+\.[0-9]\+\
 CLANG_VERSION_NUM=$(echo "$CLANG_VERSION" | sed -e 's/\.\([0-9][0-9]\)/\1/g' -e 's/\.\([0-9]\)/0\1/g' -e 's/^[0-9]\{3,4\}$$/&00/')
 
 if [ $CLANG_VERSION_NUM -lt 100000 ]; then
-    echo You have clang $CLANG_VERSION installed, but nxdk requires at least version 10. You may experience breakage.
+    echo You have clang $CLANG_VERSION installed, but nxdk requires at least version 10. You may experience breakage. >&2
 fi
 
 if [ "$1" = "-s" ]; then cat <<- DONE

--- a/bin/nxdk-pkg-config
+++ b/bin/nxdk-pkg-config
@@ -9,9 +9,9 @@ export PKG_CONFIG_PATH=""
 export PKG_CONFIG_SYSROOT_DIR=""
 export PKG_CONFIG_LIBDIR=${NXDK_DIR}/lib/pkgconfig:${NXDK_DIR}/share/pkgconfig
 
-[ "$1" = '--version' ] && exec pkg-config --version
-exec pkg-config \
+[ "$1" = '--version' ] && exec pkgconf --version
+exec pkgconf \
     --define-variable=NXDK_DIR=${NXDK_DIR} \
     --define-prefix \
     --static \
-    "$@"
+    "$@" | sed 's/\.lib\.lib/\.lib/g'

--- a/lib/pkgconfig/SDL2_image.pc
+++ b/lib/pkgconfig/SDL2_image.pc
@@ -2,5 +2,5 @@ Name: SDL2_image
 Description: image loading library for Simple DirectMedia Layer
 Version: 2.0.5
 Requires: sdl2 >= 2.0.9 libjpeg libpng
-Libs: ${NXDK_DIR}/lib/libSDL2_image.lib
+Libs: -l${NXDK_DIR}/lib/libSDL2_image.lib
 Cflags: -I${NXDK_DIR}/lib/sdl/SDL2_image

--- a/lib/pkgconfig/SDL2_ttf.pc
+++ b/lib/pkgconfig/SDL2_ttf.pc
@@ -2,5 +2,5 @@ Name: SDL2_ttf
 Description: ttf library for Simple DirectMedia Layer with FreeType 2 support
 Version: 2.0.14
 Requires: sdl2 >= 2.0.9
-Libs: ${NXDK_DIR}/lib/libSDL_ttf.lib ${NXDK_DIR}/lib/libfreetype.lib
+Libs: -l${NXDK_DIR}/lib/libSDL_ttf.lib -l${NXDK_DIR}/lib/libfreetype.lib
 Cflags: -I${NXDK_DIR}/lib/sdl -I${NXDK_DIR}/lib/sdl/SDL_ttf

--- a/lib/pkgconfig/libjpeg.pc
+++ b/lib/pkgconfig/libjpeg.pc
@@ -2,4 +2,4 @@ Name: libjpeg
 Description: A SIMD-accelerated JPEG codec that provides the libjpeg API
 Version: 2.0.4
 Libs: ${NXDK_DIR}/lib/libjpeg.lib
-Cflags: -I${NXDK_DIR}/lib/libjpeg/libjpeg-turbo -I$(NXDK_DIR)/lib/libjpeg
+Cflags: -I${NXDK_DIR}/lib/libjpeg/libjpeg-turbo -I${NXDK_DIR}/lib/libjpeg

--- a/lib/pkgconfig/libjpeg.pc
+++ b/lib/pkgconfig/libjpeg.pc
@@ -1,5 +1,5 @@
 Name: libjpeg
 Description: A SIMD-accelerated JPEG codec that provides the libjpeg API
 Version: 2.0.4
-Libs: ${NXDK_DIR}/lib/libjpeg.lib
+Libs: -l${NXDK_DIR}/lib/libjpeg.lib
 Cflags: -I${NXDK_DIR}/lib/libjpeg/libjpeg-turbo -I${NXDK_DIR}/lib/libjpeg

--- a/lib/pkgconfig/libpng.pc
+++ b/lib/pkgconfig/libpng.pc
@@ -2,5 +2,5 @@ Name: libpng
 Description: Loads and saves PNG files
 Version: 1.6.37
 Requires: zlib
-Libs: ${NXDK_DIR}/lib/libpng.lib
+Libs: -l${NXDK_DIR}/lib/libpng.lib
 Cflags: -I${NXDK_DIR}/lib/libpng -I${NXDK_DIR}/lib/libpng/libpng

--- a/lib/pkgconfig/sdl2.pc
+++ b/lib/pkgconfig/sdl2.pc
@@ -3,5 +3,5 @@ Description: Simple DirectMedia Layer is a cross-platform multimedia library des
 Version: 2.0.9
 Requires:
 Conflicts:
-Libs: ${NXDK_DIR}/lib/libSDL2.lib
+Libs: -l${NXDK_DIR}/lib/libSDL2.lib
 Cflags: -I${NXDK_DIR}/lib/sdl/SDL2/include -DXBOX

--- a/lib/pkgconfig/zlib.pc
+++ b/lib/pkgconfig/zlib.pc
@@ -3,5 +3,5 @@ Description: zlib compression library
 Version: 1.2.11
 
 Requires:
-Libs: ${NXDK_DIR}/lib/libzlib.lib
+Libs: -l${NXDK_DIR}/lib/libzlib.lib
 Cflags: -I${NXDK_DIR}/lib/zlib/zlib -DZ_SOLO


### PR DESCRIPTION
The last two commits are from https://github.com/XboxDev/nxdk/pull/631, with only the commit title updated. They make it possible for CMake to find the libraries to link against via pkg-config.

These two commits had the problem that they fix CMake, but by doing so are breaking direct usage of `nxdk-pkg-config` (and probably meson) because the emitted linker arguments are in `ld` syntax, while we rely on the syntax of `link.exe`.

This PR circumvents this issue by switching from whatever pkg-config the host OS provides to explicitly requiring `pkgconf` (which is the default `pkg-config` implementation on Arch, Alpine and probably others anyway).
`pkgconf` provides a `--msvc-syntax` parameter that can be used to get the required `link.exe`-style linker parameters. This would add an additional `.lib` suffix to the library paths (resulting in things like `libjpeg.lib.lib`), so I added a small `sed` command to fix that.