### PR TITLE
nvnetdrv v2 part 3

### DIFF
--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -178,7 +178,7 @@
  * a fragmented IP packet waits for all fragments to arrive. If not all fragments arrived
  * in this time, the whole packet is discarded.
  */
-#define IP_REASS_MAXAGE                 3
+#define IP_REASS_MAXAGE                 15
 
 /**
  * IP_REASS_MAX_PBUFS: Total maximum amount of pbufs waiting to be reassembled.

--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -83,7 +83,7 @@
  * ATTENTION: this does not work when tcpip_input() is called from
  * interrupt context!
  */
-#define LWIP_TCPIP_CORE_LOCKING_INPUT   1
+#define LWIP_TCPIP_CORE_LOCKING_INPUT   0
 
 /**
  * SYS_LIGHTWEIGHT_PROT==1: enable inter-task protection (and task-vs-interrupt

--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -283,6 +283,7 @@ static void nvnetdrv_handle_tx_irq (void)
         // If registered, call the users tx complete callback funciton.
         if (g_txData[g_txRingHead].callback) {
             g_txData[g_txRingHead].callback(g_txData[g_txRingHead].userdata);
+            g_txData[g_txRingHead].callback = NULL;
         }
 
         freed_descriptors++;
@@ -652,7 +653,7 @@ void nvnetdrv_stop (void)
     NtClose(g_irqThread);
 
     // Pass back all TX buffers to user.
-    for (int i = 0; i < g_txRingSize; i++) {
+    for (size_t i = g_txRingTail; i != g_txRingHead; i = (i + 1) % g_txRingSize) {
         if (g_txData[i].callback) {
             g_txData[i].callback(g_txData[i].userdata);
         }

--- a/lib/net/nvnetdrv/nvnetdrv_lwip.c
+++ b/lib/net/nvnetdrv/nvnetdrv_lwip.c
@@ -92,16 +92,6 @@ void rx_callback (void *buffer, uint16_t length)
  */
 static err_t low_level_init (struct netif *netif)
 {
-    if (nvnetdrv_init(RX_BUFF_CNT, rx_callback, PBUF_POOL_SIZE) < 0) {
-        return ERR_IF;
-    }
-
-    /* set MAC hardware address length */
-    netif->hwaddr_len = ETHARP_HWADDR_LEN;
-
-    /* set MAC hardware address */
-    memcpy(netif->hwaddr, nvnetdrv_get_ethernet_addr(), 6);
-
     /* maximum transfer unit */
     netif->mtu = 1500;
 
@@ -122,6 +112,16 @@ static err_t low_level_init (struct netif *netif)
     }
 #endif /* LWIP_IPV6 && LWIP_IPV6_MLD */
     g_pnetif = netif;
+
+    if (nvnetdrv_init(RX_BUFF_CNT, rx_callback, PBUF_POOL_SIZE) < 0) {
+        return ERR_IF;
+    }
+
+    /* set MAC hardware address length */
+    netif->hwaddr_len = ETHARP_HWADDR_LEN;
+
+    /* set MAC hardware address */
+    memcpy(netif->hwaddr, nvnetdrv_get_ethernet_addr(), 6);
 
     return ERR_OK;
 }


### PR DESCRIPTION
I think this will be my last major PR for this at this moment.

Primary change is significant optimizations to the RX ring. This drops the entire RX ring threading which in hindsight I'm not sure why I made it so complicated. This will reduce memory usage (atleast 2 or 3 pages) and improve performance.

Fixes a race during init because we setup hardware before lwip and if a packet arrived (via irq) before lwip was setup, it would try push it into the uninitialized network stack and could do strange things.

Updates to latest upstream LWIP. This fixes an actual issue we encountered with http downloads and timeouts not clearing correctly.
