### PR TITLE
xboxkrnl: Fix RtlMoveMemory prototype

### DIFF
--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -1996,7 +1996,7 @@ XBAPI NTSTATUS NTAPI RtlMultiByteToUnicodeN
 XBAPI VOID NTAPI RtlMoveMemory
 (
     PVOID Destination,
-    CONST PVOID *Source,
+    CONST PVOID Source,
     ULONG Length
 );
 


### PR DESCRIPTION
Noticed when reviewing https://github.com/XboxDev/nxdk/pull/725

`PVOID *` would ofcourse be `void **` which isn't correct.