### PR TITLE
Implement `CompareFileTime`, `FileTimeToSystemTime`, and `SystemTimeToFileTime`

### DIFF
--- a/lib/winapi/fileapi.h
+++ b/lib/winapi/fileapi.h
@@ -18,6 +18,7 @@ DWORD GetFileAttributesA (LPCSTR lpFileName);
 BOOL GetFileAttributesExA (LPCSTR lpFileName, GET_FILEEX_INFO_LEVELS fInfoLevelId, LPVOID lpFileInformation);
 BOOL SetFileAttributesA (LPCSTR lpFileName, DWORD dwFileAttributes);
 
+LONG CompareFileTime (const FILETIME *lpFileTime1, const FILETIME *lpFileTime2);
 BOOL GetFileTime (HANDLE hFile, LPFILETIME lpCreationTime, LPFILETIME lpLastAccessTime, LPFILETIME lpLastWriteTime);
 BOOL SetFileTime (HANDLE hFile, const FILETIME *lpCreationTime, const FILETIME *lpLastAccessTime, const FILETIME *lpLastWriteTime);
 

--- a/lib/winapi/filemanip.c
+++ b/lib/winapi/filemanip.c
@@ -106,6 +106,28 @@ BOOL SetFileAttributesA (LPCSTR lpFileName, DWORD dwFileAttributes)
     return TRUE;
 }
 
+LONG CompareFileTime (const FILETIME *lpFileTime1, const FILETIME *lpFileTime2)
+{
+    ULARGE_INTEGER filetime1;
+    ULARGE_INTEGER filetime2;
+
+    assert(lpFileTime1 != NULL);
+    assert(lpFileTime2 != NULL);
+
+    filetime1.LowPart = lpFileTime1->dwLowDateTime;
+    filetime1.HighPart = lpFileTime1->dwHighDateTime;
+    filetime2.LowPart = lpFileTime2->dwLowDateTime;
+    filetime2.HighPart = lpFileTime2->dwHighDateTime;
+
+    if (filetime1.QuadPart < filetime2.QuadPart) {
+        return -1;
+    }
+    if (filetime1.QuadPart > filetime2.QuadPart) {
+        return 1;
+    }
+    return 0;
+}
+
 BOOL GetFileTime (HANDLE hFile, LPFILETIME lpCreationTime, LPFILETIME lpLastAccessTime, LPFILETIME lpLastWriteTime)
 {
     NTSTATUS status;

--- a/lib/winapi/sysinfo.c
+++ b/lib/winapi/sysinfo.c
@@ -24,7 +24,7 @@ void GetSystemTime (LPSYSTEMTIME lpSystemTime)
     lpSystemTime->wHour = timeFields.Hour;
     lpSystemTime->wMinute = timeFields.Minute;
     lpSystemTime->wSecond = timeFields.Second;
-    lpSystemTime->wMilliseconds = timeFields.Millisecond;
+    lpSystemTime->wMilliseconds = timeFields.Milliseconds;
     lpSystemTime->wDayOfWeek = timeFields.Weekday;
 }
 
@@ -92,6 +92,6 @@ void GetLocalTime (LPSYSTEMTIME lpSystemTime)
     lpSystemTime->wHour = timeFields.Hour;
     lpSystemTime->wMinute = timeFields.Minute;
     lpSystemTime->wSecond = timeFields.Second;
-    lpSystemTime->wMilliseconds = timeFields.Millisecond;
+    lpSystemTime->wMilliseconds = timeFields.Milliseconds;
     lpSystemTime->wDayOfWeek = timeFields.Weekday;
 }

--- a/lib/winapi/timezoneapi.c
+++ b/lib/winapi/timezoneapi.c
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: MIT
 
 // SPDX-FileCopyrightText: 2023 Ryan Wendland
+// SPDX-FileCopyrightText: 2025 Stefan Schmidt
 
 #include <assert.h>
 #include <string.h>
 #include <timezoneapi.h>
+#include <winerror.h>
 #include <winbase.h>
 #include <xboxkrnl/xboxkrnl.h>
 
@@ -209,4 +211,34 @@ DWORD GetTimeZoneInformation (LPTIME_ZONE_INFORMATION lpTimeZoneInformation)
     } else {
         return TIME_ZONE_ID_STANDARD;
     }
+}
+
+BOOL FileTimeToSystemTime (const FILETIME *lpFileTime, LPSYSTEMTIME lpSystemTime)
+{
+    if (!lpFileTime || !lpSystemTime) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    LARGE_INTEGER filetime;
+    filetime.LowPart = lpFileTime->dwLowDateTime;
+    filetime.HighPart = lpFileTime->dwHighDateTime;
+    if (filetime.QuadPart < 0) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    TIME_FIELDS timefields;
+    RtlTimeToTimeFields(&filetime, &timefields);
+
+    lpSystemTime->wYear = timefields.Year;
+    lpSystemTime->wMonth = timefields.Month;
+    lpSystemTime->wDay = timefields.Day;
+    lpSystemTime->wDayOfWeek = timefields.Weekday;
+    lpSystemTime->wHour = timefields.Hour;
+    lpSystemTime->wMinute = timefields.Minute;
+    lpSystemTime->wSecond = timefields.Second;
+    lpSystemTime->wMilliseconds = timefields.Milliseconds;
+
+    return TRUE;
 }

--- a/lib/winapi/timezoneapi.c
+++ b/lib/winapi/timezoneapi.c
@@ -242,3 +242,30 @@ BOOL FileTimeToSystemTime (const FILETIME *lpFileTime, LPSYSTEMTIME lpSystemTime
 
     return TRUE;
 }
+
+BOOL SystemTimeToFileTime (const SYSTEMTIME *lpSystemTime, LPFILETIME lpFileTime)
+{
+    if (!lpSystemTime || !lpFileTime) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    TIME_FIELDS timefields;
+    timefields.Year = lpSystemTime->wYear;
+    timefields.Month = lpSystemTime->wMonth;
+    timefields.Day = lpSystemTime->wDay;
+    timefields.Hour = lpSystemTime->wHour;
+    timefields.Minute = lpSystemTime->wMinute;
+    timefields.Second = lpSystemTime->wSecond;
+    timefields.Milliseconds = lpSystemTime->wMilliseconds;
+
+    LARGE_INTEGER filetime;
+    if (!RtlTimeFieldsToTime(&timefields, &filetime)) {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    lpFileTime->dwLowDateTime = filetime.LowPart;
+    lpFileTime->dwHighDateTime = filetime.HighPart;
+    return TRUE;
+}

--- a/lib/winapi/timezoneapi.h
+++ b/lib/winapi/timezoneapi.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 // SPDX-FileCopyrightText: 2023 Ryan Wendland
+// SPDX-FileCopyrightText: 2025 Stefan Schmidt
 
 #ifndef __TIMEZONEAPI_H__
 #define __TIMEZONEAPI_H__
@@ -28,6 +29,8 @@ typedef struct _TIME_ZONE_INFORMATION
 } TIME_ZONE_INFORMATION, *PTIME_ZONE_INFORMATION, *LPTIME_ZONE_INFORMATION;
 
 DWORD GetTimeZoneInformation (LPTIME_ZONE_INFORMATION lpTimeZoneInformation);
+
+BOOL FileTimeToSystemTime (const FILETIME *lpFileTime, LPSYSTEMTIME lpSystemTime);
 
 #ifdef __cplusplus
 }

--- a/lib/winapi/timezoneapi.h
+++ b/lib/winapi/timezoneapi.h
@@ -31,6 +31,7 @@ typedef struct _TIME_ZONE_INFORMATION
 DWORD GetTimeZoneInformation (LPTIME_ZONE_INFORMATION lpTimeZoneInformation);
 
 BOOL FileTimeToSystemTime (const FILETIME *lpFileTime, LPSYSTEMTIME lpSystemTime);
+BOOL SystemTimeToFileTime (const SYSTEMTIME *lpSystemTime, LPFILETIME lpFileTime);
 
 #ifdef __cplusplus
 }

--- a/lib/xboxkrnl/xboxkrnl.h
+++ b/lib/xboxkrnl/xboxkrnl.h
@@ -184,7 +184,7 @@ typedef struct _TIME_FIELDS
     SHORT Hour; /**< Specifies a value from 0 to 23 */
     SHORT Minute; /**< Specifies a value from 0 to 59 */
     SHORT Second; /**< Specifies a value from 0 to 59 */
-    SHORT Millisecond; /**< Specifies a value from 0 to 999 */
+    SHORT Milliseconds; /**< Specifies a value from 0 to 999 */
     SHORT Weekday; /**< Specifies a value from 0 to 6 (Sunday to Saturday) */
 } TIME_FIELDS, *PTIME_FIELDS;
 


### PR DESCRIPTION
This implements `CompareFileTime`, `FileTimeToSystemTime`, and `SystemTimeToFileTime`. `CompareFileTime` only has an assert to check for null pointer parameters because it has no way to signal an error to the caller.

Also fixes a typo in the `TIME_FIELDS` struct definition.