### PR TITLE
build: Undefine __MMX__

### DIFF
--- a/bin/nxdk-cc
+++ b/bin/nxdk-cc
@@ -21,4 +21,5 @@ clang \
     -DNXDK \
     -D__STDC__=1 \
     -U__STDC_NO_THREADS__ \
+    -U__MMX__ \
     "$@"

--- a/bin/nxdk-cxx
+++ b/bin/nxdk-cxx
@@ -22,5 +22,6 @@ clang \
     -DNXDK \
     -D__STDC__=1 \
     -U__STDC_NO_THREADS__ \
+    -U__MMX__ \
     -fno-exceptions \
     "$@"


### PR DESCRIPTION
LLVM has dropped direct support of MMX intrinsics in version 20, instead implementing them as wrappers of SSE2 functionality (https://github.com/llvm/llvm-project/pull/96540).
As a non-SSE2 target, we now have no MMX support (which according to upstream was prone to issues anyway), so we need to lose the `__MMX__` define.

Fixes https://github.com/XboxDev/nxdk/issues/733