### PR TITLE
net: Add stub nxNetShutdown to prevent link errors

### DIFF
--- a/lib/nxdk/net.c
+++ b/lib/nxdk/net.c
@@ -153,3 +153,8 @@ int nxNetInit(const nx_net_parameters_t *parameters)
 
     return 0;
 }
+
+int nxNetShutdown()
+{
+    return 0;
+}

--- a/lib/nxdk/net.h
+++ b/lib/nxdk/net.h
@@ -28,6 +28,11 @@ typedef struct nx_net_parameters_t_
     // ipv6 static ip fields
 } nx_net_parameters_t;
 
+/**
+ * Initializes the networking subsystem.
+ * @param parameters nx_net_parameters_t containing configuration data
+ * @return 0 on success, negative values indicate various errors.
+ */
 int nxNetInit(const nx_net_parameters_t *parameters);
 int nxNetShutdown();
 


### PR DESCRIPTION
Looks like the method is declared but not defined, this adds a stub so that users of the nxdk can be prepared for an eventual implementation.