### PR TITLE
lwip: Improve UDP buffering and thread priority

### DIFF
--- a/lib/net/nforceif/include/arch/sys_arch.h
+++ b/lib/net/nforceif/include/arch/sys_arch.h
@@ -73,7 +73,16 @@ typedef struct {
 /* let sys.h use binary semaphores for mutexes */
 #define LWIP_COMPAT_MUTEX 1
 
-#define SYS_MBOX_SIZE 128
+/**
+ * @brief Fixed mailbox capacity used by the nxdk lwIP sys_arch backend.
+ *
+ * This port backs every lwIP mailbox with a statically sized ring rather than
+ * honoring per-mailbox size requests. This larger shared depth absorbs
+ * transient backlog from short UDP bursts, especially through xemu user-mode
+ * NAT. This value is capped at 255 because lwIP's sys_sem_new() API only
+ * accepts an 8-bit initial semaphore count.
+ */
+#define SYS_MBOX_SIZE 255
 
 typedef struct {
     volatile int first, last;

--- a/lib/net/nforceif/include/lwipopts.h
+++ b/lib/net/nforceif/include/lwipopts.h
@@ -43,6 +43,9 @@
 #define LWIP_IPV4 1
 #define LWIP_IPV6 1
 #define LWIP_IPV6_DHCP6 1
+#define LWIP_MDNS_RESPONDER 1
+#define LWIP_MDNS_SEARCH 1
+#define LWIP_NUM_NETIF_CLIENT_DATA LWIP_MDNS_RESPONDER
 #define LWIP_DEBUG 1
 #define LWIP_ERRNO_STDINCLUDE 1
 #define LWIP_COMPAT_MUTEX_ALLOWED
@@ -142,6 +145,15 @@
  * a lot of data that needs to be copied, this should be set high.
  */
 #define MEM_SIZE                        16000
+
+/**
+ * MEMP_NUM_PBUF: the number of pbuf reference structures that can be queued
+ * at once.
+ *
+ * This provides enough socket-layer bookkeeping entries for applications that
+ * receive short bursts of UDP packets.
+ */
+#define MEMP_NUM_PBUF                   128
 
 /*
    ---------------------------------
@@ -280,7 +292,7 @@
 /**
  * LWIP_IGMP==1: Turn on IGMP module.
  */
-#define LWIP_IGMP                       0
+#define LWIP_IGMP                       1
 
 /*
    ----------------------------------
@@ -361,6 +373,14 @@
  */
 #define PBUF_LINK_HLEN                  16
 
+/**
+ * PBUF_POOL_SIZE: the number of packet buffers in the receive pool.
+ *
+ * This provides enough packet buffers for sustained UDP traffic while
+ * applications drain their receive sockets.
+ */
+#define PBUF_POOL_SIZE                  128
+
 /*
    ------------------------------------------------
    ---------- Network Interfaces options ----------
@@ -402,11 +422,27 @@
 #define TCPIP_THREAD_STACKSIZE          4096
 
 /**
+ * TCPIP_THREAD_PRIO: The priority assigned to the main tcpip thread.
+ *
+ * Running the tcpip thread above the platform default helps it drain lwIP
+ * mailboxes before transient packet bursts turn into packet loss.
+ */
+#define TCPIP_THREAD_PRIO               2
+
+/**
  * DEFAULT_THREAD_STACKSIZE: The stack size used by any other lwIP thread.
  * The stack size value itself is platform-dependent, but is passed to
  * sys_thread_new() when the thread is created.
  */
 #define DEFAULT_THREAD_STACKSIZE        4096
+
+/**
+ * DEFAULT_THREAD_PRIO: The priority assigned to auxiliary lwIP threads.
+ *
+ * Auxiliary lwIP threads also run above the platform default so they keep up
+ * while the system is under application and network load.
+ */
+#define DEFAULT_THREAD_PRIO             1
 
 /*
    ----------------------------------------------
@@ -428,6 +464,22 @@
  * LWIP_SOCKET==1: Enable Socket API (require to use sockets.c)
  */
 #define LWIP_SOCKET                     1
+
+/**
+ * LWIP_SO_RCVTIMEO==1: enable SO_RCVTIMEO support.
+ *
+ * Socket users can set receive timeouts instead of relying only on blocking
+ * receive calls.
+ */
+#define LWIP_SO_RCVTIMEO                1
+
+/**
+ * LWIP_SO_RCVBUF==1: enable SO_RCVBUF support.
+ *
+ * Socket users can tune receive buffer sizes for workloads with high-rate or
+ * bursty traffic.
+ */
+#define LWIP_SO_RCVBUF                  1
 
 /*
    ----------------------------------------

--- a/lib/net/nforceif/src/sys_arch.c
+++ b/lib/net/nforceif/src/sys_arch.c
@@ -40,6 +40,7 @@
 #include <assert.h>
 #include <stdlib.h>
 
+#include <windows.h>
 #include <xboxkrnl/xboxkrnl.h>
 
 #if LWIP_DEBUG
@@ -68,9 +69,13 @@ sys_thread_t
 sys_thread_new(const char *name, lwip_thread_fn function, void *arg, int stacksize, int prio)
 {
     LWIP_UNUSED_ARG(name);
-    LWIP_UNUSED_ARG(prio);
 
-    return CreateThread(NULL, stacksize, (void *)function, arg, 0, NULL);
+    HANDLE thread = CreateThread(NULL, stacksize, (void *)function, arg, 0, NULL);
+    if ((thread != NULL) && (prio != 0)) {
+        SetThreadPriority(thread, prio);
+    }
+
+    return thread;
 }
 
 err_t

--- a/lib/net/nvnetdrv/nvnetdrv_lwip.c
+++ b/lib/net/nvnetdrv/nvnetdrv_lwip.c
@@ -25,7 +25,7 @@
 #define IFNAME0     'x'
 #define IFNAME1     'b'
 #ifndef RX_BUFF_CNT
-#define RX_BUFF_CNT (64)
+#define RX_BUFF_CNT (PBUF_POOL_SIZE)
 #endif
 
 #if RX_BUFF_CNT < TCP_WND / TCP_MSS
@@ -70,7 +70,13 @@ void rx_pbuf_free_callback (struct pbuf *p)
 void rx_callback (void *buffer, uint16_t length)
 {
     rx_pbuf_t *rx_pbuf = (rx_pbuf_t *)LWIP_MEMPOOL_ALLOC(RX_POOL);
-    LWIP_ASSERT("RX_POOL full\n", rx_pbuf != NULL);
+    if (rx_pbuf == NULL) {
+        LINK_STATS_INC(link.memerr);
+        LINK_STATS_INC(link.drop);
+        nvnetdrv_rx_release(buffer);
+        return;
+    }
+
     rx_pbuf->p.custom_free_function = rx_pbuf_free_callback;
     rx_pbuf->buff = buffer;
     struct pbuf *p = pbuf_alloced_custom(PBUF_RAW,
@@ -81,6 +87,8 @@ void rx_callback (void *buffer, uint16_t length)
                                          NVNET_RX_BUFF_LEN - ETH_PAD_SIZE);
 
     if (g_pnetif->input(p, g_pnetif) != ERR_OK) {
+        LINK_STATS_INC(link.memerr);
+        LINK_STATS_INC(link.drop);
         pbuf_free(p);
     }
 }


### PR DESCRIPTION
Increase lwIP resource limits and enable socket features to better handle short, high-rate UDP bursts: raise SYS_MBOX_SIZE to 255, MEMP_NUM_PBUF and PBUF_POOL_SIZE to 128, enable LWIP_IGMP, mDNS support, SO_RCVTIMEO, and SO_RCVBUF.

Add TCPIP_THREAD_PRIO and DEFAULT_THREAD_PRIO so the tcpip thread can drain mailboxes under load. In sys_arch.c, include <windows.h> and apply the requested thread priority when a thread is created.

Make RX_BUFF_CNT follow PBUF_POOL_SIZE in nvnetdrv_lwip.c. Replace the hard RX_POOL allocation assert with a graceful packet drop and link statistics updates, and account for link drops when netif input fails.

These changes reduce packet loss and improve responsiveness under short UDP bursts while avoiding crashes on RX resource exhaustion.

The combination of all of these changes, make streaming in my https://github.com/LizardByte/Moonlight-XboxOG project actually work, in combination with https://github.com/XboxDev/nxdk/pull/773