### PR TITLE
video: Disable soften filter on start-up & fix limits for flicker filter

### DIFF
--- a/lib/hal/video.c
+++ b/lib/hal/video.c
@@ -54,7 +54,7 @@ static DWORD			dwEncoderSettings 	= 0;
 static VIDEO_MODE		vmCurrent = { 0, 0, 0, 0 };
 static int			flickerLevel		= 5;
 static BOOL			flickerSet		= FALSE;
-static BOOL			softenFilter		= TRUE;
+static BOOL			softenFilter		= FALSE;
 static BOOL			softenSet		= FALSE;
 static GAMMA_RAMP_ENTRY	gammaRampEntries[256];
 
@@ -381,7 +381,7 @@ void XVideoInit(DWORD dwMode, int width, int height, int bpp)
 	_fb = framebufferMemory;
 
 	XVideoSetFlickerFilter(5);
-	XVideoSetSoftenFilter(TRUE);
+	XVideoSetSoftenFilter(FALSE);
 
 	for(i = 0; i < 256; i++) {
 		defaultGammaRampEntries[i].red = i;


### PR DESCRIPTION
D3D init:
```
          D3DDevice_SetFlickerFilter(5);
          D3DDevice_SetSoftDisplayFilter(0);
```


FilterFilter:
```
LAB_8002fda6:
      _smbus_write(RegisterBase,bVar5,bVar4);
      return;
    }
    if (DAT_8003b3e4 != 0xe0) {
      if (Param == 0) {
        bVar5 = 200;
        HalReadSMBusValue(DAT_8003b3e4,200,'\0',&Param);
        bVar4 = (byte)Param | 0x40;
      }
      else {
        if (Param == 1) {
          bVar5 = 1;
        }
        else if (Param == 2) {
          bVar5 = 2;
        }
        else if (Param == 3) {
          bVar5 = 3;
        }
        else {
          bVar5 = 0;
        }
        HalReadSMBusValue(DAT_8003b3e4,200,'\0',(ULONG *)&Result);
        _smbus_write(RegisterBase,200,(byte)Result & 0x80 | bVar5 << 3 | bVar5);
        if (Param == 5) {
          bVar4 = 0x80;
        }
        else {
          bVar4 = 0;
        }
        bVar5 = 0x34;
      }
      goto LAB_8002fda6;
    }
```

