### PR TITLE
pbkit: Expose pb_print_char to allow use of alternative printf

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -388,7 +388,7 @@ static void pb_scrollup(void)
     memset(&pb_text_screen[ROWS-1][0],0,COLS);
 }
 
-static void pb_print_char(char c)
+void pb_print_char(char c)
 {
     if (c=='\n')
     {

--- a/lib/pbkit/pbkit.h
+++ b/lib/pbkit/pbkit.h
@@ -115,6 +115,7 @@ void    pb_set_viewport(int dwx,int dwy,int width,int height,float zmin,float zm
 
 int pb_busy(void);
 
+void pb_print_char(char c);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This facilitates integration with alternative `printf` implementations that support floats like mpaland/printf.