### PR TITLE
pbkit: Add perspective-correct texture mapping bit to control0

### DIFF
--- a/lib/pbkit/nv_regs.h
+++ b/lib/pbkit/nv_regs.h
@@ -162,6 +162,8 @@
 #       define NV097_SET_CONTROL0_Z_FORMAT_FIXED                  0
 #       define NV097_SET_CONTROL0_Z_FORMAT_FLOAT                  NV097_SET_CONTROL0_Z_FORMAT
 #       define NV097_SET_CONTROL0_Z_PERSPECTIVE_ENABLE            (1 << 16)
+        // Perspective corrected texture mapping (bit 20) is always enabled by DirectX
+#       define NV097_SET_CONTROL0_TEXTURE_PERSPECTIVE_ENABLE      (1 << 20)
 #       define NV097_SET_CONTROL0_COLOR_SPACE_CONVERT             0xF0000000
 #       define NV097_SET_CONTROL0_COLOR_SPACE_CONVERT_CRYCB_TO_RGB (0x10 << 24)
 #   define NV097_SET_COLOR_MATERIAL 0x298


### PR DESCRIPTION
Bit 20 in NV097_SET_CONTROL0 enables perspective corrected texture mapping (and perspective corrected color interpolation D0, D1, B0 and B1). It is always enabled by DirectX.

Left image bit 20 unset, right image bit 20 set:

Quad using two triangles:
![pers_bitri](https://github.com/user-attachments/assets/89f924ef-297f-4048-81ae-ba640d96bcf5)

Just quad:
![pers_quad](https://github.com/user-attachments/assets/15fe1ff4-0ed6-4f64-bcc6-fcc7d5527d61)

(Images from Xbox HW and https://github.com/coldhex/nxdk_pgraph_tests/commit/aa83445899633cf2c2609850cd90f87d2422b8ba)