### PR TITLE
Add SDL_net support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -42,3 +42,7 @@
 [submodule "lib/usb/libusbohci"]
 	path = lib/usb/libusbohci
 	url = https://github.com/XboxDev/libusbohci.git
+[submodule "lib/sdl/SDL_net"]
+	path = lib/sdl/SDL_net
+	url = https://github.com/PaulMDemers/SDL_net.git
+	branch = nxdk-sdl-net

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Notable features:
 - No complicated cross-compiling or big library dependencies! Builds with `make` and just needs standard tools and llvm.
 - Modern C / C++ standards and compiler features.
 - Supports popular APIs like Windows API and BSD sockets.
-- SDL2 support for input, audio and 2D graphics.
+- SDL2 support for input, audio, networking, and 2D graphics.
 - Custom API for 3D graphics using NVIDIA-designed shader-languages (with additional Xbox extensions).
 - Open-Source drivers which can be modified to get the most out of the hardware.
 - Modifiable startup code, for as much system control as necessary.
@@ -64,7 +64,7 @@ Code Overview
 * `lib/net` - Network stack for the Xbox based on lwIP.
 * `lib/pdclib` - Xbox port of PDCLib, a CC0-licensed C standard library.
 * `lib/pbkit` - A low level library for interfacing with the Xbox GPU.
-* `lib/sdl` - Xbox ports of SDL2 and SDL_ttf.
+* `lib/sdl` - Xbox ports of SDL2, SDL_image, SDL_net, and SDL_ttf.
 * `lib/usb` - USB support from OpenXDK. Hacked together parts of an old Linux OHCI stack.
 * `lib/winapi` - Xbox specific implementations of common useful WinAPI-functions.
 * `lib/xboxkrnl` - Header and import library for interfacing with the Xbox kernel.

--- a/lib/pkgconfig/SDL2_net.pc
+++ b/lib/pkgconfig/SDL2_net.pc
@@ -1,0 +1,6 @@
+Name: SDL2_net
+Description: networking library for Simple DirectMedia Layer
+Version: 2.0.1
+Requires: sdl2 >= 2.0.9
+Libs: -l${NXDK_DIR}/lib/libSDL2_net.lib
+Cflags: -I${NXDK_DIR}/lib/sdl/SDL_net

--- a/lib/sdl/Makefile
+++ b/lib/sdl/Makefile
@@ -74,3 +74,25 @@ CLEANRULES += clean-libsdlimage
 .PHONY: clean-libsdlimage
 clean-libsdlimage:
 	$(VE)rm -f $(LIBSDLIMAGE_OBJS) $(NXDK_DIR)/lib/libSDL2_image.lib
+
+SDLNET_DIR = $(NXDK_DIR)/lib/sdl/SDL_net
+
+SDLNET_SRCS = $(SDLNET_DIR)/SDLnet.c \
+              $(SDLNET_DIR)/SDLnetselect.c \
+              $(SDLNET_DIR)/SDLnetTCP.c \
+              $(SDLNET_DIR)/SDLnetUDP.c
+
+SDLNET_OBJS = $(addsuffix .obj, $(basename $(SDLNET_SRCS)))
+
+NXDK_CFLAGS += -I$(SDLNET_DIR)
+NXDK_CXXFLAGS += -I$(SDLNET_DIR)
+
+$(NXDK_DIR)/lib/libSDL2_net.lib: $(SDLNET_OBJS)
+
+main.exe: $(NXDK_DIR)/lib/libSDL2_net.lib
+
+CLEANRULES += clean-sdlnet
+
+.PHONY: clean-sdlnet
+clean-sdlnet:
+	$(VE)rm -f $(SDLNET_OBJS) $(NXDK_DIR)/lib/libSDL2_net.lib

--- a/samples/sdl_net/Makefile
+++ b/samples/sdl_net/Makefile
@@ -1,0 +1,7 @@
+XBE_TITLE = nxdk\ sample\ -\ SDL2_net
+GEN_XISO = $(XBE_TITLE).iso
+SRCS = $(CURDIR)/main.c
+NXDK_DIR ?= $(CURDIR)/../..
+NXDK_SDL = y
+
+include $(NXDK_DIR)/Makefile

--- a/samples/sdl_net/main.c
+++ b/samples/sdl_net/main.c
@@ -1,0 +1,57 @@
+#include <SDL.h>
+#include <SDL_net.h>
+#include <hal/debug.h>
+#include <hal/video.h>
+#include <lwip/ip4_addr.h>
+#include <nxdk/net.h>
+#include <windows.h>
+
+int main(void)
+{
+    IPaddress local;
+    UDPsocket udp;
+
+    XVideoSetMode(640, 480, 32, REFRESH_DEFAULT);
+    debugPrint("nxdk SDL_net sample\n");
+
+    if (SDL_Init(0) < 0) {
+        debugPrint("SDL_Init failed: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    nxNetInit(NULL);
+
+    if (SDLNet_Init() < 0) {
+        debugPrint("SDLNet_Init failed: %s\n", SDLNet_GetError());
+        SDL_Quit();
+        return 1;
+    }
+
+    if (SDLNet_ResolveHost(&local, "127.0.0.1", 12345) == 0) {
+        debugPrint("Resolved 127.0.0.1:%u\n", SDLNet_Read16(&local.port));
+    } else {
+        debugPrint("Resolve failed: %s\n", SDLNet_GetError());
+    }
+
+    udp = SDLNet_UDP_Open(0);
+    if (udp) {
+        IPaddress *bound = SDLNet_UDP_GetPeerAddress(udp, -1);
+        if (bound) {
+            ip4_addr_t addr;
+            addr.addr = bound->host;
+            debugPrint("UDP bound to %s:%u\n", ip4addr_ntoa(&addr), SDLNet_Read16(&bound->port));
+        }
+        SDLNet_UDP_Close(udp);
+    } else {
+        debugPrint("UDP open failed: %s\n", SDLNet_GetError());
+    }
+
+    SDLNet_Quit();
+    SDL_Quit();
+
+    while (1) {
+        Sleep(1000);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Adds SDL_net support to nxdk as an SDL2 companion library, backed by nxdk’s existing lwIP network stack.

This adds SDL_net as a submodule, builds it into `libSDL2_net.lib` when `NXDK_SDL = y`, exposes a pkg-config file, and includes a small smoke-test sample that resolves localhost and opens a UDP socket.

## Changes

- Add `lib/sdl/SDL_net` submodule
- Add nxdk/lwIP compatibility patch in the SDL_net fork
- Build `libSDL2_net.lib` from SDL_net sources
- Add `lib/pkgconfig/SDL2_net.pc`
- Add `samples/sdl_net`
- Update README SDL library summary

## Verification

Built successfully on Windows/MSYS2 with:

```bash
make -C samples/sdl_net
```

This produced:
- lib/libSDL2_net.lib
- samples/sdl_net/bin/default.xbe
- samples/sdl_net/nxdk sample - SDL2_net.iso

## Notes
The SDL_net submodule points at PaulMDemers/SDL_net, branch nxdk-sdl-net, which is based on SDL_net 2.0.1 with minimal nxdk compatibility changes for lwIP sockets.