### PR TITLE
pbkit: Fix pb_kill softlock in shutdown handler

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -2551,6 +2551,8 @@ void pb_kill(void)
     while(pb_BackBufferbReady[pb_BackBufferNxt]);
 
     pb_running=0;
+    pb_uninstall_gpu_interrupt();
+    KeRemoveQueueDpc(&pb_DPCObject);
 
     if (pb_ExtraBuffersCount) MmFreeContiguousMemory((PVOID)pb_EXAddr[0]);
     if (pb_DepthStencilAddr) MmFreeContiguousMemory((PVOID)pb_DepthStencilAddr);
@@ -2631,8 +2633,6 @@ void pb_kill(void)
     VIDEOREG(NV_PMC_ENABLE)=pb_OldMCEnable;
     VIDEOREG(NV_PMC_INTR_EN_0)=pb_OldMCInterrupt;
     VIDEOREG(PCRTC_START)=pb_OldVideoStart;
-
-    pb_uninstall_gpu_interrupt();
 
     NtClose(pb_VBlankEvent);
 }


### PR DESCRIPTION
Fixes #710 

Trivial program used to repro:
```
    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);

    if ((status = pb_init())) {
        debugPrint("pb_init Error %d\n", status);
        Sleep(2000);
        return 1;
    }

    pb_show_front_screen();

    pb_fill(0, 0, width, height, 0xff202020);
    pb_erase_text_screen();

    pb_print("Sleeping and rebooting...");
    pb_draw_text_screen();
    while(pb_busy()) {
        /* Wait for completion... */
    }

    /* Swap buffers (if we can) */
    while (pb_finished()) {
        /* Not ready to swap yet */
    }
    Sleep(500);
```