### PR TITLE
nvnetdrv: Implement link state change handling

### DIFF
--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -264,6 +264,7 @@ static void nvnetdrv_handle_mii_irq (uint32_t miiStatus, bool init)
 
     if (miiStatus & NVREG_MIISTAT_LINKCHANGE) {
         nvnetdrv_start_txrx();
+        nvnetdrv_link_state_change_callback(linkState & XNET_ETHERNET_LINK_ACTIVE);
     }
 
     INC_STAT(phy_interrupts, 1);
@@ -653,4 +654,15 @@ void nvnetdrv_rx_release (void *buffer_virt)
     g_rxRing[index].length = NVNET_RX_BUFF_LEN;
     g_rxRing[index].flags = NV_RX_AVAIL;
     reg32(NvRegTxRxControl) = NVREG_TXRXCTL_GET;
+}
+
+bool nvnetdrv_is_link_up (void)
+{
+    uint32_t linkState = PhyGetLinkState(false);
+    return (linkState & XNET_ETHERNET_LINK_ACTIVE) != 0;
+}
+
+__attribute__((weak)) void nvnetdrv_link_state_change_callback (bool link_active)
+{
+    (void)link_active;
 }

--- a/lib/net/nvnetdrv/nvnetdrv.h
+++ b/lib/net/nvnetdrv/nvnetdrv.h
@@ -8,6 +8,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdbool.h>
 #include <xboxkrnl/xboxkrnl.h>
 
 // Must be greater than max ethernet frame size. A multiple of page size prevents page boundary crossing
@@ -87,4 +88,15 @@ void nvnetdrv_submit_tx_descriptors (nvnetdrv_descriptor_t *buffers, size_t coun
  */
 void nvnetdrv_rx_release (void *buffer_virt);
 
+/**
+ * @brief Check if the link is up.
+ * @return true if link connected, false if link is down.
+ */
+bool nvnetdrv_is_link_up (void);
+
+/**
+ * Called by the ISR when the link state changes.
+ * @param link_up True if the link is up, false if it is down.
+ */
+void nvnetdrv_link_state_change_callback (bool link_up);
 #endif


### PR DESCRIPTION
Previously it was assumed the link state was up at all times.

This implements link state handling. You can now connect the ethernet cable anytime (or unplug) and lwip should handle things better.

