### PR TITLE
build: Fix libxboxkrnl.lib not getting built in NXDK_ONLY mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ $(SRCS): $(SHADER_OBJS)
 
 ifneq ($(NXDK_ONLY),)
 .PHONY: main.exe
-main.exe: $(OBJS)
+main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 else
 main.exe: $(OBJS) $(NXDK_DIR)/lib/xboxkrnl/libxboxkrnl.lib
 	@echo "[ LD       ] $@"


### PR DESCRIPTION
Follow-up fix for https://github.com/XboxDev/nxdk/pull/776

In `NXDK_ONLY` mode `libxboxkrnl.lib` wasn't listed as a dependency, which resulted in it not getting built automatically.