### PR TITLE
winapi: Implement FileTimeToLocalFileTime()

### DIFF
--- a/lib/winapi/timezoneapi.h
+++ b/lib/winapi/timezoneapi.h
@@ -32,6 +32,7 @@ DWORD GetTimeZoneInformation (LPTIME_ZONE_INFORMATION lpTimeZoneInformation);
 
 BOOL FileTimeToSystemTime (const FILETIME *lpFileTime, LPSYSTEMTIME lpSystemTime);
 BOOL SystemTimeToFileTime (const SYSTEMTIME *lpSystemTime, LPFILETIME lpFileTime);
+BOOL FileTimeToLocalFileTime (const FILETIME *lpFileTime, LPFILETIME lpLocalFileTime);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
I needed this for an application.

I noticed the creation time seemed 1 second or 2 ahead of the current time, however this is present in the system time (before the local time conversion) and from my research appears to be normal.

`FileTimeToLocalFileTime()` does not consider daylight savings changes and just adds on the base timezone bias. msdocs suggest to use `SystemTimeToTzSpecificLocalTime()` if DST correction is also required.

Tested with the following code with the output shown

```
Now (Local): 2025-08-04 16:49:19
Created (Local): 2025-08-04 16:49:20
Created (UTC): 2025-08-04 07:19:20
```

```
#include <windows.h>
#include <nxdk/mount.h>

int main()
{
    nxMountDrive('E', "\\Device\\Harddisk0\\Partition1\\");

    // Current Local Time
    SYSTEMTIME st;
    GetLocalTime(&st);
    DbgPrint("Now: %04d-%02d-%02d %02d:%02d:%02d\n",
             st.wYear, st.wMonth, st.wDay, st.wHour, st.wMinute, st.wSecond);

    // Create a file to test GetFileTime
    HANDLE h = CreateFileA("E:\\test.txt",
                           GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
    CloseHandle(h);

    // Get the file creation time as a FILETIME
    h = CreateFileA("E:\\test.txt",
                    GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
    FILETIME creationTime;
    GetFileTime(h, &creationTime, NULL, NULL);
    CloseHandle(h);

    // Convert the FILETIME to local FILETIME
    FILETIME creationLocalTime;
    FileTimeToLocalFileTime(&creationTime, &creationLocalTime);

    // Convert the local FILETIME to SYSTEMTIME so we
    SYSTEMTIME tLocal;
    FileTimeToSystemTime(&creationLocalTime, &tLocal);

    // Also print the UTC SYSTEMTIME for comparison
    SYSTEMTIME tUTC;
    FileTimeToSystemTime(&creationTime, &tUTC);

    DbgPrint("Created (Local): %04d-%02d-%02d %02d:%02d:%02d\n",
             tLocal.wYear, tLocal.wMonth, tLocal.wDay, tLocal.wHour, tLocal.wMinute, tLocal.wSecond);

    DbgPrint("Created (UTC): %04d-%02d-%02d %02d:%02d:%02d\n",
             tUTC.wYear, tUTC.wMonth, tUTC.wDay, tUTC.wHour, tUTC.wMinute, tUTC.wSecond);

    Sleep(10000);
    return 0;
}

```