### PR TITLE
net: Properly clear memory space for g_txData

### DIFF
--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -378,7 +378,7 @@ int nvnetdrv_init (size_t rx_buffer_count, nvnetdrv_rx_callback_t rx_callback, s
     g_txRingHead = 0;
     g_txRingTail = 0;
     g_txPendingCount = 0;
-    RtlZeroMemory(g_txData, sizeof(g_txData));
+    RtlZeroMemory(g_txData, g_txRingSize * sizeof(struct tx_misc_t));
 
     // Setup the TX and RX ring descriptor pointers
     g_rxRing = (volatile struct descriptor_t *)descriptors;


### PR DESCRIPTION
```
/home/sl/Projects/LithiumX/src/libs/nxdk/lib/net/nvnetdrv/nvnetdrv.c:381:36: warning: 'RtlZeroMemory' call operates on objects of type 'struct tx_misc_t' while the size is based on a different type 'struct tx_misc_t *' [-Wsizeof-pointer-memaccess]
  381 |     RtlZeroMemory(g_txData, sizeof(g_txData));
      |                   ~~~~~~~~         ^~~~~~~~
/home/sl/Projects/LithiumX/src/libs/nxdk/lib/net/nvnetdrv/nvnetdrv.c:381:36: note: did you mean to dereference the argument to 'sizeof' (and multiply it by the number of elements)?
  381 |     RtlZeroMemory(g_txData, sizeof(g_txData));
      |                                    ^~~~~~~~
1 warning generated.
```