### PR TITLE
nvnetdrv minor fixes

### DIFF
--- a/lib/net/nvnetdrv/nvnetdrv.c
+++ b/lib/net/nvnetdrv/nvnetdrv.c
@@ -421,6 +421,7 @@ int nvnetdrv_init (size_t rx_buffer_count, nvnetdrv_rx_callback_t rx_callback, s
 
     // Initialise the transceiver
     if (PhyInitialize(FALSE, NULL) != STATUS_SUCCESS) {
+        free(g_txData);
         MmFreeContiguousMemory(descriptors);
         MmFreeContiguousMemory(g_rxRingUserBuffers);
         return NVNET_PHY_ERR;

--- a/lib/net/nvnetdrv/nvnetdrv_lwip.c
+++ b/lib/net/nvnetdrv/nvnetdrv_lwip.c
@@ -182,15 +182,15 @@ static err_t low_level_output (struct netif *netif, struct pbuf *p)
     nvnetdrv_descriptor_t descriptors[4];
     size_t pbufCount = 0;
     for (struct pbuf *q = p; q != NULL; q = q->next) {
-        assert(p->len < 4096);
+        assert(q->len < 4096);
+        if (pbufCount > 3) {
+            return ERR_MEM;
+        }
         descriptors[pbufCount].addr = q->payload;
         descriptors[pbufCount].length = q->len;
         descriptors[pbufCount].callback = NULL;
 
         pbufCount++;
-        if (pbufCount > 4) {
-            return ERR_MEM;
-        }
 
         const uint32_t addr_start = (uint32_t)q->payload;
         const uint32_t addr_end = ((uint32_t)q->payload + q->len);
@@ -205,6 +205,10 @@ static err_t low_level_output (struct netif *netif, struct pbuf *p)
                 continue;
             }
 
+            if (pbufCount > 3) {
+                return ERR_MEM;
+            }
+
             // Fixup the descriptor
             descriptors[pbufCount - 1].length = length_a;
 
@@ -214,9 +218,6 @@ static err_t low_level_output (struct netif *netif, struct pbuf *p)
             descriptors[pbufCount].callback = NULL;
 
             pbufCount++;
-            if (pbufCount > 4) {
-                return ERR_MEM;
-            }
         }
     }
 

--- a/lib/net/nvnetdrv/nvnetdrv_lwip.c
+++ b/lib/net/nvnetdrv/nvnetdrv_lwip.c
@@ -82,7 +82,6 @@ void rx_callback (void *buffer, uint16_t length)
 
     if (g_pnetif->input(p, g_pnetif) != ERR_OK) {
         pbuf_free(p);
-        nvnetdrv_rx_release(buffer);
     }
 }
 

--- a/lib/net/nvnetdrv/nvnetdrv_lwip.c
+++ b/lib/net/nvnetdrv/nvnetdrv_lwip.c
@@ -28,6 +28,10 @@
 #define RX_BUFF_CNT (64)
 #endif
 
+#if RX_BUFF_CNT < TCP_WND / TCP_MSS
+#error "RX_BUFF_CNT must be large enough to contain at least one full TCP window"
+#endif
+
 #define LINK_SPEED_OF_YOUR_NETIF_IN_BPS 100 * 1000 * 1000 /* 100 Mbps */
 
 static struct netif *g_pnetif;


### PR DESCRIPTION
Some minor fixes for nvnetdrv backend.

[nvnetdrv: Add sanity check on RX ring size](https://github.com/XboxDev/nxdk/commit/2a7b0f5326fcb99bc4e9f3c7ee6de5207125d818)
I was experimenting with lowering memory footprint and transfers would stall if I set this to below ~45.
This turns about to be exactly how many packets is required to contain a 64k TCP window and because we are 100% zero-copy here LWIP can hold these buffers until the window is finished which can drain the RX ring entirely causing the transfer to stall. (This can still happen when there is multiple TCP windows open at once - this needs some investigation)

[nvnetdrv: Fix double free on tcpip input failure](https://github.com/XboxDev/nxdk/commit/1713a5d3265f821169e9963ae598ec9df12c1bef)
We already setup the custom_free_function, which releases the buffer for us!