### PR TITLE
pbkit: Use proper PAGE_* protection flags for memory allocations

### DIFF
--- a/lib/pbkit/pbkit.c
+++ b/lib/pbkit/pbkit.c
@@ -2329,17 +2329,15 @@ int pb_init(void)
     pb_FrameBuffersAddr=0;
 
 
-    pb_DmaBuffer8=MmAllocateContiguousMemoryEx(32,0,MAXRAM,0,4);
-    pb_DmaBuffer2=MmAllocateContiguousMemoryEx(32,0,MAXRAM,0,4);
-    pb_DmaBuffer7=MmAllocateContiguousMemoryEx(32,0,MAXRAM,0,4);
-        //NumberOfBytes,LowestAcceptableAddress,HighestAcceptableAddress,Alignment,ProtectionType
+    pb_DmaBuffer8 = MmAllocateContiguousMemoryEx(32, 0, MAXRAM, 0, PAGE_READWRITE);
+    pb_DmaBuffer2 = MmAllocateContiguousMemoryEx(32, 0, MAXRAM, 0, PAGE_READWRITE);
+    pb_DmaBuffer7 = MmAllocateContiguousMemoryEx(32, 0, MAXRAM, 0, PAGE_READWRITE);
     if ((pb_DmaBuffer8==NULL)||(pb_DmaBuffer2==NULL)||(pb_DmaBuffer7==NULL)) return -2;
     memset(pb_DmaBuffer8,0,32);
     memset(pb_DmaBuffer2,0,32);
     memset(pb_DmaBuffer7,0,32);
 
-    pb_Head=MmAllocateContiguousMemoryEx(pb_Size+8*1024,0,MAXRAM,0,0x404);
-        //NumberOfBytes,LowestAcceptableAddress,HighestAcceptableAddress,Alignment OPTIONAL,ProtectionType
+    pb_Head = MmAllocateContiguousMemoryEx(pb_Size+8*1024, 0, MAXRAM, 0, PAGE_READWRITE | PAGE_WRITECOMBINE);
     if (pb_Head==NULL) return -3;
 
     memset(pb_Head,0,pb_Size+8*1024);
@@ -2992,8 +2990,7 @@ int pb_init(void)
     //Huge alignment enforcement (16 Kb aligned!) for the global size
     FBSize=(FBSize+0x3FFF)&0xFFFFC000;
 
-    FBAddr=(DWORD)MmAllocateContiguousMemoryEx(FBSize,0,0x03FFB000,0x4000,0x404);
-        //NumberOfBytes,LowestAcceptableAddress,HighestAcceptableAddress,Alignment OPTIONAL,ProtectionType
+    FBAddr = (DWORD)MmAllocateContiguousMemoryEx(FBSize, 0, 0x03FFB000, 0x4000, PAGE_READWRITE | PAGE_WRITECOMBINE);
 
     pb_FBGlobalSize=FBSize;
 
@@ -3065,8 +3062,7 @@ int pb_init(void)
     //Huge alignment enforcement (16 Kb aligned!) for the global size
     DSSize=(DSSize+0x3FFF)&0xFFFFC000;
 
-    DSAddr=(DWORD)MmAllocateContiguousMemoryEx(DSSize,0,0x03FFB000,0x4000,0x404);
-        //NumberOfBytes,LowestAcceptableAddress,HighestAcceptableAddress,Alignment OPTIONAL,ProtectionType
+    DSAddr = (DWORD)MmAllocateContiguousMemoryEx(DSSize, 0, 0x03FFB000, 0x4000, PAGE_READWRITE | PAGE_WRITECOMBINE);
 
     pb_DepthStencilAddr=DSAddr;
     if (!DSAddr)
@@ -3117,9 +3113,7 @@ int pb_init(void)
         //Huge alignment enforcement (16 Kb aligned!) for the global size
         EXSize=(EXSize+0x3FFF)&0xFFFFC000;
 
-        EXAddr=(DWORD)MmAllocateContiguousMemoryEx(EXSize,0,0x03FFB000,0x4000,0x404);
-        //NumberOfBytes,LowestAcceptableAddress,HighestAcceptableAddress,Alignment OPTIONAL,ProtectionType
-
+        EXAddr = (DWORD)MmAllocateContiguousMemoryEx(EXSize, 0, 0x03FFB000, 0x4000, PAGE_READWRITE | PAGE_WRITECOMBINE);
         if (!EXAddr)
         {
             pb_kill();

--- a/samples/mesh/main.c
+++ b/samples/mesh/main.c
@@ -91,7 +91,7 @@ int main(void)
     init_shader();
     init_textures();
 
-    alloc_vertices = MmAllocateContiguousMemoryEx(sizeof(vertices), 0, MAXRAM, 0, 0x404);
+    alloc_vertices = MmAllocateContiguousMemoryEx(sizeof(vertices), 0, MAXRAM, 0, PAGE_READWRITE | PAGE_WRITECOMBINE);
     memcpy(alloc_vertices, vertices, sizeof(vertices));
     num_vertices = sizeof(vertices)/sizeof(vertices[0]);
     num_indices = sizeof(indices)/sizeof(indices[0]);
@@ -221,11 +221,11 @@ int main(void)
         /* Set vertex position attribute */
         set_attrib_pointer(0, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
                            3, sizeof(Vertex), &alloc_vertices[0]);
-        
+
         /* Set vertex normal attribute */
         set_attrib_pointer(2, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
                            3, sizeof(Vertex), &alloc_vertices[3]);
-        
+
         /* Set texture coordinate attribute */
         set_attrib_pointer(9, NV097_SET_VERTEX_DATA_ARRAY_FORMAT_TYPE_F,
                            2, sizeof(Vertex), &alloc_vertices[6]);
@@ -332,7 +332,7 @@ static void init_textures(void)
     texture.width = texture_width;
     texture.height = texture_height;
     texture.pitch = texture.width*4;
-    texture.addr = MmAllocateContiguousMemoryEx(texture.pitch*texture.height, 0, MAXRAM, 0, 0x404);
+    texture.addr = MmAllocateContiguousMemoryEx(texture.pitch*texture.height, 0, MAXRAM, 0, PAGE_READWRITE | PAGE_WRITECOMBINE);
     memcpy(texture.addr, texture_rgba, sizeof(texture_rgba));
 }
 

--- a/samples/triangle/main.c
+++ b/samples/triangle/main.c
@@ -69,7 +69,7 @@ int main(void)
 
     /* Load constant rendering things (shaders, geometry) */
     init_shader();
-    alloc_vertices = MmAllocateContiguousMemoryEx(sizeof(verts), 0, 0x3ffb000, 0, 0x404);
+    alloc_vertices = MmAllocateContiguousMemoryEx(sizeof(verts), 0, 0x3ffb000, 0, PAGE_READWRITE | PAGE_WRITECOMBINE);
     memcpy(alloc_vertices, verts, sizeof(verts));
     num_vertices = sizeof(verts)/sizeof(verts[0]);
     matrix_viewport(m_viewport, 0, 0, width, height, 0, 65536.0f);


### PR DESCRIPTION
pbkit and the pbkit samples used magic numbers for the `Protect` parameter of  `MmAllocateContiguousMemoryEx`, this changes that to the proper constants.